### PR TITLE
Fix unmessageable toggle not available over admin

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -64,7 +64,7 @@ fun UserConfigScreen(
 
     UserConfigItemList(
         userConfig = state.userConfig,
-        enabled = true,
+        enabled = state.connected && !state.responseState.isWaiting(),
         onSaveClicked = viewModel::setOwner,
         metadata = state.metadata,
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The "unmessageable" switch in user settings is now only enabled when the device is connected and the setting is applicable, preventing unintended interactions when disconnected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->