### PR TITLE
Harden BLE transport with exception classifier and atomic guards

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
@@ -28,8 +28,11 @@ class FDroidNetworkModule {
     /**
      * F-Droid builds intentionally avoid network calls to the Meshtastic API.
      *
-     * Returning empty results allows the repository layer to fall through to the bundled JSON assets without incurring
-     * the cost of exception creation and stack-trace filling on every refresh attempt.
+     * Returning empty results (a valid [NetworkFirmwareReleases] with default empty lists) avoids exception creation
+     * and stack-trace filling on every refresh. Empty API responses do NOT trigger bundled-JSON fallback —
+     * [FirmwareReleaseRepositoryImpl]'s `singleFlightRefresh()` inserts returned lists directly (no-op for empty), and
+     * bundled JSON seeding is driven by `ensureSeeded()` only when the local DB/cache is empty, not as a consequence of
+     * empty network results.
      */
     @Single
     fun provideApiService(): ApiService = object : ApiService {

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
@@ -28,15 +28,13 @@ class FDroidNetworkModule {
     /**
      * F-Droid builds intentionally avoid network calls to the Meshtastic API.
      *
-     * We throw [UnsupportedOperationException] (an [Exception], not an [Error]) so that `safeCatching {}` in the
-     * repositories captures the failure and falls back to the bundled JSON assets instead of crashing the app.
+     * Returning empty results allows the repository layer to fall through to the bundled JSON assets
+     * without incurring the cost of exception creation and stack-trace filling on every refresh attempt.
      */
     @Single
     fun provideApiService(): ApiService = object : ApiService {
-        override suspend fun getDeviceHardware(): List<NetworkDeviceHardware> =
-            throw UnsupportedOperationException("getDeviceHardware is not supported on F-Droid builds.")
+        override suspend fun getDeviceHardware(): List<NetworkDeviceHardware> = emptyList()
 
-        override suspend fun getFirmwareReleases(): NetworkFirmwareReleases =
-            throw UnsupportedOperationException("getFirmwareReleases is not supported on F-Droid builds.")
+        override suspend fun getFirmwareReleases(): NetworkFirmwareReleases = NetworkFirmwareReleases()
     }
 }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
@@ -26,18 +26,29 @@ import org.meshtastic.core.network.service.ApiService
 class FDroidNetworkModule {
 
     /**
-     * F-Droid builds intentionally avoid network calls to the Meshtastic API.
+     * Provides an [ApiService] implementation for F-Droid builds that returns empty results instead of making network calls.
      *
-     * Returning empty results (a valid [NetworkFirmwareReleases] with default empty lists) avoids exception creation
-     * and stack-trace filling on every refresh. Empty API responses do NOT trigger bundled-JSON fallback —
-     * [FirmwareReleaseRepositoryImpl]'s `singleFlightRefresh()` inserts returned lists directly (no-op for empty), and
-     * bundled JSON seeding is driven by `ensureSeeded()` only when the local DB/cache is empty, not as a consequence of
-     * empty network results.
+     * Returning empty results avoids creating exceptions and stack traces on every refresh.
+     *
+     * @return An [ApiService] that returns an empty device-hardware list and a default [NetworkFirmwareReleases] instance.
      */
     @Single
     fun provideApiService(): ApiService = object : ApiService {
-        override suspend fun getDeviceHardware(): List<NetworkDeviceHardware> = emptyList()
+        /**
+ * Provides no device hardware from the network for F-Droid builds.
+ *
+ * @return An empty list of device hardware.
+ */
+override suspend fun getDeviceHardware(): List<NetworkDeviceHardware> = emptyList()
 
-        override suspend fun getFirmwareReleases(): NetworkFirmwareReleases = NetworkFirmwareReleases()
+        /**
+ * Provides default firmware release data without making network calls.
+ *
+ * This stub implementation for F-Droid builds returns a default [NetworkFirmwareReleases] instance
+ * instead of performing any network requests.
+ *
+ * @return A default [NetworkFirmwareReleases] instance.
+ */
+override suspend fun getFirmwareReleases(): NetworkFirmwareReleases = NetworkFirmwareReleases()
     }
 }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
@@ -28,8 +28,8 @@ class FDroidNetworkModule {
     /**
      * F-Droid builds intentionally avoid network calls to the Meshtastic API.
      *
-     * Returning empty results allows the repository layer to fall through to the bundled JSON assets
-     * without incurring the cost of exception creation and stack-trace filling on every refresh attempt.
+     * Returning empty results allows the repository layer to fall through to the bundled JSON assets without incurring
+     * the cost of exception creation and stack-trace filling on every refresh attempt.
      */
     @Single
     fun provideApiService(): ApiService = object : ApiService {

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -62,7 +62,7 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
     dependencies {
         "debugImplementation"(libs.library("compose-multiplatform-ui-tooling"))
         "implementation"(libs.library("compose-multiplatform-runtime"))
-        "runtimeOnly"(libs.library("androidx-compose-runtime-tracing"))
+        "debugRuntimeOnly"(libs.library("androidx-compose-runtime-tracing"))
 
         "implementation"(libs.library("compose-multiplatform-resources"))
 

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -21,6 +21,13 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 
 /** Configure Compose-specific options */
+/**
+ * Configures Android Compose build settings and manages dependency versions.
+ *
+ * Enables Jetpack Compose support, excludes conflicting transitive Compose BOMs
+ * from third-party libraries, pins core AndroidX Compose artifacts to an aligned
+ * version, and configures the Compose compiler.
+ */
 internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
     commonExtension.apply { buildFeatures.compose = true }
 

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -62,7 +62,9 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
     dependencies {
         "debugImplementation"(libs.library("compose-multiplatform-ui-tooling"))
         "implementation"(libs.library("compose-multiplatform-runtime"))
-        "debugRuntimeOnly"(libs.library("androidx-compose-runtime-tracing"))
+        // androidx.compose.runtime:runtime-tracing intentionally omitted — it instruments every
+        // Compose node per frame and was the primary cause of debug-build UI stutter (tab switches,
+        // scrolling). Re-add via debugRuntimeOnly if you need Chrome trace events for profiling.
 
         "implementation"(libs.library("compose-multiplatform-resources"))
 

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -62,3 +62,26 @@ fun Throwable.classifyBleException(): BleExceptionInfo? = when (this) {
 
     else -> null
 }
+
+/**
+ * GATT status codes that indicate the BLE session is irrecoverably broken.
+ *
+ * Used by [isSessionFatalBleException] and shared across the BLE stack so classification stays in one place.
+ */
+@Suppress("MagicNumber")
+private val FATAL_GATT_STATUSES =
+    setOf(
+        133, // GATT_ERROR — generic connection failure
+        8, // GATT_CONN_TIMEOUT — link-layer timeout
+        129, // GATT_FAILURE — unrecoverable operation failure
+    )
+
+/**
+ * Returns `true` if this throwable indicates the BLE session is irrecoverably broken and should be torn down
+ * (triggering reconnection), as opposed to a transient condition that can be retried.
+ */
+fun Throwable.isSessionFatalBleException(): Boolean = when (this) {
+    is NotConnectedException -> true
+    is GattStatusException -> status in FATAL_GATT_STATUSES
+    else -> false
+}

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -40,6 +40,8 @@ data class BleExceptionInfo(val isPermanent: Boolean, val gattStatus: Int? = nul
  *
  * This keeps Kable type knowledge inside `core:ble` so that `core:network` (and other consumers) can classify BLE
  * exceptions without depending on Kable directly.
+ *
+ * @return [BleExceptionInfo] if the throwable is a known Kable BLE exception; `null` otherwise.
  */
 fun Throwable.classifyBleException(): BleExceptionInfo? = when (this) {
     is GattStatusException ->
@@ -87,14 +89,21 @@ private val FATAL_GATT_STATUSES =
     )
 
 /**
- * Returns `true` if this throwable indicates the BLE session is irrecoverably broken and should be torn down
- * (triggering reconnection), as opposed to a transient condition that can be retried.
+ * Determines whether the BLE session is irrecoverably broken and requires reconnection.
  *
- * Also checks the cause chain — if a session-fatal exception is wrapped inside another exception (e.g., by coroutine
- * machinery or retry logic), it is still detected. Depth-limited to prevent stack overflow on malformed cause chains.
+ * Checks the cause chain to detect session-fatal exceptions wrapped inside other exceptions (e.g., by coroutine
+ * machinery or retry logic). The check is depth-limited to prevent stack overflow on malformed cause chains.
+ *
+ * @return `true` if the throwable indicates the session is irrecoverably broken, `false` otherwise.
  */
 fun Throwable.isSessionFatalBleException(): Boolean = isSessionFatalBleExceptionInternal(maxDepth = 10)
 
+/**
+ * Determines whether a throwable or its causes indicate the BLE session is irrecoverably broken.
+ *
+ * @param maxDepth The maximum recursion depth when traversing the cause chain; prevents infinite recursion.
+ * @return `true` if a session-fatal condition is detected, `false` otherwise or if the recursion depth limit is reached.
+ */
 private fun Throwable.isSessionFatalBleExceptionInternal(maxDepth: Int): Boolean {
     if (maxDepth <= 0) return false
     return when (this) {

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -89,9 +89,12 @@ private val FATAL_GATT_STATUSES =
 /**
  * Returns `true` if this throwable indicates the BLE session is irrecoverably broken and should be torn down
  * (triggering reconnection), as opposed to a transient condition that can be retried.
+ *
+ * Also checks the cause chain — if a session-fatal exception is wrapped inside another exception (e.g., by coroutine
+ * machinery or retry logic), it is still detected.
  */
 fun Throwable.isSessionFatalBleException(): Boolean = when (this) {
     is NotConnectedException -> true
     is GattStatusException -> status in FATAL_GATT_STATUSES
-    else -> false
+    else -> cause?.isSessionFatalBleException() ?: false
 }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -91,10 +91,15 @@ private val FATAL_GATT_STATUSES =
  * (triggering reconnection), as opposed to a transient condition that can be retried.
  *
  * Also checks the cause chain — if a session-fatal exception is wrapped inside another exception (e.g., by coroutine
- * machinery or retry logic), it is still detected.
+ * machinery or retry logic), it is still detected. Depth-limited to prevent stack overflow on malformed cause chains.
  */
-fun Throwable.isSessionFatalBleException(): Boolean = when (this) {
-    is NotConnectedException -> true
-    is GattStatusException -> status in FATAL_GATT_STATUSES
-    else -> cause?.isSessionFatalBleException() ?: false
+fun Throwable.isSessionFatalBleException(): Boolean = isSessionFatalBleExceptionInternal(maxDepth = 10)
+
+private fun Throwable.isSessionFatalBleExceptionInternal(maxDepth: Int): Boolean {
+    if (maxDepth <= 0) return false
+    return when (this) {
+        is NotConnectedException -> true
+        is GattStatusException -> status in FATAL_GATT_STATUSES
+        else -> cause?.isSessionFatalBleExceptionInternal(maxDepth - 1) ?: false
+    }
 }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -71,9 +71,19 @@ fun Throwable.classifyBleException(): BleExceptionInfo? = when (this) {
 @Suppress("MagicNumber")
 private val FATAL_GATT_STATUSES =
     setOf(
-        133, // GATT_ERROR — generic connection failure
-        8, // GATT_CONN_TIMEOUT — link-layer timeout
-        129, // GATT_FAILURE — unrecoverable operation failure
+        // 0x08 — link-layer supervision timeout (peer out of range or asleep)
+        8, // GATT_CONN_TIMEOUT
+        // 0x13 — peer-initiated disconnect (firmware reboot, user power-cycle, nRF52 link drop).
+        // The most common Meshtastic disconnect signal; without it fromRadio would spin-retry a dead link.
+        19, // GATT_CONN_TERMINATE_PEER_USER
+        // 0x16 — link manager protocol timeout (radio firmware/hardware hang)
+        22, // GATT_CONN_LMP_TIMEOUT
+        // 0x3E — connection establishment failed (discovered during connect handshake)
+        62, // GATT_CONN_FAIL_ESTABLISH
+        // 0x85 — generic connection failure; commonly fires at runtime against a stale GATT handle
+        133, // GATT_ERROR
+        // 0x81 — unrecoverable operation failure
+        129, // GATT_FAILURE
     )
 
 /**

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -99,7 +99,10 @@ private fun Throwable.isSessionFatalBleExceptionInternal(maxDepth: Int): Boolean
     if (maxDepth <= 0) return false
     return when (this) {
         is NotConnectedException -> true
-        is GattStatusException -> status in FATAL_GATT_STATUSES
+
+        is GattStatusException ->
+            status in FATAL_GATT_STATUSES || cause?.isSessionFatalBleExceptionInternal(maxDepth - 1) ?: false
+
         else -> cause?.isSessionFatalBleExceptionInternal(maxDepth - 1) ?: false
     }
 }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
@@ -109,6 +109,13 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
         }
     }
 
+    /**
+     * Observes the LOGRADIO characteristic. Session-fatal exceptions propagate to trigger reconnect.
+     *
+     * Note: a transient (non-fatal) observation error terminates this flow permanently for the current session. Unlike
+     * [fromRadio] which has a retry loop, [logRadio] does not recover from transient errors. This is intentional —
+     * logRadio is diagnostic-only, and the flow is recreated on the next reconnect cycle.
+     */
     override val logRadio: Flow<ByteArray> = flow {
         if (!service.hasCharacteristic(logRadioChar)) return@flow
         emitAll(

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
@@ -17,8 +17,6 @@
 package org.meshtastic.core.ble
 
 import co.touchlab.kermit.Logger
-import com.juul.kable.GattStatusException
-import com.juul.kable.NotConnectedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.BufferOverflow
@@ -57,27 +55,6 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
 
     companion object {
         private val TRANSIENT_RETRY_DELAY = 500.milliseconds
-
-        /** GATT status codes that indicate the BLE session is irrecoverably broken. */
-        @Suppress("MagicNumber")
-        private val FATAL_GATT_STATUSES =
-            setOf(
-                133, // GATT_ERROR — generic connection failure
-                8, // GATT_CONN_TIMEOUT — link-layer timeout
-                129, // GATT_FAILURE — unrecoverable operation failure
-            )
-    }
-
-    /**
-     * Returns `true` if [e] represents a session-fatal BLE exception that should terminate the [fromRadio] flow so the
-     * transport layer can detect the broken session and trigger recovery.
-     *
-     * Transient conditions (busy GATT, missing permissions, etc.) return `false` and are retried.
-     */
-    private fun isFatalBleException(e: Exception): Boolean = when (e) {
-        is NotConnectedException -> true
-        is GattStatusException -> e.status in FATAL_GATT_STATUSES
-        else -> false
     }
 
     private val subscriptionReady = CompletableDeferred<Unit>()
@@ -119,7 +96,7 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
                 } catch (e: Exception) {
                     // Session-fatal BLE exceptions must propagate so the transport layer detects the
                     // broken session via its .catch handler and triggers reconnection.
-                    if (isFatalBleException(e)) throw e
+                    if (e.isSessionFatalBleException()) throw e
                     Logger.w(e) { "FROMRADIO read error, pausing before next drain trigger" }
                     keepReading = false
                     delay(TRANSIENT_RETRY_DELAY)
@@ -132,6 +109,7 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
         if (service.hasCharacteristic(logRadioChar)) {
             service.observe(logRadioChar).catch { e ->
                 if (e is CancellationException) throw e
+                if (e.isSessionFatalBleException()) throw e
                 // logRadio is optional — log at debug for diagnostics but don't surface to callers.
                 Logger.d(e) { "logRadio observation failure suppressed" }
             }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
@@ -142,6 +142,11 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
         )
     }
 
+    /**
+     * Writes a packet to the radio and triggers a poll for incoming messages.
+     *
+     * @param packet The bytes to write to the radio.
+     */
     override suspend fun sendToRadio(packet: ByteArray) {
         service.write(toRadio, packet, toRadioWriteType)
         triggerDrain.tryEmit(Unit)

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
@@ -71,12 +71,23 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
     override val fromRadio: Flow<ByteArray> = channelFlow {
         launch {
             if (service.hasCharacteristic(fromNum)) {
-                service
-                    .observe(fromNum) {
-                        Logger.d { "FROMNUM CCCD written — notifications enabled" }
-                        subscriptionReady.complete(Unit)
-                    }
-                    .collect { triggerDrain.tryEmit(Unit) }
+                try {
+                    service
+                        .observe(fromNum) {
+                            Logger.d { "FROMNUM CCCD written — notifications enabled" }
+                            subscriptionReady.complete(Unit)
+                        }
+                        .collect { triggerDrain.tryEmit(Unit) }
+                } catch (e: CancellationException) {
+                    // Propagate cancellation — don't complete subscription as that would
+                    // let setup proceed on a cancelled scope.
+                    throw e
+                } catch (e: Exception) {
+                    // Complete subscriptionReady exceptionally so awaitSubscriptionReady()
+                    // throws promptly instead of waiting for the transport's 5s timeout.
+                    subscriptionReady.completeExceptionally(e)
+                    throw e
+                }
             } else {
                 subscriptionReady.complete(Unit)
             }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
@@ -25,7 +25,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import org.meshtastic.core.ble.MeshtasticBleConstants.FROMNUM_CHARACTERISTIC
 import org.meshtastic.core.ble.MeshtasticBleConstants.FROMRADIO_CHARACTERISTIC
@@ -105,17 +106,17 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
         }
     }
 
-    override val logRadio: Flow<ByteArray> =
-        if (service.hasCharacteristic(logRadioChar)) {
+    override val logRadio: Flow<ByteArray> = flow {
+        if (!service.hasCharacteristic(logRadioChar)) return@flow
+        emitAll(
             service.observe(logRadioChar).catch { e ->
                 if (e is CancellationException) throw e
                 if (e.isSessionFatalBleException()) throw e
                 // logRadio is optional — log at debug for diagnostics but don't surface to callers.
                 Logger.d(e) { "logRadio observation failure suppressed" }
-            }
-        } else {
-            emptyFlow()
-        }
+            },
+        )
+    }
 
     override suspend fun sendToRadio(packet: ByteArray) {
         service.write(toRadio, packet, toRadioWriteType)

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
@@ -17,6 +17,8 @@
 package org.meshtastic.core.ble
 
 import co.touchlab.kermit.Logger
+import com.juul.kable.GattStatusException
+import com.juul.kable.NotConnectedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.BufferOverflow
@@ -55,6 +57,27 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
 
     companion object {
         private val TRANSIENT_RETRY_DELAY = 500.milliseconds
+
+        /** GATT status codes that indicate the BLE session is irrecoverably broken. */
+        @Suppress("MagicNumber")
+        private val FATAL_GATT_STATUSES =
+            setOf(
+                133, // GATT_ERROR — generic connection failure
+                8, // GATT_CONN_TIMEOUT — link-layer timeout
+                129, // GATT_FAILURE — unrecoverable operation failure
+            )
+    }
+
+    /**
+     * Returns `true` if [e] represents a session-fatal BLE exception that should terminate the [fromRadio] flow so the
+     * transport layer can detect the broken session and trigger recovery.
+     *
+     * Transient conditions (busy GATT, missing permissions, etc.) return `false` and are retried.
+     */
+    private fun isFatalBleException(e: Exception): Boolean = when (e) {
+        is NotConnectedException -> true
+        is GattStatusException -> e.status in FATAL_GATT_STATUSES
+        else -> false
     }
 
     private val subscriptionReady = CompletableDeferred<Unit>()
@@ -94,6 +117,9 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
+                    // Session-fatal BLE exceptions must propagate so the transport layer detects the
+                    // broken session via its .catch handler and triggers reconnection.
+                    if (isFatalBleException(e)) throw e
                     Logger.w(e) { "FROMRADIO read error, pausing before next drain trigger" }
                     keepReading = false
                     delay(TRANSIENT_RETRY_DELAY)

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfile.kt
@@ -97,8 +97,11 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
                 } catch (e: Exception) {
                     // Session-fatal BLE exceptions must propagate so the transport layer detects the
                     // broken session via its .catch handler and triggers reconnection.
-                    if (e.isSessionFatalBleException()) throw e
-                    Logger.w(e) { "FROMRADIO read error, pausing before next drain trigger" }
+                    if (e.isSessionFatalBleException()) {
+                        Logger.w(e) { "FROMRADIO read hit session-fatal BLE exception — propagating for reconnect" }
+                        throw e
+                    }
+                    Logger.w(e) { "FROMRADIO read error (transient), pausing before next drain trigger" }
                     keepReading = false
                     delay(TRANSIENT_RETRY_DELAY)
                 }
@@ -111,7 +114,10 @@ class KableMeshtasticRadioProfile(private val service: BleService) : MeshtasticR
         emitAll(
             service.observe(logRadioChar).catch { e ->
                 if (e is CancellationException) throw e
-                if (e.isSessionFatalBleException()) throw e
+                if (e.isSessionFatalBleException()) {
+                    Logger.w(e) { "logRadio observation hit session-fatal BLE exception — propagating for reconnect" }
+                    throw e
+                }
                 // logRadio is optional — log at debug for diagnostics but don't surface to callers.
                 Logger.d(e) { "logRadio observation failure suppressed" }
             },

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
@@ -80,6 +80,16 @@ class BleExceptionClassifierTest {
     }
 
     @Test
+    fun `isSessionFatalBleException returns true for peer-disconnect and establishment-failure codes`() {
+        // 19 = GATT_CONN_TERMINATE_PEER_USER — firmware reboot / peer-initiated disconnect
+        assertTrue(GattStatusException(status = 19, message = "peer disconnect").isSessionFatalBleException())
+        // 22 = GATT_CONN_LMP_TIMEOUT — link manager protocol timeout
+        assertTrue(GattStatusException(status = 22, message = "lmp timeout").isSessionFatalBleException())
+        // 62 = GATT_CONN_FAIL_ESTABLISH — connection establishment failed
+        assertTrue(GattStatusException(status = 62, message = "establish failed").isSessionFatalBleException())
+    }
+
+    @Test
     fun `isSessionFatalBleException returns false for transient GATT status`() {
         assertFalse(GattStatusException(status = 6, message = "busy").isSessionFatalBleException())
     }

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
@@ -64,4 +64,29 @@ class BleExceptionClassifierTest {
     fun `RuntimeException returns null`() {
         assertNull(RuntimeException("boom").classifyBleException())
     }
+
+    // --- isSessionFatalBleException tests ---
+
+    @Test
+    fun `isSessionFatalBleException returns true for NotConnectedException`() {
+        assertTrue(NotConnectedException("test").isSessionFatalBleException())
+    }
+
+    @Test
+    fun `isSessionFatalBleException returns true for fatal GATT status codes`() {
+        assertTrue(GattStatusException(status = 133, message = "test").isSessionFatalBleException())
+        assertTrue(GattStatusException(status = 8, message = "test").isSessionFatalBleException())
+        assertTrue(GattStatusException(status = 129, message = "test").isSessionFatalBleException())
+    }
+
+    @Test
+    fun `isSessionFatalBleException returns false for transient GATT status`() {
+        assertFalse(GattStatusException(status = 6, message = "busy").isSessionFatalBleException())
+    }
+
+    @Test
+    fun `isSessionFatalBleException returns false for unrelated exceptions`() {
+        assertFalse(IllegalStateException("test").isSessionFatalBleException())
+        assertFalse(RuntimeException("test").isSessionFatalBleException())
+    }
 }

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
@@ -99,4 +99,22 @@ class BleExceptionClassifierTest {
         assertFalse(IllegalStateException("test").isSessionFatalBleException())
         assertFalse(RuntimeException("test").isSessionFatalBleException())
     }
+
+    @Test
+    fun `isSessionFatalBleException traverses cause chain for wrapped exceptions`() {
+        val fatal = GattStatusException(status = 133, message = "wrapped fatal")
+        val wrapper = RuntimeException("wrapper", fatal)
+        assertTrue(wrapper.isSessionFatalBleException())
+
+        val notConnected = NotConnectedException("wrapped")
+        val doubleWrapper = IllegalStateException("outer", RuntimeException("middle", notConnected))
+        assertTrue(doubleWrapper.isSessionFatalBleException())
+    }
+
+    @Test
+    fun `isSessionFatalBleException returns false for non-fatal cause chain`() {
+        val transient = GattStatusException(status = 6, message = "busy")
+        val wrapper = RuntimeException("wrapper", transient)
+        assertFalse(wrapper.isSessionFatalBleException())
+    }
 }

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
@@ -56,6 +56,18 @@ class KableMeshtasticRadioProfileExceptionTest {
     }
 
     @Test
+    fun `fromRadio propagates fatal GattStatusException to collector`() = runTest {
+        val service = createService()
+        val profile = KableMeshtasticRadioProfile(service)
+
+        // Fatal GATT status (133 = GATT_ERROR, in FATAL_GATT_STATUSES)
+        service.readException = GattStatusException(message = "GATT error", status = 133)
+
+        val result = assertFailsWith<GattStatusException> { profile.fromRadio.first() }
+        assertTrue(result.message!!.contains("GATT error"))
+    }
+
+    @Test
     fun `fromRadio propagates CancellationException`() = runTest {
         val service = createService()
         val profile = KableMeshtasticRadioProfile(service)

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
@@ -126,4 +126,26 @@ class KableMeshtasticRadioProfileExceptionTest {
         service.observeException = GattStatusException(status = 133, message = "GATT error")
         assertFailsWith<GattStatusException> { profile.logRadio.first() }
     }
+
+    // --- subscriptionReady exceptional completion tests ---
+
+    @Test
+    fun `awaitSubscriptionReady throws promptly when FROMNUM observe fails before readiness`() = runTest {
+        val service = createService()
+        val profile = KableMeshtasticRadioProfile(service)
+
+        // Set observeException — when fromRadio is collected, the FROMNUM observe will throw
+        // before subscriptionReady is completed. The fix completes it exceptionally.
+        service.observeException = NotConnectedException("observe failed before CCCD")
+
+        // Start collecting fromRadio (triggers the observe + launch)
+        val collectJob = launch { profile.fromRadio.collect {} }
+        advanceUntilIdle()
+
+        // awaitSubscriptionReady should throw the exception promptly, not hang
+        val result = assertFailsWith<NotConnectedException> { profile.awaitSubscriptionReady() }
+        assertTrue(result.message!!.contains("observe failed before CCCD"))
+
+        collectJob.cancel()
+    }
 }

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+import com.juul.kable.GattStatusException
+import com.juul.kable.NotConnectedException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.testing.FakeBleService
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests that [KableMeshtasticRadioProfile.fromRadio] propagates session-fatal BLE exceptions (so the transport layer
+ * can detect broken sessions) while suppressing transient errors.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class KableMeshtasticRadioProfileExceptionTest {
+
+    private fun createService(): FakeBleService = FakeBleService().apply {
+        addCharacteristic(MeshtasticBleConstants.FROMNUM_CHARACTERISTIC)
+        addCharacteristic(MeshtasticBleConstants.FROMRADIO_CHARACTERISTIC)
+        addCharacteristic(MeshtasticBleConstants.TORADIO_CHARACTERISTIC)
+    }
+
+    @Test
+    fun `fromRadio propagates NotConnectedException to collector`() = runTest {
+        val service = createService()
+        val profile = KableMeshtasticRadioProfile(service)
+
+        // Set up the read to throw NotConnectedException immediately
+        service.readException = NotConnectedException("session closed")
+
+        val result = assertFailsWith<NotConnectedException> { profile.fromRadio.first() }
+        assertTrue(result.message!!.contains("session closed"))
+    }
+
+    @Test
+    fun `fromRadio propagates CancellationException`() = runTest {
+        val service = createService()
+        val profile = KableMeshtasticRadioProfile(service)
+
+        // Set up the read to throw CancellationException
+        service.readException = CancellationException("cancelled")
+
+        val result = assertFailsWith<CancellationException> { profile.fromRadio.first() }
+        assertTrue(result.message!!.contains("cancelled"))
+    }
+
+    @Test
+    fun `fromRadio suppresses transient GattStatusException and continues`() = runTest {
+        val service = createService()
+        val profile = KableMeshtasticRadioProfile(service)
+
+        // Non-fatal GATT status (e.g. status 6 = GATT_BUSY, not in FATAL_GATT_STATUSES)
+        service.readException = GattStatusException(message = "transient busy", status = 6)
+
+        // Collect from the flow in a coroutine; after the transient error is suppressed and the
+        // delay elapses, the next drain trigger should restart reading. Enqueue a real packet so
+        // the collector eventually receives something.
+        var collected = false
+        val collectJob = launch { profile.fromRadio.collect { collected = true } }
+        advanceUntilIdle()
+
+        // The transient error was suppressed (500ms delay). Advance past it.
+        advanceTimeBy(600)
+
+        // Now enqueue a packet so the next drain cycle emits data, proving the flow survived.
+        service.enqueueRead(MeshtasticBleConstants.FROMRADIO_CHARACTERISTIC, byteArrayOf(42))
+        service.enqueueRead(MeshtasticBleConstants.FROMRADIO_CHARACTERISTIC, ByteArray(0))
+        profile.requestDrain()
+        advanceUntilIdle()
+
+        assertTrue(collected, "Flow should have emitted a packet after transient error was suppressed")
+
+        collectJob.cancel()
+    }
+}

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
@@ -20,7 +20,6 @@ import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -139,23 +138,24 @@ class KableMeshtasticRadioProfileExceptionTest {
         // before subscriptionReady is completed. The fix completes it exceptionally.
         service.observeException = NotConnectedException("observe failed before CCCD")
 
-        // Start collecting fromRadio in a SupervisorJob so the propagated exception doesn't
-        // crash the test scope. The channelFlow propagates the observe failure, which also
-        // triggers subscriptionReady.completeExceptionally(e).
-        val collectJob =
-            launch(SupervisorJob()) {
-                try {
-                    profile.fromRadio.collect {}
-                } catch (e: Exception) {
-                    // Expected — the observe failure propagates through the channelFlow
-                }
+        // Start collecting fromRadio in a regular child coroutine so it's properly scoped
+        // and cancelled by the test framework. The exception is caught inside the coroutine,
+        // so it won't crash the test scope.
+        val collectJob = launch {
+            try {
+                profile.fromRadio.collect {}
+            } catch (e: Exception) {
+                // Expected — the observe failure propagates through the channelFlow
             }
-        advanceUntilIdle()
+        }
+        try {
+            advanceUntilIdle()
 
-        // awaitSubscriptionReady should throw the exception promptly, not hang
-        val result = assertFailsWith<NotConnectedException> { profile.awaitSubscriptionReady() }
-        assertTrue(result.message!!.contains("observe failed before CCCD"))
-
-        collectJob.cancel()
+            // awaitSubscriptionReady should throw the exception promptly, not hang
+            val result = assertFailsWith<NotConnectedException> { profile.awaitSubscriptionReady() }
+            assertTrue(result.message!!.contains("observe failed before CCCD"))
+        } finally {
+            collectJob.cancel()
+        }
     }
 }

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
@@ -95,4 +95,22 @@ class KableMeshtasticRadioProfileExceptionTest {
 
         collectJob.cancel()
     }
+
+    // --- logRadio fatal exception propagation tests ---
+
+    @Test
+    fun `logRadio propagates NotConnectedException from observation`() = runTest {
+        val service = createService().apply { addCharacteristic(MeshtasticBleConstants.LOGRADIO_CHARACTERISTIC) }
+        val profile = KableMeshtasticRadioProfile(service)
+        service.observeException = NotConnectedException("log radio session closed")
+        assertFailsWith<NotConnectedException> { profile.logRadio.first() }
+    }
+
+    @Test
+    fun `logRadio propagates fatal GattStatusException from observation`() = runTest {
+        val service = createService().apply { addCharacteristic(MeshtasticBleConstants.LOGRADIO_CHARACTERISTIC) }
+        val profile = KableMeshtasticRadioProfile(service)
+        service.observeException = GattStatusException(status = 133, message = "GATT error")
+        assertFailsWith<GattStatusException> { profile.logRadio.first() }
+    }
 }

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
@@ -20,6 +20,7 @@ import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableMeshtasticRadioProfileExceptionTest.kt
@@ -20,6 +20,7 @@ import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -138,8 +139,17 @@ class KableMeshtasticRadioProfileExceptionTest {
         // before subscriptionReady is completed. The fix completes it exceptionally.
         service.observeException = NotConnectedException("observe failed before CCCD")
 
-        // Start collecting fromRadio (triggers the observe + launch)
-        val collectJob = launch { profile.fromRadio.collect {} }
+        // Start collecting fromRadio in a SupervisorJob so the propagated exception doesn't
+        // crash the test scope. The channelFlow propagates the observe failure, which also
+        // triggers subscriptionReady.completeExceptionally(e).
+        val collectJob =
+            launch(SupervisorJob()) {
+                try {
+                    profile.fromRadio.collect {}
+                } catch (e: Exception) {
+                    // Expected — the observe failure propagates through the channelFlow
+                }
+            }
         advanceUntilIdle()
 
         // awaitSubscriptionReady should throw the exception promptly, not hang

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -58,6 +58,7 @@ kotlin {
         commonTest.dependencies {
             implementation(projects.core.testing)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.kable.core) // Kable exception types for BLE failure-injection tests
         }
     }
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
             implementation(libs.okio)
             api(libs.meshtastic.mqtt.client)
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.kotlinx.atomicfu)
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.client.logging)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -140,8 +140,12 @@ class BleRadioTransport(
                 Logger.w(e) { "[$address] Failed to disconnect in exception handler" }
             }
         }
-        val (isPermanent, msg) = throwable.toDisconnectReason()
-        callback.onDisconnect(isPermanent, errorMessage = msg)
+        // Guard: use the same CAS dedup as handleFailure/onDisconnected so an uncaught
+        // exception doesn't produce a duplicate onDisconnect after handleFailure already fired.
+        if (sessionFailed.compareAndSet(expect = false, update = true)) {
+            val (isPermanent, msg) = throwable.toDisconnectReason()
+            callback.onDisconnect(isPermanent, errorMessage = msg)
+        }
     }
 
     private val connectionScope: CoroutineScope =
@@ -249,12 +253,18 @@ class BleRadioTransport(
                         }
                     },
                     onTransientDisconnect = { error ->
-                        val msg = error?.toDisconnectReason()?.second ?: "Device unreachable"
-                        callback.onDisconnect(isPermanent = false, errorMessage = msg)
+                        // Guard: if handleFailure already emitted the disconnect callback for this
+                        // session (sessionFailed CAS won), don't emit a duplicate from the policy.
+                        if (!sessionFailed.value) {
+                            val msg = error?.toDisconnectReason()?.second ?: "Device unreachable"
+                            callback.onDisconnect(isPermanent = false, errorMessage = msg)
+                        }
                     },
                     onPermanentDisconnect = { error ->
-                        val msg = error?.toDisconnectReason()?.second ?: "Device unreachable"
-                        callback.onDisconnect(isPermanent = true, errorMessage = msg)
+                        if (!sessionFailed.value) {
+                            val msg = error?.toDisconnectReason()?.second ?: "Device unreachable"
+                            callback.onDisconnect(isPermanent = true, errorMessage = msg)
+                        }
                     },
                 )
             }
@@ -416,6 +426,7 @@ class BleRadioTransport(
         }
     }
 
+    @Suppress("LongMethod")
     private suspend fun discoverServicesAndSetupCharacteristics() {
         try {
             bleConnection.profile(serviceUuid = SERVICE_UUID) { service ->
@@ -456,7 +467,15 @@ class BleRadioTransport(
 
                 requestHighPriorityAndScheduleDowngrade()
 
-                this@BleRadioTransport.callback.onConnect()
+                // Guard: if handleFailure fired during setup (e.g., fromRadio/logRadio fatal
+                // exception after subscriptionReady completed but before this line), do NOT call
+                // onConnect — it would set Connected state on a dead session. handleFailure has
+                // already emitted the disconnect callback.
+                if (!sessionFailed.value) {
+                    this@BleRadioTransport.callback.onConnect()
+                } else {
+                    Logger.w { "[$address] Session failed during setup — skipping onConnect" }
+                }
             }
         } catch (e: CancellationException) {
             // Scope was cancelled externally — still ensure GATT cleanup runs so we don't
@@ -550,11 +569,18 @@ class BleRadioTransport(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    Logger.w(e) {
-                        "[$address] Failed to write packet to toRadioCharacteristic after " +
-                            "$packetsSent successful writes"
+                    // Guard: only call handleFailure if this write was against the CURRENT session.
+                    // If radioService was replaced (new reconnect cycle) or cleared (handleFailure
+                    // already ran), this is a stale write from the old session — silently discard.
+                    if (currentService === radioService) {
+                        Logger.w(e) {
+                            "[$address] Failed to write packet to toRadioCharacteristic after " +
+                                "$packetsSent successful writes"
+                        }
+                        handleFailure(e)
+                    } else {
+                        Logger.w(e) { "[$address] Stale write failure ignored (session was replaced)" }
                     }
-                    handleFailure(e)
                 }
             }
         }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -19,6 +19,7 @@
 package org.meshtastic.core.network.radio
 
 import co.touchlab.kermit.Logger
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -155,8 +156,9 @@ class BleRadioTransport(
     // Guards against duplicate callbacks when multiple writes or a write + fromRadio failure
     // fire against the same stale session. Reset at the start of each attemptConnection().
     // Write-path failures are serialized by writeMutex; fromRadio/logRadio .catch handlers run
-    // on the flow collector coroutine and may race. Stale reads are benign (affect only dedup timing).
-    @Volatile private var sessionFailed = false
+    // on the flow collector coroutine and may race. Atomic CAS guarantees first-writer-wins —
+    // only the caller that wins the compareAndSet(false, true) fires onDisconnect.
+    private val sessionFailed = atomic(false)
 
     // Captures the exception that caused handleFailure() to tear down the session, so
     // attemptConnection() can distinguish an internal-failure disconnect from a genuine
@@ -258,7 +260,7 @@ class BleRadioTransport(
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     private suspend fun attemptConnection(): BleReconnectPolicy.Outcome {
         connectionStartTime = nowMillis
-        sessionFailed = false
+        sessionFailed.value = false
         sessionFailureCause = null
         Logger.i { "[$address] BLE connection attempt started" }
 
@@ -363,16 +365,15 @@ class BleRadioTransport(
 
     private fun onDisconnected() {
         radioService = null
-        // If handleFailure already fired the disconnect callback for this session, don't fire a
-        // duplicate here. The forced disconnect() from handleFailure causes Kable to emit
-        // Disconnected, which routes here — without this guard the UI would see two onDisconnect
-        // calls (one with the real error message from handleFailure, one generic from here).
-        val alreadyHandled = sessionFailed
-        // Set the guard so a concurrent handleFailure (from fromRadio/logRadio .catch) does
-        // not fire a second callback during the same session-loss event.
-        sessionFailed = true
+        // Atomic first-writer-wins: if handleFailure already claimed this session's failure
+        // callback (or another onDisconnected raced), CAS returns false and we skip the
+        // duplicate. The forced disconnect() from handleFailure causes Kable to emit
+        // Disconnected, which routes here — without this guard the UI would see two
+        // onDisconnect calls (one with the real error message from handleFailure, one
+        // generic from here).
+        val firstWriter = sessionFailed.compareAndSet(expect = false, update = true)
         Logger.i { "[$address] BLE disconnected - ${formatSessionStats()}" }
-        if (!alreadyHandled) {
+        if (firstWriter) {
             // Signal immediately so the UI reflects the disconnect while reconnect continues.
             callback.onDisconnect(isPermanent = false)
         }
@@ -545,10 +546,10 @@ class BleRadioTransport(
         // Never surface it as a user-facing disconnect error.
         if (throwable is CancellationException) return
 
-        // Deduplicate: only the first failure per connection attempt triggers session teardown.
-        // Heartbeat writes that arrive after the first failure must not spam callbacks.
-        if (sessionFailed) return
-        sessionFailed = true
+        // Deduplicate via atomic CAS: only the first failure per connection attempt triggers
+        // session teardown. Heartbeat writes that arrive after the first failure must not spam
+        // callbacks. compareAndSet(false, true) returns true iff THIS caller is the first.
+        if (!sessionFailed.compareAndSet(expect = false, update = true)) return
         sessionFailureCause = throwable
 
         // Tear down stale session state immediately so future writes fail-fast without retrying

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -363,12 +363,19 @@ class BleRadioTransport(
 
     private fun onDisconnected() {
         radioService = null
+        // If handleFailure already fired the disconnect callback for this session, don't fire a
+        // duplicate here. The forced disconnect() from handleFailure causes Kable to emit
+        // Disconnected, which routes here — without this guard the UI would see two onDisconnect
+        // calls (one with the real error message from handleFailure, one generic from here).
+        val alreadyHandled = sessionFailed
         // Set the guard so a concurrent handleFailure (from fromRadio/logRadio .catch) does
         // not fire a second callback during the same session-loss event.
         sessionFailed = true
         Logger.i { "[$address] BLE disconnected - ${formatSessionStats()}" }
-        // Signal immediately so the UI reflects the disconnect while reconnect continues.
-        callback.onDisconnect(isPermanent = false)
+        if (!alreadyHandled) {
+            // Signal immediately so the UI reflects the disconnect while reconnect continues.
+            callback.onDisconnect(isPermanent = false)
+        }
     }
 
     private suspend fun discoverServicesAndSetupCharacteristics() {

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -250,6 +250,13 @@ class BleRadioTransport(
         throw RadioNotConnectedException("Device not found at address $address")
     }
 
+    /**
+     * Launches the connection reconnect loop.
+     *
+     * Executes the reconnect policy to attempt connections and route transient and permanent
+     * disconnect events through callbacks. Uses [sessionFailed] to deduplicate disconnect
+     * callbacks, ensuring only the first failure path emits a callback per session.
+     */
     private fun connect() {
         connectionJob =
             connectionScope.launch {
@@ -423,6 +430,10 @@ class BleRadioTransport(
         }
     }
 
+    /**
+     * Handles BLE disconnection, clearing stale service state and emitting a single
+     * disconnect callback per session.
+     */
     private fun onDisconnected() {
         radioService = null
         // Atomic first-writer-wins: if handleFailure already claimed this session's failure
@@ -439,6 +450,15 @@ class BleRadioTransport(
         }
     }
 
+    /**
+     * Discovers the radio profile and validates packet subscription readiness.
+     *
+     * Establishes subscriptions to radio packet flows, waits for subscription confirmation
+     * with a bounded timeout, and notifies the callback on successful initialization.
+     * Aborts setup if subscription fails to establish or times out.
+     *
+     * @throws Exception if profile discovery, subscription setup, or readiness validation fails.
+     */
     @Suppress("LongMethod", "ThrowsCount")
     private suspend fun discoverServicesAndSetupCharacteristics() {
         try {
@@ -580,12 +600,9 @@ class BleRadioTransport(
     /**
      * Sends a packet to the radio with retry support.
      *
-     * Write-failure policy: any non-cancellation exception from a failed write (after exhausting [retryBleOperation]
-     * retries) is treated as fatal to the current BLE session. Production logs show long-running sessions eventually
-     * failing writes with [NotConnectedException] after hundreds of successful writes — by that point the GATT handle
-     * is stale and retrying in-place cannot recover. Calling [handleFailure] forces a full GATT teardown + reconnect
-     * cycle, which is the only reliable recovery for a dead session. Transient single-write blips are absorbed by
-     * [retryBleOperation]'s 3-attempt retry before reaching this catch.
+     * Transient write failures are handled by [retryBleOperation]'s internal retry logic. If a write fails
+     * after all retries are exhausted, the exception is treated as fatal to the current BLE session and
+     * triggers a full GATT teardown and reconnect cycle via [handleFailure].
      *
      * @param p The packet to send.
      */
@@ -640,7 +657,12 @@ class BleRadioTransport(
         connectionScope.launch { heartbeatSender.sendHeartbeat() }
     }
 
-    /** Closes the connection to the device. */
+    /**
+     * Closes the BLE connection and cancels all reconnection attempts.
+     *
+     * Ensures GATT cleanup occurs even if the caller's coroutine is cancelled,
+     * preventing BluetoothGatt leaks and reconnection failures.
+     */
     override suspend fun close() {
         Logger.i { "[$address] Disconnecting. ${formatSessionStats()}" }
         connectionScope.cancel()
@@ -661,6 +683,11 @@ class BleRadioTransport(
         cleanupScope.cancel()
     }
 
+    /**
+     * Routes a received radio packet to the application callback.
+     *
+     * @param packet The serialized packet data received from the radio.
+     */
     private fun dispatchPacket(packet: ByteArray) {
         val received = packetsReceived.incrementAndGet()
         val rxBytes = bytesReceived.addAndGet(packet.size.toLong())
@@ -668,6 +695,13 @@ class BleRadioTransport(
         callback.handleFromRadio(packet)
     }
 
+    /**
+     * Deduplicates failure handling, clears session state, and forces GATT disconnect for reconnection.
+     *
+     * Only the first failure per connection attempt triggers teardown and emits a disconnect callback.
+     * Subsequent failures are ignored. [CancellationException] signals intentional disconnection and
+     * is never treated as a failure.
+     */
     private fun handleFailure(throwable: Throwable) {
         // CancellationException signals intentional scope cancellation (close() called).
         // Never surface it as a user-facing disconnect error.
@@ -709,6 +743,12 @@ class BleRadioTransport(
             "Packets TX: ${packetsSent.value} (${bytesSent.value} bytes)"
     }
 
+    /**
+     * Converts this exception to a disconnect reason pair.
+     *
+     * @return A pair where the first element is `true` if the disconnect is permanent, `false` otherwise,
+     *         and the second element is a human-readable reason message.
+     */
     private fun Throwable.toDisconnectReason(): Pair<Boolean, String> {
         classifyBleException()?.let {
             return it.isPermanent to it.message

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -255,7 +255,7 @@ class BleRadioTransport(
      * Finds the device, bonds if needed, connects, discovers services, and waits for disconnect. Returns a
      * [BleReconnectPolicy.Outcome] describing how the connection ended.
      */
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private suspend fun attemptConnection(): BleReconnectPolicy.Outcome {
         connectionStartTime = nowMillis
         sessionFailed = false
@@ -291,6 +291,17 @@ class BleRadioTransport(
         onConnected()
 
         discoverServicesAndSetupCharacteristics()
+
+        // If a fatal session failure (fromRadio/logRadio error) forced disconnect during setup,
+        // skip the Connected gate — return a retryable failure so BleReconnectPolicy handles it.
+        if (sessionFailureCause != null) {
+            Logger.w(sessionFailureCause) {
+                "[$address] Session failed during profile setup — returning failed outcome"
+            }
+            return BleReconnectPolicy.Outcome.Failed(
+                sessionFailureCause ?: RuntimeException("Session setup failed"),
+            )
+        }
 
         // Wait for the StateFlow to actually reflect Connected before watching for the next
         // Disconnected. connectAndAwait returns synchronously based on the underlying Kable

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -257,7 +257,7 @@ class BleRadioTransport(
      * Finds the device, bonds if needed, connects, discovers services, and waits for disconnect. Returns a
      * [BleReconnectPolicy.Outcome] describing how the connection ended.
      */
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod", "ReturnCount")
     private suspend fun attemptConnection(): BleReconnectPolicy.Outcome {
         connectionStartTime = nowMillis
         sessionFailed.value = false
@@ -308,7 +308,22 @@ class BleRadioTransport(
         // peripheral state, but our _connectionState observer runs on a separate coroutine and
         // may lag. Without this gate the next .first { Disconnected } below could match the
         // *previous* cycle's stale Disconnected value and fire immediately, breaking reconnect.
-        bleConnection.connectionState.first { it is BleConnectionState.Connected }
+        //
+        // RACE GUARD: A fatal fromRadio/logRadio failure can land AFTER the sessionFailureCause
+        // check above but BEFORE connectionState reaches Connected. handleFailure() forces
+        // bleConnection.disconnect(), which emits Disconnected — so .first { Connected } would
+        // hang forever. We race the Connected wait against a sessionFailureCause poll: if a
+        // failure arrives first, we return a retryable Failed outcome immediately.
+        val connectedReached =
+            bleConnection.connectionState.first { it is BleConnectionState.Connected || sessionFailureCause != null }
+        if (connectedReached !is BleConnectionState.Connected) {
+            Logger.w(sessionFailureCause) {
+                "[$address] Session failed before Connected gate — returning failed outcome"
+            }
+            return BleReconnectPolicy.Outcome.Failed(
+                sessionFailureCause ?: RuntimeException("Session failed before Connected gate"),
+            )
+        }
 
         // Suspend until the next Disconnected emission. We deliberately do NOT wrap this in a
         // coroutineScope { launchIn(...); first(...) } pattern: launching a hot StateFlow
@@ -471,6 +486,13 @@ class BleRadioTransport(
 
     /**
      * Sends a packet to the radio with retry support.
+     *
+     * Write-failure policy: any non-cancellation exception from a failed write (after exhausting [retryBleOperation]
+     * retries) is treated as fatal to the current BLE session. Production logs show long-running sessions eventually
+     * failing writes with [NotConnectedException] after hundreds of successful writes — by that point the GATT handle
+     * is stale and retrying in-place cannot recover. Calling [handleFailure] forces a full GATT teardown + reconnect
+     * cycle, which is the only reliable recovery for a dead session. Transient single-write blips are absorbed by
+     * [retryBleOperation]'s 3-attempt retry before reaching this catch.
      *
      * @param p The packet to send.
      */

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -80,6 +80,15 @@ private val SCAN_TIMEOUT = 5.seconds
 private val GATT_CLEANUP_TIMEOUT = 5.seconds
 
 /**
+ * Bounded wait for the connectionState StateFlow to reflect Connected after connectAndAwait returns.
+ *
+ * In normal operation the observer coroutine lags by milliseconds. If a fatal session failure fires before Connected is
+ * observed and the StateFlow was already at a stale Disconnected value (no re-emit), this timeout prevents
+ * [attemptConnection] from hanging indefinitely.
+ */
+private val CONNECTED_GATE_TIMEOUT = 5.seconds
+
+/**
  * Delay after onConnect before downgrading BLE connection priority to Balanced.
  *
  * The initial config drain (fromRadio burst) typically completes within 2–5 seconds on most devices, but slower radios
@@ -311,18 +320,19 @@ class BleRadioTransport(
         //
         // RACE GUARD: A fatal fromRadio/logRadio failure can land AFTER the sessionFailureCause
         // check above but BEFORE connectionState reaches Connected. handleFailure() forces
-        // bleConnection.disconnect(), which emits Disconnected — so .first { Connected } would
-        // hang forever. We race the Connected wait against a sessionFailureCause poll: if a
-        // failure arrives first, we return a retryable Failed outcome immediately.
+        // bleConnection.disconnect(), which should emit Disconnected — but if the StateFlow was
+        // already at a stale Disconnected value, it may NOT re-emit (StateFlow suppresses
+        // duplicate values). A bounded timeout ensures we cannot hang: if Connected doesn't
+        // arrive within CONNECTED_GATE_TIMEOUT, we check sessionFailureCause and return a
+        // retryable Failed outcome.
         val connectedReached =
-            bleConnection.connectionState.first { it is BleConnectionState.Connected || sessionFailureCause != null }
-        if (connectedReached !is BleConnectionState.Connected) {
-            Logger.w(sessionFailureCause) {
-                "[$address] Session failed before Connected gate — returning failed outcome"
+            withTimeoutOrNull(CONNECTED_GATE_TIMEOUT) {
+                bleConnection.connectionState.first { it is BleConnectionState.Connected }
             }
-            return BleReconnectPolicy.Outcome.Failed(
-                sessionFailureCause ?: RuntimeException("Session failed before Connected gate"),
-            )
+        if (connectedReached == null) {
+            val failure = sessionFailureCause ?: RuntimeException("Timed out waiting for Connected state gate")
+            Logger.w(failure) { "[$address] Session failed before Connected gate — returning failed outcome" }
+            return BleReconnectPolicy.Outcome.Failed(failure)
         }
 
         // Suspend until the next Disconnected emission. We deliberately do NOT wrap this in a
@@ -497,31 +507,40 @@ class BleRadioTransport(
      * @param p The packet to send.
      */
     override fun handleSendToRadio(p: ByteArray) {
-        val currentService = radioService
-        if (currentService != null) {
-            connectionScope.launch {
-                writeMutex.withLock {
-                    try {
-                        retryBleOperation(tag = address) { currentService.sendToRadio(p) }
-                        packetsSent++
-                        bytesSent += p.size
-                        Logger.v {
-                            "[$address] Wrote packet #$packetsSent " +
-                                "to toRadio (${p.size} bytes, total TX: $bytesSent bytes)"
+        // Fast-path check: skip coroutine launch entirely if no transport is active.
+        if (radioService == null) {
+            Logger.w { "[$address] toRadio characteristic unavailable, can't send data" }
+            return
+        }
+        connectionScope.launch {
+            writeMutex.withLock {
+                // Re-read radioService UNDER the lock — handleFailure may have nulled it
+                // between the outer check and lock acquisition. Without this, a queued send
+                // can retry writes against a stale/dead profile.
+                val currentService =
+                    radioService
+                        ?: run {
+                            Logger.w { "[$address] toRadio characteristic cleared during write queue" }
+                            return@withLock
                         }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        Logger.w(e) {
-                            "[$address] Failed to write packet to toRadioCharacteristic after " +
-                                "$packetsSent successful writes"
-                        }
-                        handleFailure(e)
+                try {
+                    retryBleOperation(tag = address) { currentService.sendToRadio(p) }
+                    packetsSent++
+                    bytesSent += p.size
+                    Logger.v {
+                        "[$address] Wrote packet #$packetsSent " +
+                            "to toRadio (${p.size} bytes, total TX: $bytesSent bytes)"
                     }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e) {
+                        "[$address] Failed to write packet to toRadioCharacteristic after " +
+                            "$packetsSent successful writes"
+                    }
+                    handleFailure(e)
                 }
             }
-        } else {
-            Logger.w { "[$address] toRadio characteristic unavailable, can't send data" }
         }
     }
 

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -332,6 +332,18 @@ class BleRadioTransport(
         if (connectedReached == null) {
             val failure = sessionFailureCause ?: RuntimeException("Timed out waiting for Connected state gate")
             Logger.w(failure) { "[$address] Session failed before Connected gate — returning failed outcome" }
+            // CRITICAL: force GATT cleanup before returning Failed so we don't start a new
+            // attempt over an uncleared session. Without this, a timeout caused by flow lag or
+            // a stale-Disconnected state mismatch would leave a live/half-live GATT handle behind.
+            radioService = null
+            isFullyConnected = false
+            withContext(NonCancellable) {
+                try {
+                    bleConnection.disconnect()
+                } catch (ignored: Exception) {
+                    Logger.w(ignored) { "[$address] disconnect() failed during Connected-gate timeout cleanup" }
+                }
+            }
             return BleReconnectPolicy.Outcome.Failed(failure)
         }
 
@@ -449,6 +461,8 @@ class BleRadioTransport(
         } catch (e: CancellationException) {
             // Scope was cancelled externally — still ensure GATT cleanup runs so we don't
             // leak a BluetoothGatt handle and trigger GATT status 133 on the next attempt.
+            radioService = null
+            isFullyConnected = false
             withContext(NonCancellable) {
                 try {
                     bleConnection.disconnect()
@@ -459,8 +473,10 @@ class BleRadioTransport(
             throw e
         } catch (e: Exception) {
             Logger.w(e) { "[$address] Profile service discovery or operation failed" }
-            // Disconnect to let the outer reconnect loop see a clean Disconnected state.
-            // Do NOT call handleFailure here — the reconnect loop owns failure counting.
+            // Clear stale state so the next attempt starts clean — if failure happened after
+            // radioService assignment but before callback.onConnect(), stale state would survive.
+            radioService = null
+            isFullyConnected = false
             withContext(NonCancellable) {
                 try {
                     bleConnection.disconnect()

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -298,9 +298,7 @@ class BleRadioTransport(
             Logger.w(sessionFailureCause) {
                 "[$address] Session failed during profile setup — returning failed outcome"
             }
-            return BleReconnectPolicy.Outcome.Failed(
-                sessionFailureCause ?: RuntimeException("Session setup failed"),
-            )
+            return BleReconnectPolicy.Outcome.Failed(sessionFailureCause ?: RuntimeException("Session setup failed"))
         }
 
         // Wait for the StateFlow to actually reflect Connected before watching for the next

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -89,6 +89,14 @@ private val GATT_CLEANUP_TIMEOUT = 5.seconds
 private val CONNECTED_GATE_TIMEOUT = 5.seconds
 
 /**
+ * Bounded wait for FROMNUM CCCD subscription before proceeding with the handshake.
+ *
+ * In normal operation the observe callback fires within milliseconds. If a fatal fromRadio failure fires before
+ * subscriptionReady completes, this timeout prevents a permanent hang.
+ */
+private val SUBSCRIPTION_READY_TIMEOUT = 5.seconds
+
+/**
  * Delay after onConnect before downgrading BLE connection priority to Balanced.
  *
  * The initial config drain (fromRadio burst) typically completes within 2–5 seconds on most devices, but slower radios
@@ -142,7 +150,12 @@ class BleRadioTransport(
         }
         // Guard: use the same CAS dedup as handleFailure/onDisconnected so an uncaught
         // exception doesn't produce a duplicate onDisconnect after handleFailure already fired.
-        if (sessionFailed.compareAndSet(expect = false, update = true)) {
+        // Also set sessionFailureCause so attemptConnection treats the forced disconnect as
+        // an internal failure (not user-initiated LocalDisconnect).
+        if (throwable !is CancellationException && sessionFailed.compareAndSet(expect = false, update = true)) {
+            sessionFailureCause = throwable
+            radioService = null
+            isFullyConnected = false
             val (isPermanent, msg) = throwable.toDisconnectReason()
             callback.onDisconnect(isPermanent, errorMessage = msg)
         }
@@ -426,7 +439,7 @@ class BleRadioTransport(
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "ThrowsCount")
     private suspend fun discoverServicesAndSetupCharacteristics() {
         try {
             bleConnection.profile(serviceUuid = SERVICE_UUID) { service ->
@@ -459,7 +472,15 @@ class BleRadioTransport(
                 Logger.i { "[$address] Profile service active and characteristics subscribed" }
 
                 // Wait for FROMNUM CCCD write before triggering the Meshtastic handshake.
-                radioService.awaitSubscriptionReady()
+                // Bounded: if fromRadio fails before subscriptionReady completes, handleFailure
+                // sets sessionFailureCause. The timeout prevents a hang — we check sessionFailed
+                // and throw a retryable setup failure if the session is already dead.
+                withTimeoutOrNull(SUBSCRIPTION_READY_TIMEOUT) { radioService.awaitSubscriptionReady() }
+                if (sessionFailed.value) {
+                    val cause = sessionFailureCause ?: RuntimeException("Session failed before subscription ready")
+                    Logger.w(cause) { "[$address] Session failed during subscription wait — aborting setup" }
+                    throw cause
+                }
 
                 // Log negotiated MTU for diagnostics
                 val maxLen = bleConnection.maximumWriteValueLength(BleWriteType.WITHOUT_RESPONSE)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -502,6 +502,23 @@ class BleRadioTransport(
                 // exception after subscriptionReady completed but before this line), do NOT call
                 // onConnect — it would set Connected state on a dead session. handleFailure has
                 // already emitted the disconnect callback.
+                //
+                // ORDERING NOTE: callback.onConnect() is emitted here, BEFORE attemptConnection()
+                // re-confirms the link via the Connected gate (see CONNECTED_GATE_TIMEOUT). In the
+                // rare case the gate times out (connectionState observer-coroutine lag, or a stale
+                // Disconnected value the StateFlow does not re-emit), the UI has briefly seen
+                // Connected. This is deliberate and acceptable:
+                //   - The gate-timeout path returns Outcome.Failed, which drives BleReconnectPolicy
+                //     (Retry backoff immediately; onTransientDisconnect → DeviceSleep once
+                //     consecutiveFailures reaches failureThreshold, default 3).
+                //   - The timeout path nulls radioService and forces bleConnection.disconnect()
+                //     under NonCancellable, so handleSendToRadio() fails fast against a null
+                //     service and the next attempt starts over a clean GATT handle.
+                // The net worst case is a brief Connected indication while the transport cycles a
+                // sub-threshold retry — a cosmetic UX lag, not a correctness or data issue.
+                // Deferring onConnect until after the gate would require a structural refactor of
+                // the profile-setup callback and introduce its own races, so the current ordering
+                // is retained.
                 if (!sessionFailed.value) {
                     this@BleRadioTransport.callback.onConnect()
                 } else {

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -172,9 +172,9 @@ class BleRadioTransport(
 
     private val packetsSent = atomic(0)
 
-    @Volatile private var bytesReceived: Long = 0
+    private val bytesReceived = atomic(0L)
 
-    @Volatile private var bytesSent: Long = 0
+    private val bytesSent = atomic(0L)
 
     @Volatile private var isFullyConnected = false
     private var connectionJob: Job? = null
@@ -592,9 +592,9 @@ class BleRadioTransport(
                 try {
                     retryBleOperation(tag = address) { currentService.sendToRadio(p) }
                     val sent = packetsSent.incrementAndGet()
-                    bytesSent += p.size
+                    val txBytes = bytesSent.addAndGet(p.size.toLong())
                     Logger.v {
-                        "[$address] Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $bytesSent bytes)"
+                        "[$address] Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $txBytes bytes)"
                     }
                 } catch (e: CancellationException) {
                     throw e
@@ -646,10 +646,8 @@ class BleRadioTransport(
 
     private fun dispatchPacket(packet: ByteArray) {
         val received = packetsReceived.incrementAndGet()
-        bytesReceived += packet.size
-        Logger.v {
-            "[$address] Dispatching packet #$received " + "(${packet.size} bytes, total RX: $bytesReceived bytes)"
-        }
+        val rxBytes = bytesReceived.addAndGet(packet.size.toLong())
+        Logger.v { "[$address] Dispatching packet #$received " + "(${packet.size} bytes, total RX: $rxBytes bytes)" }
         callback.handleFromRadio(packet)
     }
 
@@ -690,8 +688,8 @@ class BleRadioTransport(
     private fun formatSessionStats(): String {
         val uptime = if (connectionStartTime > 0) nowMillis - connectionStartTime else 0
         return "Uptime: ${uptime}ms, " +
-            "Packets RX: ${packetsReceived.value} ($bytesReceived bytes), " +
-            "Packets TX: ${packetsSent.value} ($bytesSent bytes)"
+            "Packets RX: ${packetsReceived.value} (${bytesReceived.value} bytes), " +
+            "Packets TX: ${packetsSent.value} (${bytesSent.value} bytes)"
     }
 
     private fun Throwable.toDisconnectReason(): Pair<Boolean, String> {

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -141,23 +141,23 @@ class BleRadioTransport(
 
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         Logger.w(throwable) { "[$address] Uncaught exception in connectionScope" }
-        cleanupScope.launch {
-            try {
-                bleConnection.disconnect()
-            } catch (e: Exception) {
-                Logger.w(e) { "[$address] Failed to disconnect in exception handler" }
-            }
-        }
-        // Guard: use the same CAS dedup as handleFailure/onDisconnected so an uncaught
-        // exception doesn't produce a duplicate onDisconnect after handleFailure already fired.
-        // Also set sessionFailureCause so attemptConnection treats the forced disconnect as
-        // an internal failure (not user-initiated LocalDisconnect).
+        // CRITICAL: set state BEFORE launching disconnect() — if disconnect emits Disconnected
+        // immediately, attemptConnection() must see sessionFailureCause to classify it as
+        // internal (not user-initiated LocalDisconnect). Launching disconnect first creates a
+        // race where the Disconnected emission arrives before sessionFailureCause is visible.
         if (throwable !is CancellationException && sessionFailed.compareAndSet(expect = false, update = true)) {
             sessionFailureCause = throwable
             radioService = null
             isFullyConnected = false
             val (isPermanent, msg) = throwable.toDisconnectReason()
             callback.onDisconnect(isPermanent, errorMessage = msg)
+        }
+        cleanupScope.launch {
+            try {
+                bleConnection.disconnect()
+            } catch (e: Exception) {
+                Logger.w(e) { "[$address] Failed to disconnect in exception handler" }
+            }
         }
     }
 
@@ -473,12 +473,22 @@ class BleRadioTransport(
 
                 // Wait for FROMNUM CCCD write before triggering the Meshtastic handshake.
                 // Bounded: if fromRadio fails before subscriptionReady completes, handleFailure
-                // sets sessionFailureCause. The timeout prevents a hang — we check sessionFailed
-                // and throw a retryable setup failure if the session is already dead.
-                withTimeoutOrNull(SUBSCRIPTION_READY_TIMEOUT) { radioService.awaitSubscriptionReady() }
-                if (sessionFailed.value) {
-                    val cause = sessionFailureCause ?: RuntimeException("Session failed before subscription ready")
-                    Logger.w(cause) { "[$address] Session failed during subscription wait — aborting setup" }
+                // sets sessionFailureCause. The timeout also prevents a hang if FROMNUM observe
+                // never completes for reasons other than a fatal exception (e.g., firmware doesn't
+                // send CCCD confirmation). We MUST abort setup on timeout — proceeding without
+                // subscription readiness creates a half-initialized session.
+                val subscriptionReady =
+                    withTimeoutOrNull(SUBSCRIPTION_READY_TIMEOUT) {
+                        radioService.awaitSubscriptionReady()
+                        true
+                    } ?: false
+                if (!subscriptionReady || sessionFailed.value) {
+                    val cause =
+                        sessionFailureCause ?: RuntimeException("Timed out waiting for FROMNUM subscription readiness")
+                    Logger.w(cause) {
+                        val reason = if (!subscriptionReady) "timed out" else "failed"
+                        "[$address] Subscription wait $reason — aborting setup"
+                    }
                     throw cause
                 }
 

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -158,6 +158,12 @@ class BleRadioTransport(
     // on the flow collector coroutine and may race. Stale reads are benign (affect only dedup timing).
     @Volatile private var sessionFailed = false
 
+    // Captures the exception that caused handleFailure() to tear down the session, so
+    // attemptConnection() can distinguish an internal-failure disconnect from a genuine
+    // LocalDisconnect (user-initiated or clean close). When non-null, the reconnect policy
+    // treats the disconnect as unintentional and applies backoff escalation.
+    @Volatile private var sessionFailureCause: Throwable? = null
+
     // Never give up while the user has this device selected. Higher layers (SharedRadioInterfaceService)
     // own the explicit-disconnect lifecycle and will close() us when the user picks a different device or
     // toggles the connection off; until then, retry forever with the policy's exponential-backoff cap (60 s).
@@ -253,6 +259,7 @@ class BleRadioTransport(
     private suspend fun attemptConnection(): BleReconnectPolicy.Outcome {
         connectionStartTime = nowMillis
         sessionFailed = false
+        sessionFailureCause = null
         Logger.i { "[$address] BLE connection attempt started" }
 
         val device = findDevice()
@@ -306,7 +313,19 @@ class BleRadioTransport(
 
         Logger.i { "[$address] BLE connection dropped (reason: $disconnectReason), preparing to reconnect" }
 
-        val wasIntentional = disconnectReason is DisconnectReason.LocalDisconnect
+        // Internal session failures (write/read exceptions that triggered handleFailure →
+        // disconnect) must NOT be treated as intentional/user disconnects — the reconnect policy
+        // needs to escalate backoff for these.
+        val internalFailure = sessionFailureCause
+        if (internalFailure != null) {
+            Logger.w(internalFailure) { "[$address] Session forced disconnect due to internal failure" }
+        }
+        val wasIntentional =
+            if (internalFailure != null) {
+                false
+            } else {
+                disconnectReason is DisconnectReason.LocalDisconnect
+            }
         val connectionUptime = (nowMillis - gattConnectedAt).milliseconds
         val wasStable = connectionUptime >= reconnectPolicy.minStableConnection
 
@@ -407,6 +426,7 @@ class BleRadioTransport(
                     Logger.w(ignored) { "[$address] disconnect() failed after profile error" }
                 }
             }
+            throw e // Re-throw so attemptConnection() returns Outcome.Failed(e) for policy backoff.
         }
     }
 
@@ -513,6 +533,7 @@ class BleRadioTransport(
         // Heartbeat writes that arrive after the first failure must not spam callbacks.
         if (sessionFailed) return
         sessionFailed = true
+        sessionFailureCause = throwable
 
         // Tear down stale session state immediately so future writes fail-fast without retrying
         // against a dead GATT handle.

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -152,6 +152,11 @@ class BleRadioTransport(
     @Volatile private var isFullyConnected = false
     private var connectionJob: Job? = null
 
+    // Guards against duplicate callbacks when multiple writes fail against the same stale session.
+    // Reset at the start of each attemptConnection(). Set under writeMutex (or hit by a single
+    // winning caller); read without lock since stale reads are benign (only affect dedup timing).
+    @Volatile private var sessionFailed = false
+
     // Never give up while the user has this device selected. Higher layers (SharedRadioInterfaceService)
     // own the explicit-disconnect lifecycle and will close() us when the user picks a different device or
     // toggles the connection off; until then, retry forever with the policy's exponential-backoff cap (60 s).
@@ -246,6 +251,7 @@ class BleRadioTransport(
     @Suppress("CyclomaticComplexMethod")
     private suspend fun attemptConnection(): BleReconnectPolicy.Outcome {
         connectionStartTime = nowMillis
+        sessionFailed = false
         Logger.i { "[$address] BLE connection attempt started" }
 
         val device = findDevice()
@@ -440,6 +446,8 @@ class BleRadioTransport(
                             "[$address] Wrote packet #$packetsSent " +
                                 "to toRadio (${p.size} bytes, total TX: $bytesSent bytes)"
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Logger.w(e) {
                             "[$address] Failed to write packet to toRadioCharacteristic after " +
@@ -493,8 +501,35 @@ class BleRadioTransport(
     }
 
     private fun handleFailure(throwable: Throwable) {
+        // CancellationException signals intentional scope cancellation (close() called).
+        // Never surface it as a user-facing disconnect error.
+        if (throwable is CancellationException) return
+
+        // Deduplicate: only the first failure per connection attempt triggers session teardown.
+        // Heartbeat writes that arrive after the first failure must not spam callbacks.
+        if (sessionFailed) return
+        sessionFailed = true
+
+        // Tear down stale session state immediately so future writes fail-fast without retrying
+        // against a dead GATT handle.
+        radioService = null
+        isFullyConnected = false
+
         val (isPermanent, msg) = throwable.toDisconnectReason()
         callback.onDisconnect(isPermanent, errorMessage = msg)
+
+        Logger.w(throwable) { "[$address] Session failure — forcing cleanup for reconnect" }
+
+        // Force GATT disconnect on the detached cleanupScope (matching the pattern used by
+        // the existing exceptionHandler at lines 124-135). This causes Kable's connectionState
+        // to emit Disconnected, unblocking attemptConnection so BleReconnectPolicy iterates.
+        cleanupScope.launch {
+            try {
+                bleConnection.disconnect()
+            } catch (e: Exception) {
+                Logger.w(e) { "[$address] Failed to disconnect after session failure" }
+            }
+        }
     }
 
     /** Formats a one-line session statistics summary for logging. */

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -152,9 +152,10 @@ class BleRadioTransport(
     @Volatile private var isFullyConnected = false
     private var connectionJob: Job? = null
 
-    // Guards against duplicate callbacks when multiple writes fail against the same stale session.
-    // Reset at the start of each attemptConnection(). Set under writeMutex (or hit by a single
-    // winning caller); read without lock since stale reads are benign (only affect dedup timing).
+    // Guards against duplicate callbacks when multiple writes or a write + fromRadio failure
+    // fire against the same stale session. Reset at the start of each attemptConnection().
+    // Write-path failures are serialized by writeMutex; fromRadio/logRadio .catch handlers run
+    // on the flow collector coroutine and may race. Stale reads are benign (affect only dedup timing).
     @Volatile private var sessionFailed = false
 
     // Never give up while the user has this device selected. Higher layers (SharedRadioInterfaceService)
@@ -334,6 +335,9 @@ class BleRadioTransport(
 
     private fun onDisconnected() {
         radioService = null
+        // Set the guard so a concurrent handleFailure (from fromRadio/logRadio .catch) does
+        // not fire a second callback during the same session-loss event.
+        sessionFailed = true
         Logger.i { "[$address] BLE disconnected - ${formatSessionStats()}" }
         // Signal immediately so the UI reflects the disconnect while reconnect continues.
         callback.onDisconnect(isPermanent = false)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -168,9 +168,9 @@ class BleRadioTransport(
 
     @Volatile private var connectionStartTime: Long = 0
 
-    @Volatile private var packetsReceived: Int = 0
+    private val packetsReceived = atomic(0)
 
-    @Volatile private var packetsSent: Int = 0
+    private val packetsSent = atomic(0)
 
     @Volatile private var bytesReceived: Long = 0
 
@@ -591,11 +591,10 @@ class BleRadioTransport(
                         }
                 try {
                     retryBleOperation(tag = address) { currentService.sendToRadio(p) }
-                    packetsSent++
+                    val sent = packetsSent.incrementAndGet()
                     bytesSent += p.size
                     Logger.v {
-                        "[$address] Wrote packet #$packetsSent " +
-                            "to toRadio (${p.size} bytes, total TX: $bytesSent bytes)"
+                        "[$address] Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $bytesSent bytes)"
                     }
                 } catch (e: CancellationException) {
                     throw e
@@ -606,7 +605,7 @@ class BleRadioTransport(
                     if (currentService === radioService) {
                         Logger.w(e) {
                             "[$address] Failed to write packet to toRadioCharacteristic after " +
-                                "$packetsSent successful writes"
+                                "${packetsSent.value} successful writes"
                         }
                         handleFailure(e)
                     } else {
@@ -646,11 +645,10 @@ class BleRadioTransport(
     }
 
     private fun dispatchPacket(packet: ByteArray) {
-        packetsReceived++
+        val received = packetsReceived.incrementAndGet()
         bytesReceived += packet.size
         Logger.v {
-            "[$address] Dispatching packet #$packetsReceived " +
-                "(${packet.size} bytes, total RX: $bytesReceived bytes)"
+            "[$address] Dispatching packet #$received " + "(${packet.size} bytes, total RX: $bytesReceived bytes)"
         }
         callback.handleFromRadio(packet)
     }
@@ -692,8 +690,8 @@ class BleRadioTransport(
     private fun formatSessionStats(): String {
         val uptime = if (connectionStartTime > 0) nowMillis - connectionStartTime else 0
         return "Uptime: ${uptime}ms, " +
-            "Packets RX: $packetsReceived ($bytesReceived bytes), " +
-            "Packets TX: $packetsSent ($bytesSent bytes)"
+            "Packets RX: ${packetsReceived.value} ($bytesReceived bytes), " +
+            "Packets TX: ${packetsSent.value} ($bytesSent bytes)"
     }
 
     private fun Throwable.toDisconnectReason(): Pair<Boolean, String> {

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -39,6 +39,7 @@ import org.meshtastic.core.ble.BleDevice
 import org.meshtastic.core.ble.BleService
 import org.meshtastic.core.ble.BleWriteType
 import org.meshtastic.core.ble.DisconnectReason
+import org.meshtastic.core.ble.MeshtasticBleConstants.FROMNUM_CHARACTERISTIC
 import org.meshtastic.core.ble.MeshtasticBleConstants.SERVICE_UUID
 import org.meshtastic.core.testing.FakeBleConnection
 import org.meshtastic.core.testing.FakeBleConnectionFactory
@@ -609,6 +610,101 @@ class BleRadioTransportReconnectCrashTest {
 
         // Still no disconnect should have been called
         dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
+
+        bleTransport.close()
+    }
+
+    // ─── Read-path session-failure recovery (fromRadio fatal) ──────────────────────────────────────
+
+    /**
+     * Validates that a session-fatal exception in the fromRadio READ path (not just the write path) triggers
+     * handleFailure → forced disconnect → reconnect.
+     *
+     * Existing tests only exercise the WRITE path. The read-path recovery is the primary mechanism for detecting zombie
+     * sessions where fromRadio throws GATT 133/19/8/129 during a poll.
+     */
+    @Test
+    fun `fromRadio read failure triggers handleFailure and reconnect`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L) // connect + handshake
+        assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
+
+        // Inject a read failure that will fire on the next drain cycle
+        connection.service.readException = NotConnectedException("read session closed")
+
+        // Trigger a drain by emitting a FROMNUM notification — this causes the profile to poll
+        // fromRadioChar, which throws NotConnectedException (a session-fatal BLE exception).
+        connection.service.emitNotification(FROMNUM_CHARACTERISTIC.uuid, byteArrayOf(1))
+        advanceUntilIdle()
+
+        // handleFailure must have forced a GATT disconnect
+        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after fromRadio read failure")
+
+        // Reconnect policy should iterate
+        advanceTimeBy(10_000L)
+        assertTrue(
+            connection.connectAndAwaitCalls >= 2,
+            "Reconnect loop must iterate after fromRadio read failure " +
+                "(actual calls: ${connection.connectAndAwaitCalls})",
+        )
+
+        bleTransport.close()
+    }
+
+    /**
+     * Validates the sessionFailed dedup guard when read-path and write-path failures race.
+     *
+     * The guard at the top of handleFailure exists precisely for this scenario: fromRadio's .catch handler and a
+     * concurrent write failure both call handleFailure against the same dead session. Only the first caller should fire
+     * onDisconnect.
+     */
+    @Test
+    fun `concurrent fromRadio and write failure fires onDisconnect exactly once`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        var onDisconnectCalls = 0
+        every { service.onDisconnect(any(), any()) } calls { onDisconnectCalls++ }
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L)
+
+        // Inject BOTH read and write failures against the same session
+        connection.service.readException = NotConnectedException("read failure")
+        connection.service.writeException = NotConnectedException("write failure")
+
+        // Trigger both paths nearly simultaneously
+        connection.service.emitNotification(FROMNUM_CHARACTERISTIC.uuid, byteArrayOf(1))
+        bleTransport.handleSendToRadio(byteArrayOf(42))
+        advanceUntilIdle()
+
+        assertEquals(
+            1,
+            onDisconnectCalls,
+            "onDisconnect must fire exactly once despite concurrent read+write failures " +
+                "(actual: $onDisconnectCalls)",
+        )
 
         bleTransport.close()
     }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -341,9 +341,9 @@ class BleRadioTransportReconnectCrashTest {
 
             // Trigger a write (simulating a heartbeat or user packet)
             bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
-            // Drain the immediate failure path without advancing through the reconnect loop's
-            // delayed retry — the subsequent advanceTimeBy covers the retry.
-            testScheduler.runCurrent()
+            // Advance through retryBleOperation's 3 retries (~750ms backoff) so the write failure
+            // reaches handleFailure and forces disconnect. Stay under the 3s reconnect settle delay.
+            advanceTimeBy(1_000L)
 
             // After failure: disconnect must be called (GATT cleanup)
             assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
@@ -505,9 +505,9 @@ class BleRadioTransportReconnectCrashTest {
             // Inject a write failure — this should NOT be treated as intentional
             connection.service.writeException = NotConnectedException("session closed")
             bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
-            // Drain the immediate failure path; the reconnect loop's delayed retry is advanced
-            // explicitly below.
-            testScheduler.runCurrent()
+            // Advance through retryBleOperation's 3 retries (~750ms backoff) so the write failure
+            // reaches handleFailure and forces disconnect.
+            advanceTimeBy(1_000L)
 
             // disconnect must have been called (forced cleanup)
             assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
@@ -788,8 +788,9 @@ class BleRadioTransportReconnectCrashTest {
             // Trigger both paths nearly simultaneously
             connection.service.emitNotification(FROMNUM_CHARACTERISTIC, byteArrayOf(1))
             bleTransport.handleSendToRadio(byteArrayOf(42))
-            // Drain both failure paths; handleFailure's CAS guard should leave exactly one onDisconnect.
-            testScheduler.runCurrent()
+            // Advance through the write-path retryBleOperation (~750ms) so BOTH the read and write
+            // failure paths reach handleFailure, truly exercising the CAS dedup guard.
+            advanceTimeBy(1_000L)
 
             assertEquals(
                 1,

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -628,6 +628,12 @@ class BleRadioTransportReconnectCrashTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)
 
+        // Register FROMNUM before start() so the profile's observe collector is set up during
+        // discoverServicesAndSetupCharacteristics. Without this, hasCharacteristic(FROMNUM)
+        // returns false at setup time, no collector is established, and emitNotification
+        // below would fire into a void.
+        connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
+
         val bleTransport =
             BleRadioTransport(
                 scope = this,
@@ -674,6 +680,10 @@ class BleRadioTransportReconnectCrashTest {
     fun `concurrent fromRadio and write failure fires onDisconnect exactly once`() = runTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)
+
+        // Register FROMNUM before start() so the profile's observe collector is set up during
+        // discoverServicesAndSetupCharacteristics. See the read-failure test above for details.
+        connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
 
         var onDisconnectCalls = 0
         every { service.onDisconnect(any(), any()) } calls { onDisconnectCalls++ }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -47,8 +47,8 @@ import org.meshtastic.core.testing.FakeBleConnection
 import org.meshtastic.core.testing.FakeBleConnectionFactory
 import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.core.testing.FakeBleScanner
-import org.meshtastic.core.testing.FakeBluetoothRepository
 import org.meshtastic.core.testing.FakeBleService
+import org.meshtastic.core.testing.FakeBluetoothRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -971,9 +971,7 @@ private class NeverConnectedStateBleConnection : BleConnection {
     override val device: BleDevice?
         get() = _deviceFlow.value
 
-    val service = FakeBleService().apply {
-        addCharacteristic(FROMNUM_CHARACTERISTIC)
-    }
+    val service = FakeBleService().apply { addCharacteristic(FROMNUM_CHARACTERISTIC) }
 
     var connectAndAwaitCalls = 0
         private set

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.network.radio
 
+import com.juul.kable.NotConnectedException
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
@@ -310,7 +311,7 @@ class BleRadioTransportReconnectCrashTest {
         assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
 
         // Inject write failure while BLE state remains Connected
-        connection.service.writeException = IllegalStateException("session closed")
+        connection.service.writeException = NotConnectedException("session closed")
 
         // Trigger a write (simulating a heartbeat or user packet)
         bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
@@ -381,7 +382,7 @@ class BleRadioTransportReconnectCrashTest {
         advanceTimeBy(4_000L)
 
         // First write failure — should trigger onDisconnect once
-        connection.service.writeException = IllegalStateException("session closed")
+        connection.service.writeException = NotConnectedException("session closed")
         bleTransport.handleSendToRadio(byteArrayOf(1))
         // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
         // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
@@ -416,7 +417,7 @@ class BleRadioTransportReconnectCrashTest {
         val writesBefore = connection.service.writes.size
 
         // First write failure clears radioService
-        connection.service.writeException = IllegalStateException("session closed")
+        connection.service.writeException = NotConnectedException("session closed")
         bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
         // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
         // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
@@ -433,6 +434,38 @@ class BleRadioTransportReconnectCrashTest {
             connection.service.writes.size,
             "No new write should be recorded after radioService was cleared",
         )
+
+        bleTransport.close()
+    }
+
+    @Test
+    fun `internal session failure is not treated as intentional disconnect`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L) // connect + handshake
+
+        // Inject a write failure — this should NOT be treated as intentional
+        connection.service.writeException = NotConnectedException("session closed")
+        bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
+        advanceUntilIdle()
+
+        // disconnect must have been called (forced cleanup)
+        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
+
+        // Reconnect should happen (policy should iterate)
+        advanceTimeBy(15_000L)
+        assertTrue(connection.connectAndAwaitCalls >= 2, "Reconnect loop must iterate after internal session failure")
 
         bleTransport.close()
     }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -646,7 +646,7 @@ class BleRadioTransportReconnectCrashTest {
 
         // Trigger a drain by emitting a FROMNUM notification — this causes the profile to poll
         // fromRadioChar, which throws NotConnectedException (a session-fatal BLE exception).
-        connection.service.emitNotification(FROMNUM_CHARACTERISTIC.uuid, byteArrayOf(1))
+        connection.service.emitNotification(FROMNUM_CHARACTERISTIC, byteArrayOf(1))
         advanceUntilIdle()
 
         // handleFailure must have forced a GATT disconnect
@@ -695,7 +695,7 @@ class BleRadioTransportReconnectCrashTest {
         connection.service.writeException = NotConnectedException("write failure")
 
         // Trigger both paths nearly simultaneously
-        connection.service.emitNotification(FROMNUM_CHARACTERISTIC.uuid, byteArrayOf(1))
+        connection.service.emitNotification(FROMNUM_CHARACTERISTIC, byteArrayOf(1))
         bleTransport.handleSendToRadio(byteArrayOf(42))
         advanceUntilIdle()
 

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -27,11 +27,11 @@ import dev.mokkery.mock
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.ble.BleConnection
 import org.meshtastic.core.ble.BleConnectionFactory
@@ -105,16 +105,20 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        // Allow the connection loop to reach the connected state.
-        advanceTimeBy(4_000L)
+            // Allow the connection loop to reach the connected state.
+            advanceTimeBy(4_000L)
 
-        bleTransport.close()
+            bleTransport.close()
 
-        // disconnect() must be called: once by the connection loop teardown + once by close() itself.
-        // We only assert it was called at least once — the exact count depends on timing.
-        assertTrue(connection.disconnectCalls >= 1, "Expected disconnect() to be called at least once")
+            // disconnect() must be called: once by the connection loop teardown + once by close() itself.
+            // We only assert it was called at least once — the exact count depends on timing.
+            assertTrue(connection.disconnectCalls >= 1, "Expected disconnect() to be called at least once")
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── disconnect called on connection failure ──────────────────────────────────────────────────
@@ -143,14 +147,18 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        advanceTimeBy(30_000L)
+            advanceTimeBy(30_000L)
 
-        bleTransport.close()
+            bleTransport.close()
 
-        // Each failed connectAndAwait round-trips through the reconnect loop; close() always disconnects.
-        assertTrue(connection.disconnectCalls >= 1, "disconnect() not called after connection failure")
+            // Each failed connectAndAwait round-trips through the reconnect loop; close() always disconnects.
+            assertTrue(connection.disconnectCalls >= 1, "disconnect() not called after connection failure")
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── transient onDisconnect after failure threshold ──────────────────────────────────────────
@@ -180,18 +188,22 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        advanceTimeBy(24_001L)
+            advanceTimeBy(24_001L)
 
-        // Transient disconnect must have been signalled.
-        dev.mokkery.verify { service.onDisconnect(isPermanent = false, errorMessage = any()) }
-        // Permanent disconnect must NEVER be called by the transport on its own.
-        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) {
-            service.onDisconnect(isPermanent = true, errorMessage = any())
+            // Transient disconnect must have been signalled.
+            dev.mokkery.verify { service.onDisconnect(isPermanent = false, errorMessage = any()) }
+            // Permanent disconnect must NEVER be called by the transport on its own.
+            dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) {
+                service.onDisconnect(isPermanent = true, errorMessage = any())
+            }
+
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
         }
-
-        bleTransport.close()
     }
 
     // ─── CancellationException is not silently swallowed ─────────────────────────────────────────
@@ -225,17 +237,21 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        // Allow one connection attempt to reach profile() and be cancelled.
-        advanceTimeBy(4_000L)
+            // Allow one connection attempt to reach profile() and be cancelled.
+            advanceTimeBy(4_000L)
 
-        bleTransport.close()
+            bleTransport.close()
 
-        assertTrue(
-            throwingConnection.disconnectCalls >= 1,
-            "disconnect() must be called after CancellationException in profile() — GATT leak fix",
-        )
+            assertTrue(
+                throwingConnection.disconnectCalls >= 1,
+                "disconnect() must be called after CancellationException in profile() — GATT leak fix",
+            )
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── Reconnect after a stable connection drops ───────────────────────────────────────────────
@@ -270,29 +286,33 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        // Settle delay (3 s) + connect + handshake.
-        advanceTimeBy(4_000L)
-        assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen during initial start window")
+            // Settle delay (3 s) + connect + handshake.
+            advanceTimeBy(4_000L)
+            assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen during initial start window")
 
-        // Stay connected long enough to be considered stable (> minStableConnection = 5 s).
-        advanceTimeBy(10_000L)
+            // Stay connected long enough to be considered stable (> minStableConnection = 5 s).
+            advanceTimeBy(10_000L)
 
-        // Simulate the firmware dying mid-session — the same path a node power-cycle takes.
-        connection.simulateRemoteDisconnect(reason = DisconnectReason.Timeout)
+            // Simulate the firmware dying mid-session — the same path a node power-cycle takes.
+            connection.simulateRemoteDisconnect(reason = DisconnectReason.Timeout)
 
-        // Settle delay (3 s) before the next attempt + re-connect window. Generous to absorb
-        // the policy retry backoff (5 s on first failure) plus another 3 s settle delay.
-        advanceTimeBy(30_000L)
+            // Settle delay (3 s) before the next attempt + re-connect window. Generous to absorb
+            // the policy retry backoff (5 s on first failure) plus another 3 s settle delay.
+            advanceTimeBy(30_000L)
 
-        assertTrue(
-            connection.connectAndAwaitCalls >= 2,
-            "Reconnect loop must call connectAndAwait again after a remote disconnect " +
-                "(actual calls: ${connection.connectAndAwaitCalls})",
-        )
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must call connectAndAwait again after a remote disconnect " +
+                    "(actual calls: ${connection.connectAndAwaitCalls})",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── Session-failure recovery (Wave 2) ────────────────────────────────────────────────────────
@@ -311,29 +331,35 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L) // connect + handshake
-        assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L) // connect + handshake
+            assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
 
-        // Inject write failure while BLE state remains Connected
-        connection.service.writeException = NotConnectedException("session closed")
+            // Inject write failure while BLE state remains Connected
+            connection.service.writeException = NotConnectedException("session closed")
 
-        // Trigger a write (simulating a heartbeat or user packet)
-        bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
-        advanceUntilIdle()
+            // Trigger a write (simulating a heartbeat or user packet)
+            bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
+            // Drain the immediate failure path without advancing through the reconnect loop's
+            // delayed retry — the subsequent advanceTimeBy covers the retry.
+            testScheduler.runCurrent()
 
-        // After failure: disconnect must be called (GATT cleanup)
-        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
+            // After failure: disconnect must be called (GATT cleanup)
+            assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
 
-        // Reconnect policy should iterate — wait for settle (3s) + connect
-        advanceTimeBy(10_000L)
-        assertTrue(
-            connection.connectAndAwaitCalls >= 2,
-            "Reconnect loop must call connectAndAwait again after session failure " +
-                "(actual calls: ${connection.connectAndAwaitCalls})",
-        )
+            // Reconnect policy should iterate — wait for settle (3s) + connect
+            advanceTimeBy(10_000L)
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must call connectAndAwait again after session failure " +
+                    "(actual calls: ${connection.connectAndAwaitCalls})",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     @Test
@@ -352,18 +378,23 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L)
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
 
-        connection.service.writeException = CancellationException("cancelled")
+            connection.service.writeException = CancellationException("cancelled")
 
-        bleTransport.handleSendToRadio(byteArrayOf(1))
-        advanceUntilIdle()
+            bleTransport.handleSendToRadio(byteArrayOf(1))
+            // Drain the cancelled write coroutine; no retry is triggered for CancellationException.
+            testScheduler.runCurrent()
 
-        // CancellationException must NOT result in a user-facing disconnect callback
-        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
+            // CancellationException must NOT result in a user-facing disconnect callback
+            dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     @Test
@@ -383,23 +414,27 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L)
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
 
-        // First write failure — should trigger onDisconnect once
-        connection.service.writeException = NotConnectedException("session closed")
-        bleTransport.handleSendToRadio(byteArrayOf(1))
-        // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
-        // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
-        advanceTimeBy(2_000L)
+            // First write failure — should trigger onDisconnect once
+            connection.service.writeException = NotConnectedException("session closed")
+            bleTransport.handleSendToRadio(byteArrayOf(1))
+            // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
+            // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
+            advanceTimeBy(2_000L)
 
-        // Second write failure against same session — must NOT trigger another callback
-        bleTransport.handleSendToRadio(byteArrayOf(2))
-        advanceTimeBy(1_000L)
+            // Second write failure against same session — must NOT trigger another callback
+            bleTransport.handleSendToRadio(byteArrayOf(2))
+            advanceTimeBy(1_000L)
 
-        assertEquals(1, onDisconnectCalls, "onDisconnect must be called exactly once for the session failure")
+            assertEquals(1, onDisconnectCalls, "onDisconnect must be called exactly once for the session failure")
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     @Test
@@ -416,31 +451,35 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L)
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
 
-        val writesBefore = connection.service.writes.size
+            val writesBefore = connection.service.writes.size
 
-        // First write failure clears radioService
-        connection.service.writeException = NotConnectedException("session closed")
-        bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
-        // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
-        // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
-        advanceTimeBy(2_000L)
+            // First write failure clears radioService
+            connection.service.writeException = NotConnectedException("session closed")
+            bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
+            // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
+            // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
+            advanceTimeBy(2_000L)
 
-        // Second write — radioService should be null, so no write is attempted
-        connection.service.writeException = null // clear the exception hook
-        bleTransport.handleSendToRadio(byteArrayOf(4, 5, 6))
-        advanceTimeBy(1_000L)
+            // Second write — radioService should be null, so no write is attempted
+            connection.service.writeException = null // clear the exception hook
+            bleTransport.handleSendToRadio(byteArrayOf(4, 5, 6))
+            advanceTimeBy(1_000L)
 
-        // No new writes should have been recorded (radioService was null → write skipped)
-        assertEquals(
-            writesBefore,
-            connection.service.writes.size,
-            "No new write should be recorded after radioService was cleared",
-        )
+            // No new writes should have been recorded (radioService was null → write skipped)
+            assertEquals(
+                writesBefore,
+                connection.service.writes.size,
+                "No new write should be recorded after radioService was cleared",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     @Test
@@ -459,28 +498,37 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L) // connect + handshake
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L) // connect + handshake
 
-        // Inject a write failure — this should NOT be treated as intentional
-        connection.service.writeException = NotConnectedException("session closed")
-        bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
-        advanceUntilIdle()
+            // Inject a write failure — this should NOT be treated as intentional
+            connection.service.writeException = NotConnectedException("session closed")
+            bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
+            // Drain the immediate failure path; the reconnect loop's delayed retry is advanced
+            // explicitly below.
+            testScheduler.runCurrent()
 
-        // disconnect must have been called (forced cleanup)
-        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
+            // disconnect must have been called (forced cleanup)
+            assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
 
-        // Verify onDisconnect was called with isPermanent = false (not true)
-        dev.mokkery.verify { service.onDisconnect(isPermanent = false, errorMessage = any()) }
-        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) {
-            service.onDisconnect(isPermanent = true, errorMessage = any())
+            // Verify onDisconnect was called with isPermanent = false (not true)
+            dev.mokkery.verify { service.onDisconnect(isPermanent = false, errorMessage = any()) }
+            dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) {
+                service.onDisconnect(isPermanent = true, errorMessage = any())
+            }
+
+            // Reconnect should happen (policy should iterate)
+            advanceTimeBy(15_000L)
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must iterate after internal session failure",
+            )
+
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
         }
-
-        // Reconnect should happen (policy should iterate)
-        advanceTimeBy(15_000L)
-        assertTrue(connection.connectAndAwaitCalls >= 2, "Reconnect loop must iterate after internal session failure")
-
-        bleTransport.close()
     }
 
     // ─── Liveness restart semantics (Wave 3) ──────────────────────────────────────────────────────
@@ -507,32 +555,43 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L)
-        assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
+            assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
 
-        // Simulate liveness restart: close + create fresh transport
-        bleTransport.close()
-        advanceTimeBy(2_000L)
+            // Simulate liveness restart: close + create fresh transport
+            bleTransport.close()
+            advanceTimeBy(2_000L)
 
-        val freshConnection = FakeBleConnection()
-        val freshFactory = FakeBleConnectionFactory(freshConnection)
+            val freshConnection = FakeBleConnection()
+            val freshFactory = FakeBleConnectionFactory(freshConnection)
 
-        val restartedTransport =
-            BleRadioTransport(
-                scope = this,
-                scanner = scanner,
-                bluetoothRepository = bluetoothRepository,
-                connectionFactory = freshFactory,
-                callback = service,
-                address = address,
-            )
-        restartedTransport.start()
-        advanceTimeBy(4_000L)
+            val restartedTransport =
+                BleRadioTransport(
+                    scope = this,
+                    scanner = scanner,
+                    bluetoothRepository = bluetoothRepository,
+                    connectionFactory = freshFactory,
+                    callback = service,
+                    address = address,
+                )
+            try {
+                restartedTransport.start()
+                advanceTimeBy(4_000L)
 
-        assertTrue(freshConnection.connectAndAwaitCalls >= 1, "Fresh transport must attempt connection after restart")
+                assertTrue(
+                    freshConnection.connectAndAwaitCalls >= 1,
+                    "Fresh transport must attempt connection after restart",
+                )
 
-        restartedTransport.close()
+                restartedTransport.close()
+            } finally {
+                restartedTransport.close()
+            }
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── Profile setup failure returns Failed outcome and retries ──────────────────────────────────
@@ -559,20 +618,24 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        // First attempt fails at profile setup, then settle delay + reconnect.
-        advanceTimeBy(15_000L)
+            // First attempt fails at profile setup, then settle delay + reconnect.
+            advanceTimeBy(15_000L)
 
-        // The reconnect loop should have called connectAndAwait at least twice
-        // (initial failure + retry)
-        assertTrue(
-            connection.connectAndAwaitCalls >= 2,
-            "Reconnect loop must iterate after profile setup failure " +
-                "(actual calls: ${connection.connectAndAwaitCalls})",
-        )
+            // The reconnect loop should have called connectAndAwait at least twice
+            // (initial failure + retry)
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must iterate after profile setup failure " +
+                    "(actual calls: ${connection.connectAndAwaitCalls})",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     /**
@@ -595,26 +658,31 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L)
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
 
-        // Inject CancellationException into a write
-        connection.service.writeException = CancellationException("cancelled")
-        bleTransport.handleSendToRadio(byteArrayOf(1))
-        advanceUntilIdle()
+            // Inject CancellationException into a write
+            connection.service.writeException = CancellationException("cancelled")
+            bleTransport.handleSendToRadio(byteArrayOf(1))
+            // Drain the cancelled write coroutine; no retry is triggered for CancellationException.
+            testScheduler.runCurrent()
 
-        // CancellationException must NOT result in a user-facing disconnect callback
-        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
+            // CancellationException must NOT result in a user-facing disconnect callback
+            dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
 
-        // Clear the exception and verify the transport is still usable
-        connection.service.writeException = null
-        bleTransport.handleSendToRadio(byteArrayOf(2))
-        advanceTimeBy(1_000L)
+            // Clear the exception and verify the transport is still usable
+            connection.service.writeException = null
+            bleTransport.handleSendToRadio(byteArrayOf(2))
+            advanceTimeBy(1_000L)
 
-        // Still no disconnect should have been called
-        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
+            // Still no disconnect should have been called
+            dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── Read-path session-failure recovery (fromRadio fatal) ──────────────────────────────────────
@@ -648,30 +716,36 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L) // connect + handshake
-        assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L) // connect + handshake
+            assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
 
-        // Inject a read failure that will fire on the next drain cycle
-        connection.service.readException = NotConnectedException("read session closed")
+            // Inject a read failure that will fire on the next drain cycle
+            connection.service.readException = NotConnectedException("read session closed")
 
-        // Trigger a drain by emitting a FROMNUM notification — this causes the profile to poll
-        // fromRadioChar, which throws NotConnectedException (a session-fatal BLE exception).
-        connection.service.emitNotification(FROMNUM_CHARACTERISTIC, byteArrayOf(1))
-        advanceUntilIdle()
+            // Trigger a drain by emitting a FROMNUM notification — this causes the profile to poll
+            // fromRadioChar, which throws NotConnectedException (a session-fatal BLE exception).
+            connection.service.emitNotification(FROMNUM_CHARACTERISTIC, byteArrayOf(1))
+            // Drain the immediate fromRadio failure and forced disconnect; the explicit advanceTimeBy
+            // below covers the reconnect loop's delayed retry.
+            testScheduler.runCurrent()
 
-        // handleFailure must have forced a GATT disconnect
-        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after fromRadio read failure")
+            // handleFailure must have forced a GATT disconnect
+            assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after fromRadio read failure")
 
-        // Reconnect policy should iterate
-        advanceTimeBy(10_000L)
-        assertTrue(
-            connection.connectAndAwaitCalls >= 2,
-            "Reconnect loop must iterate after fromRadio read failure " +
-                "(actual calls: ${connection.connectAndAwaitCalls})",
-        )
+            // Reconnect policy should iterate
+            advanceTimeBy(10_000L)
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must iterate after fromRadio read failure " +
+                    "(actual calls: ${connection.connectAndAwaitCalls})",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     /**
@@ -703,26 +777,31 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
-        advanceTimeBy(4_000L)
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
 
-        // Inject BOTH read and write failures against the same session
-        connection.service.readException = NotConnectedException("read failure")
-        connection.service.writeException = NotConnectedException("write failure")
+            // Inject BOTH read and write failures against the same session
+            connection.service.readException = NotConnectedException("read failure")
+            connection.service.writeException = NotConnectedException("write failure")
 
-        // Trigger both paths nearly simultaneously
-        connection.service.emitNotification(FROMNUM_CHARACTERISTIC, byteArrayOf(1))
-        bleTransport.handleSendToRadio(byteArrayOf(42))
-        advanceUntilIdle()
+            // Trigger both paths nearly simultaneously
+            connection.service.emitNotification(FROMNUM_CHARACTERISTIC, byteArrayOf(1))
+            bleTransport.handleSendToRadio(byteArrayOf(42))
+            // Drain both failure paths; handleFailure's CAS guard should leave exactly one onDisconnect.
+            testScheduler.runCurrent()
 
-        assertEquals(
-            1,
-            onDisconnectCalls,
-            "onDisconnect must fire exactly once despite concurrent read+write failures " +
-                "(actual: $onDisconnectCalls)",
-        )
+            assertEquals(
+                1,
+                onDisconnectCalls,
+                "onDisconnect must fire exactly once despite concurrent read+write failures " +
+                    "(actual: $onDisconnectCalls)",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── FROMNUM subscription readiness setup failures ───────────────────────────────────────────
@@ -759,23 +838,27 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        // Initial settle (3s) + setup failure. Assert before retry can succeed, proving the failed
-        // pre-readiness attempt did not falsely mark subscription readiness or call onConnect().
-        advanceTimeBy(4_000L)
+            // Initial settle (3s) + setup failure. Assert before retry can succeed, proving the failed
+            // pre-readiness attempt did not falsely mark subscription readiness or call onConnect().
+            advanceTimeBy(4_000L)
 
-        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after FROMNUM observe failure")
-        assertEquals(0, onConnectCalls, "Failed pre-readiness setup must not call onConnect")
+            assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after FROMNUM observe failure")
+            assertEquals(0, onConnectCalls, "Failed pre-readiness setup must not call onConnect")
 
-        advanceTimeBy(10_000L)
-        assertTrue(
-            connection.connectAndAwaitCalls >= 2,
-            "Reconnect loop must retry after FROMNUM pre-readiness failure " +
-                "(actual calls: ${connection.connectAndAwaitCalls})",
-        )
+            advanceTimeBy(10_000L)
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must retry after FROMNUM pre-readiness failure " +
+                    "(actual calls: ${connection.connectAndAwaitCalls})",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     @Test
@@ -799,31 +882,35 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        // Settle (3s) + SUBSCRIPTION_READY_TIMEOUT (5s) + margin. FROMNUM observe never invokes
-        // onSubscription, so setup must abort instead of continuing with a half-initialized service.
-        advanceTimeBy(9_000L)
+            // Settle (3s) + SUBSCRIPTION_READY_TIMEOUT (5s) + margin. FROMNUM observe never invokes
+            // onSubscription, so setup must abort instead of continuing with a half-initialized service.
+            advanceTimeBy(9_000L)
 
-        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after subscription timeout")
-        assertEquals(0, onConnectCalls, "Subscription timeout must not call onConnect")
+            assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after subscription timeout")
+            assertEquals(0, onConnectCalls, "Subscription timeout must not call onConnect")
 
-        val writesBefore = connection.service.writes.size
-        bleTransport.handleSendToRadio(byteArrayOf(7, 8, 9))
-        assertEquals(
-            writesBefore,
-            connection.service.writes.size,
-            "Timed-out setup must clear radioService so writes do not use a half-initialized service",
-        )
+            val writesBefore = connection.service.writes.size
+            bleTransport.handleSendToRadio(byteArrayOf(7, 8, 9))
+            assertEquals(
+                writesBefore,
+                connection.service.writes.size,
+                "Timed-out setup must clear radioService so writes do not use a half-initialized service",
+            )
 
-        advanceTimeBy(10_000L)
-        assertTrue(
-            connection.connectAndAwaitCalls >= 2,
-            "Reconnect loop must retry after subscription readiness timeout " +
-                "(actual calls: ${connection.connectAndAwaitCalls})",
-        )
+            advanceTimeBy(10_000L)
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must retry after subscription readiness timeout " +
+                    "(actual calls: ${connection.connectAndAwaitCalls})",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     // ─── Connected-gate timeout cleanup ──────────────────────────────────────────────────────────
@@ -850,38 +937,42 @@ class BleRadioTransportReconnectCrashTest {
                 callback = service,
                 address = address,
             )
-        bleTransport.start()
+        try {
+            bleTransport.start()
 
-        // Settle (3s) + CONNECTED_GATE_TIMEOUT (5s) + margin. connectAndAwait returns Connected,
-        // profile setup succeeds, but connectionState never emits Connected, so the gate times out.
-        advanceTimeBy(9_000L)
+            // Settle (3s) + CONNECTED_GATE_TIMEOUT (5s) + margin. connectAndAwait returns Connected,
+            // profile setup succeeds, but connectionState never emits Connected, so the gate times out.
+            advanceTimeBy(9_000L)
 
-        assertTrue(staleConnection.disconnectCalls >= 1, "Connected-gate timeout must force GATT disconnect")
-        assertTrue(onDisconnectCalls <= 1, "Connected-gate timeout must not spam onDisconnect callbacks")
+            assertTrue(staleConnection.disconnectCalls >= 1, "Connected-gate timeout must force GATT disconnect")
+            assertTrue(onDisconnectCalls <= 1, "Connected-gate timeout must not spam onDisconnect callbacks")
 
-        val writesBefore = staleConnection.service.writes.size
-        bleTransport.handleSendToRadio(byteArrayOf(4, 5, 6))
-        assertEquals(
-            writesBefore,
-            staleConnection.service.writes.size,
-            "Connected-gate timeout must clear radioService so writes do not use stale profile state",
-        )
+            val writesBefore = staleConnection.service.writes.size
+            bleTransport.handleSendToRadio(byteArrayOf(4, 5, 6))
+            assertEquals(
+                writesBefore,
+                staleConnection.service.writes.size,
+                "Connected-gate timeout must clear radioService so writes do not use stale profile state",
+            )
 
-        advanceTimeBy(10_000L)
-        assertTrue(
-            staleConnection.connectAndAwaitCalls >= 2,
-            "Reconnect loop must retry after Connected-gate timeout " +
-                "(actual calls: ${staleConnection.connectAndAwaitCalls})",
-        )
+            advanceTimeBy(10_000L)
+            assertTrue(
+                staleConnection.connectAndAwaitCalls >= 2,
+                "Reconnect loop must retry after Connected-gate timeout " +
+                    "(actual calls: ${staleConnection.connectAndAwaitCalls})",
+            )
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 
     /**
      * Validates the normal Connected-gate path: when connectAndAwait returns Connected and the connectionState
-     * StateFlow reflects Connected, the gate succeeds immediately and the transport operates normally. This test does
-     * NOT exercise the timeout path (which requires a StateFlow that never reaches Connected — not easily simulated
-     * with the existing fake). The timeout cleanup logic is verified by static analysis.
+     * StateFlow reflects Connected, the gate succeeds immediately and the transport operates normally. The timeout path
+     * — where connectionState never reaches Connected — is covered separately by the `Connected-gate timeout cleans up
+     * stale service and retries without disconnect spam` test.
      */
     @Test
     fun `Connected-gate normal path succeeds and transport operates`() = runTest {
@@ -899,17 +990,18 @@ class BleRadioTransportReconnectCrashTest {
             )
         every { service.onDisconnect(any(), any()) } returns Unit
 
-        bleTransport.start()
-        // advance past connect — connectAndAwait returns Connected synchronously, but
-        // connectionState StateFlow stays Disconnected (FakeBleConnection sets it to Connected
-        // in connect(), so this test verifies the normal path where the gate succeeds).
-        // For the timeout to fire, we need connectionState to NOT reach Connected, which
-        // can't be easily simulated with the existing fake. Instead, we verify that the
-        // transport connects and operates normally when the gate succeeds.
-        advanceTimeBy(10_000L)
-        assertTrue(connection.connectAndAwaitCalls >= 1, "Must attempt at least one connection")
+        try {
+            bleTransport.start()
+            // advance past connect — connectAndAwait returns Connected synchronously and the
+            // FakeBleConnection sets connectionState to Connected in connect(), so this test
+            // verifies the normal path where the gate succeeds.
+            advanceTimeBy(10_000L)
+            assertTrue(connection.connectAndAwaitCalls >= 1, "Must attempt at least one connection")
 
-        bleTransport.close()
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
     }
 }
 
@@ -1000,7 +1092,7 @@ private class NeverConnectedStateBleConnection : BleConnection {
         serviceUuid: kotlin.uuid.Uuid,
         timeout: Duration,
         setup: suspend CoroutineScope.(BleService) -> T,
-    ): T = CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined).setup(service)
+    ): T = CoroutineScope(currentCoroutineContext()).setup(service)
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = null
 }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -726,12 +726,13 @@ class BleRadioTransportReconnectCrashTest {
     // ─── Connected-gate timeout cleanup ──────────────────────────────────────────────────────────
 
     /**
-     * Validates the Connected-gate timeout cleanup: when connectAndAwait returns Connected but connectionState never
-     * emits Connected (stale Disconnected), the gate times out, cleans up (disconnect + clear radioService), and the
-     * reconnect loop iterates.
+     * Validates the normal Connected-gate path: when connectAndAwait returns Connected and the connectionState
+     * StateFlow reflects Connected, the gate succeeds immediately and the transport operates normally. This test does
+     * NOT exercise the timeout path (which requires a StateFlow that never reaches Connected — not easily simulated
+     * with the existing fake). The timeout cleanup logic is verified by static analysis.
      */
     @Test
-    fun `Connected-gate timeout forces cleanup and retries`() = runTest {
+    fun `Connected-gate normal path succeeds and transport operates`() = runTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)
 

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.core.network.radio
 
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.ble.BleConnection
 import org.meshtastic.core.ble.BleConnectionFactory
@@ -43,6 +45,7 @@ import org.meshtastic.core.testing.FakeBleScanner
 import org.meshtastic.core.testing.FakeBluetoothRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 
@@ -281,6 +284,154 @@ class BleRadioTransportReconnectCrashTest {
             connection.connectAndAwaitCalls >= 2,
             "Reconnect loop must call connectAndAwait again after a remote disconnect " +
                 "(actual calls: ${connection.connectAndAwaitCalls})",
+        )
+
+        bleTransport.close()
+    }
+
+    // ─── Session-failure recovery (Wave 2) ────────────────────────────────────────────────────────
+
+    @Test
+    fun `write failure while connected clears state and triggers reconnect`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L) // connect + handshake
+        assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
+
+        // Inject write failure while BLE state remains Connected
+        connection.service.writeException = IllegalStateException("session closed")
+
+        // Trigger a write (simulating a heartbeat or user packet)
+        bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
+        advanceUntilIdle()
+
+        // After failure: disconnect must be called (GATT cleanup)
+        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
+
+        // Reconnect policy should iterate — wait for settle (3s) + connect
+        advanceTimeBy(10_000L)
+        assertTrue(
+            connection.connectAndAwaitCalls >= 2,
+            "Reconnect loop must call connectAndAwait again after session failure " +
+                "(actual calls: ${connection.connectAndAwaitCalls})",
+        )
+
+        bleTransport.close()
+    }
+
+    @Test
+    fun `CancellationException from write does not trigger callback`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        every { service.onDisconnect(any(), any()) } returns Unit
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L)
+
+        connection.service.writeException = CancellationException("cancelled")
+
+        bleTransport.handleSendToRadio(byteArrayOf(1))
+        advanceUntilIdle()
+
+        // CancellationException must NOT result in a user-facing disconnect callback
+        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
+
+        bleTransport.close()
+    }
+
+    @Test
+    fun `repeated writes after session failure do not spam onDisconnect`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        var onDisconnectCalls = 0
+        every { service.onDisconnect(any(), any()) } calls { onDisconnectCalls++ }
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L)
+
+        // First write failure — should trigger onDisconnect once
+        connection.service.writeException = IllegalStateException("session closed")
+        bleTransport.handleSendToRadio(byteArrayOf(1))
+        // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
+        // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
+        advanceTimeBy(2_000L)
+
+        // Second write failure against same session — must NOT trigger another callback
+        bleTransport.handleSendToRadio(byteArrayOf(2))
+        advanceTimeBy(1_000L)
+
+        assertEquals(1, onDisconnectCalls, "onDisconnect must be called exactly once for the session failure")
+
+        bleTransport.close()
+    }
+
+    @Test
+    fun `stale radioService is cleared after session failure`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L)
+
+        val writesBefore = connection.service.writes.size
+
+        // First write failure clears radioService
+        connection.service.writeException = IllegalStateException("session closed")
+        bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3))
+        // Advance enough for retryBleOperation to exhaust 3 retries (~750ms max) + handleFailure +
+        // disconnect, but NOT enough to reach the 3 s reconnect settle delay.
+        advanceTimeBy(2_000L)
+
+        // Second write — radioService should be null, so no write is attempted
+        connection.service.writeException = null // clear the exception hook
+        bleTransport.handleSendToRadio(byteArrayOf(4, 5, 6))
+        advanceTimeBy(1_000L)
+
+        // No new writes should have been recorded (radioService was null → write skipped)
+        assertEquals(
+            writesBefore,
+            connection.service.writes.size,
+            "No new write should be recorded after radioService was cleared",
         )
 
         bleTransport.close()

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -39,6 +39,7 @@ import org.meshtastic.core.ble.BleDevice
 import org.meshtastic.core.ble.BleService
 import org.meshtastic.core.ble.BleWriteType
 import org.meshtastic.core.ble.DisconnectReason
+import org.meshtastic.core.ble.MeshtasticBleConstants.SERVICE_UUID
 import org.meshtastic.core.testing.FakeBleConnection
 import org.meshtastic.core.testing.FakeBleConnectionFactory
 import org.meshtastic.core.testing.FakeBleDevice
@@ -443,6 +444,8 @@ class BleRadioTransportReconnectCrashTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)
 
+        every { service.onDisconnect(any(), any()) } returns Unit
+
         val bleTransport =
             BleRadioTransport(
                 scope = this,
@@ -463,9 +466,149 @@ class BleRadioTransportReconnectCrashTest {
         // disconnect must have been called (forced cleanup)
         assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after write failure")
 
+        // Verify onDisconnect was called with isPermanent = false (not true)
+        dev.mokkery.verify { service.onDisconnect(isPermanent = false, errorMessage = any()) }
+        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) {
+            service.onDisconnect(isPermanent = true, errorMessage = any())
+        }
+
         // Reconnect should happen (policy should iterate)
         advanceTimeBy(15_000L)
         assertTrue(connection.connectAndAwaitCalls >= 2, "Reconnect loop must iterate after internal session failure")
+
+        bleTransport.close()
+    }
+
+    // ─── Liveness restart semantics (Wave 3) ──────────────────────────────────────────────────────
+
+    /**
+     * Validates the transport-level behavior that liveness restart depends on: after stop (close) + start, a new
+     * connection attempt must occur.
+     *
+     * The [SharedRadioInterfaceService.checkLiveness] path calls stopTransportLocked then startTransportLocked, which
+     * destroys and recreates the transport. This test verifies that BleRadioTransport correctly handles this stop/start
+     * cycle.
+     */
+    @Test
+    fun `stop and restart creates a new connection attempt`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L)
+        assertTrue(connection.connectAndAwaitCalls == 1, "First connect must happen")
+
+        // Simulate liveness restart: close + create fresh transport
+        bleTransport.close()
+        advanceTimeBy(2_000L)
+
+        val freshConnection = FakeBleConnection()
+        val freshFactory = FakeBleConnectionFactory(freshConnection)
+
+        val restartedTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = freshFactory,
+                callback = service,
+                address = address,
+            )
+        restartedTransport.start()
+        advanceTimeBy(4_000L)
+
+        assertTrue(freshConnection.connectAndAwaitCalls >= 1, "Fresh transport must attempt connection after restart")
+
+        restartedTransport.close()
+    }
+
+    // ─── Profile setup failure returns Failed outcome and retries ──────────────────────────────────
+
+    /**
+     * When profile setup fails (e.g. missing service UUID), the transport should return a
+     * [BleReconnectPolicy.Outcome.Failed] and the reconnect loop should iterate. Uses
+     * [FakeBleConnection.missingServices] to cause `profile()` to throw.
+     */
+    @Test
+    fun `profile setup failure returns Failed outcome and retries`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        // Make SERVICE_UUID missing → profile() throws NoSuchElementException
+        connection.missingServices.add(SERVICE_UUID)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+
+        // First attempt fails at profile setup, then settle delay + reconnect.
+        advanceTimeBy(15_000L)
+
+        // The reconnect loop should have called connectAndAwait at least twice
+        // (initial failure + retry)
+        assertTrue(
+            connection.connectAndAwaitCalls >= 2,
+            "Reconnect loop must iterate after profile setup failure " +
+                "(actual calls: ${connection.connectAndAwaitCalls})",
+        )
+
+        bleTransport.close()
+    }
+
+    /**
+     * Regression: CancellationException from a write should not trigger onDisconnect even after the transport has
+     * reconnected and is operating normally.
+     */
+    @Test
+    fun `CancellationException from write does not trigger onDisconnect after reconnection`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        every { service.onDisconnect(any(), any()) } returns Unit
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(4_000L)
+
+        // Inject CancellationException into a write
+        connection.service.writeException = CancellationException("cancelled")
+        bleTransport.handleSendToRadio(byteArrayOf(1))
+        advanceUntilIdle()
+
+        // CancellationException must NOT result in a user-facing disconnect callback
+        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
+
+        // Clear the exception and verify the transport is still usable
+        connection.service.writeException = null
+        bleTransport.handleSendToRadio(byteArrayOf(2))
+        advanceTimeBy(1_000L)
+
+        // Still no disconnect should have been called
+        dev.mokkery.verify(mode = dev.mokkery.verify.VerifyMode.not) { service.onDisconnect(any(), any()) }
 
         bleTransport.close()
     }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -40,6 +40,7 @@ import org.meshtastic.core.ble.BleService
 import org.meshtastic.core.ble.BleWriteType
 import org.meshtastic.core.ble.DisconnectReason
 import org.meshtastic.core.ble.MeshtasticBleConstants.FROMNUM_CHARACTERISTIC
+import org.meshtastic.core.ble.MeshtasticBleConstants.FROMRADIO_CHARACTERISTIC
 import org.meshtastic.core.ble.MeshtasticBleConstants.SERVICE_UUID
 import org.meshtastic.core.testing.FakeBleConnection
 import org.meshtastic.core.testing.FakeBleConnectionFactory
@@ -628,11 +629,13 @@ class BleRadioTransportReconnectCrashTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)
 
-        // Register FROMNUM before start() so the profile's observe collector is set up during
-        // discoverServicesAndSetupCharacteristics. Without this, hasCharacteristic(FROMNUM)
-        // returns false at setup time, no collector is established, and emitNotification
-        // below would fire into a void.
+        // Register FROMNUM + FROMRADIO before start() so the profile's observe collector and read
+        // loop are set up during discoverServicesAndSetupCharacteristics. Without FROMNUM, no
+        // notification collector is established (emitNotification fires into a void). Without
+        // FROMRADIO, hasCharacteristic(fromRadioChar) returns false and the read loop skips before
+        // readException can fire.
         connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
+        connection.service.addCharacteristic(FROMRADIO_CHARACTERISTIC)
 
         val bleTransport =
             BleRadioTransport(
@@ -681,9 +684,10 @@ class BleRadioTransportReconnectCrashTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)
 
-        // Register FROMNUM before start() so the profile's observe collector is set up during
-        // discoverServicesAndSetupCharacteristics. See the read-failure test above for details.
+        // Register FROMNUM + FROMRADIO before start() so both read and write failure paths can
+        // fire. See the read-failure test above for details.
         connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
+        connection.service.addCharacteristic(FROMRADIO_CHARACTERISTIC)
 
         var onDisconnectCalls = 0
         every { service.onDisconnect(any(), any()) } calls { onDisconnectCalls++ }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -722,6 +722,42 @@ class BleRadioTransportReconnectCrashTest {
 
         bleTransport.close()
     }
+
+    // ─── Connected-gate timeout cleanup ──────────────────────────────────────────────────────────
+
+    /**
+     * Validates the Connected-gate timeout cleanup: when connectAndAwait returns Connected but connectionState never
+     * emits Connected (stale Disconnected), the gate times out, cleans up (disconnect + clear radioService), and the
+     * reconnect loop iterates.
+     */
+    @Test
+    fun `Connected-gate timeout forces cleanup and retries`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        every { service.onDisconnect(any(), any()) } returns Unit
+
+        bleTransport.start()
+        // advance past connect — connectAndAwait returns Connected synchronously, but
+        // connectionState StateFlow stays Disconnected (FakeBleConnection sets it to Connected
+        // in connect(), so this test verifies the normal path where the gate succeeds).
+        // For the timeout to fire, we need connectionState to NOT reach Connected, which
+        // can't be easily simulated with the existing fake. Instead, we verify that the
+        // transport connects and operates normally when the gate succeeds.
+        advanceTimeBy(10_000L)
+        assertTrue(connection.connectAndAwaitCalls >= 1, "Must attempt at least one connection")
+
+        bleTransport.close()
+    }
 }
 
 // ─── Test doubles ────────────────────────────────────────────────────────────────────────────────

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.network.radio
 
+import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
@@ -47,6 +48,7 @@ import org.meshtastic.core.testing.FakeBleConnectionFactory
 import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.core.testing.FakeBleScanner
 import org.meshtastic.core.testing.FakeBluetoothRepository
+import org.meshtastic.core.testing.FakeBleService
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -723,7 +725,157 @@ class BleRadioTransportReconnectCrashTest {
         bleTransport.close()
     }
 
+    // ─── FROMNUM subscription readiness setup failures ───────────────────────────────────────────
+
+    @Test
+    fun `FROMNUM NotConnected before readiness aborts setup and retries`() =
+        fromNumPreReadinessFailureAbortsSetupAndRetries(
+            failure = NotConnectedException("FROMNUM observe failed before CCCD"),
+        )
+
+    @Test
+    fun `FROMNUM GATT 133 before readiness aborts setup and retries`() =
+        fromNumPreReadinessFailureAbortsSetupAndRetries(
+            failure = GattStatusException(status = 133, message = "GATT error"),
+        )
+
+    private fun fromNumPreReadinessFailureAbortsSetupAndRetries(failure: Exception) = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
+        connection.service.observeBeforeSubscriptionExceptionByCharacteristic[FROMNUM_CHARACTERISTIC] = failure
+
+        var onConnectCalls = 0
+        every { service.onConnect() } calls { onConnectCalls++ }
+        every { service.onDisconnect(any(), any()) } returns Unit
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+
+        // Initial settle (3s) + setup failure. Assert before retry can succeed, proving the failed
+        // pre-readiness attempt did not falsely mark subscription readiness or call onConnect().
+        advanceTimeBy(4_000L)
+
+        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after FROMNUM observe failure")
+        assertEquals(0, onConnectCalls, "Failed pre-readiness setup must not call onConnect")
+
+        advanceTimeBy(10_000L)
+        assertTrue(
+            connection.connectAndAwaitCalls >= 2,
+            "Reconnect loop must retry after FROMNUM pre-readiness failure " +
+                "(actual calls: ${connection.connectAndAwaitCalls})",
+        )
+
+        bleTransport.close()
+    }
+
+    @Test
+    fun `FROMNUM subscription readiness timeout aborts setup clears stale service and retries`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
+        connection.service.observeNeverSubscribeCharacteristics += FROMNUM_CHARACTERISTIC
+
+        var onConnectCalls = 0
+        every { service.onConnect() } calls { onConnectCalls++ }
+        every { service.onDisconnect(any(), any()) } returns Unit
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+
+        // Settle (3s) + SUBSCRIPTION_READY_TIMEOUT (5s) + margin. FROMNUM observe never invokes
+        // onSubscription, so setup must abort instead of continuing with a half-initialized service.
+        advanceTimeBy(9_000L)
+
+        assertTrue(connection.disconnectCalls >= 1, "disconnect() must be called after subscription timeout")
+        assertEquals(0, onConnectCalls, "Subscription timeout must not call onConnect")
+
+        val writesBefore = connection.service.writes.size
+        bleTransport.handleSendToRadio(byteArrayOf(7, 8, 9))
+        assertEquals(
+            writesBefore,
+            connection.service.writes.size,
+            "Timed-out setup must clear radioService so writes do not use a half-initialized service",
+        )
+
+        advanceTimeBy(10_000L)
+        assertTrue(
+            connection.connectAndAwaitCalls >= 2,
+            "Reconnect loop must retry after subscription readiness timeout " +
+                "(actual calls: ${connection.connectAndAwaitCalls})",
+        )
+
+        bleTransport.close()
+    }
+
     // ─── Connected-gate timeout cleanup ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `Connected-gate timeout cleans up stale service and retries without disconnect spam`() = runTest {
+        val staleConnection = NeverConnectedStateBleConnection()
+        val staleFactory =
+            object : BleConnectionFactory {
+                override fun create(scope: CoroutineScope, tag: String): BleConnection = staleConnection
+            }
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+
+        var onDisconnectCalls = 0
+        every { service.onDisconnect(any(), any()) } calls { onDisconnectCalls++ }
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = staleFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+
+        // Settle (3s) + CONNECTED_GATE_TIMEOUT (5s) + margin. connectAndAwait returns Connected,
+        // profile setup succeeds, but connectionState never emits Connected, so the gate times out.
+        advanceTimeBy(9_000L)
+
+        assertTrue(staleConnection.disconnectCalls >= 1, "Connected-gate timeout must force GATT disconnect")
+        assertTrue(onDisconnectCalls <= 1, "Connected-gate timeout must not spam onDisconnect callbacks")
+
+        val writesBefore = staleConnection.service.writes.size
+        bleTransport.handleSendToRadio(byteArrayOf(4, 5, 6))
+        assertEquals(
+            writesBefore,
+            staleConnection.service.writes.size,
+            "Connected-gate timeout must clear radioService so writes do not use stale profile state",
+        )
+
+        advanceTimeBy(10_000L)
+        assertTrue(
+            staleConnection.connectAndAwaitCalls >= 2,
+            "Reconnect loop must retry after Connected-gate timeout " +
+                "(actual calls: ${staleConnection.connectAndAwaitCalls})",
+        )
+
+        bleTransport.close()
+    }
 
     /**
      * Validates the normal Connected-gate path: when connectAndAwait returns Connected and the connectionState
@@ -800,6 +952,57 @@ private class CancellingProfileBleConnection : BleConnection {
         timeout: Duration,
         setup: suspend CoroutineScope.(BleService) -> T,
     ): T = throw CancellationException("Simulated scope cancellation during service discovery")
+
+    override fun maximumWriteValueLength(writeType: BleWriteType): Int? = null
+}
+
+/**
+ * A [BleConnection] whose [connectAndAwait] reports success while [connectionState] never emits
+ * [BleConnectionState.Connected]. This exercises the Connected-gate timeout cleanup path after profile setup succeeds.
+ */
+private class NeverConnectedStateBleConnection : BleConnection {
+
+    private val _deviceFlow = MutableStateFlow<BleDevice?>(null)
+    override val deviceFlow: StateFlow<BleDevice?> = _deviceFlow.asStateFlow()
+
+    private val _connectionState = MutableStateFlow<BleConnectionState>(BleConnectionState.Disconnected())
+    override val connectionState: StateFlow<BleConnectionState> = _connectionState.asStateFlow()
+
+    override val device: BleDevice?
+        get() = _deviceFlow.value
+
+    val service = FakeBleService().apply {
+        addCharacteristic(FROMNUM_CHARACTERISTIC)
+    }
+
+    var connectAndAwaitCalls = 0
+        private set
+
+    var disconnectCalls = 0
+        private set
+
+    override suspend fun connect(device: BleDevice) {
+        _deviceFlow.value = device
+        _connectionState.value = BleConnectionState.Connecting
+    }
+
+    override suspend fun connectAndAwait(device: BleDevice, timeout: Duration): BleConnectionState {
+        connectAndAwaitCalls++
+        connect(device)
+        return BleConnectionState.Connected
+    }
+
+    override suspend fun disconnect() {
+        disconnectCalls++
+        _connectionState.value = BleConnectionState.Disconnected()
+        _deviceFlow.value = null
+    }
+
+    override suspend fun <T> profile(
+        serviceUuid: kotlin.uuid.Uuid,
+        timeout: Duration,
+        setup: suspend CoroutineScope.(BleService) -> T,
+    ): T = CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined).setup(service)
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = null
 }

--- a/core/service/build.gradle.kts
+++ b/core/service/build.gradle.kts
@@ -60,6 +60,9 @@ kotlin {
             }
         }
 
-        commonTest.dependencies { implementation(libs.kotlinx.coroutines.test) }
+        commonTest.dependencies {
+            implementation(projects.core.testing)
+            implementation(libs.kotlinx.coroutines.test)
+        }
     }
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -356,20 +356,21 @@ class SharedRadioInterfaceService(
 
         val silenceMs = now() - lastDataReceivedMillis
         if (silenceMs > LIVENESS_TIMEOUT_MILLIS) {
-            Logger.w {
-                "Liveness check failed: no data received for ${silenceMs}ms " +
-                    "(threshold: ${LIVENESS_TIMEOUT_MILLIS}ms). Treating as disconnect."
-            }
-
             // "Silence" = lastDataReceivedMillis not updated by handleFromRadio (no inbound
             // packets). Only BLE suffers from silent zombie sessions (no disconnect signal from
             // stack), so the liveness-restart path is BLE-only. For non-BLE transports we return
             // WITHOUT emitting a disconnect or mutating ConnectionState — there is no
             // transport-level timeout contract proving that silence past this threshold means
-            // the session is dead. Healthy TCP/serial firmware responds to heartbeat ToRadio with
-            // a queueStatus FromRadio packet, so true silence likely indicates a different issue
-            // that the transport's own reconnect mechanism handles.
-            if (runningTransportId != InterfaceId.BLUETOOTH) return
+            // the session is dead.
+            if (runningTransportId != InterfaceId.BLUETOOTH) {
+                Logger.d { "Ignoring liveness timeout for non-BLE transport (silence: ${silenceMs}ms)" }
+                return
+            }
+
+            Logger.w {
+                "Liveness check failed: no data received for ${silenceMs}ms " +
+                    "(threshold: ${LIVENESS_TIMEOUT_MILLIS}ms). Restarting BLE transport."
+            }
 
             // Force transport restart to recover from silent zombie sessions where the BLE stack
             // did not report a disconnect. Uses the same processLifecycle scope and transportMutex

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -266,7 +266,12 @@ class SharedRadioInterfaceService(
         return true
     }
 
-    /** Must be called under [transportMutex]. */
+    /**
+     * Starts the radio transport connection and begins heartbeat monitoring.
+     *
+     * Must be called under [transportMutex]. Does nothing if a transport is already
+     * running or if no valid bonded device address is available.
+     */
     private fun startTransportLocked() {
         if (radioTransport != null) return
 
@@ -288,6 +293,8 @@ class SharedRadioInterfaceService(
     }
 
     /**
+     * Stops the radio transport and cleans up its resources.
+     *
      * Must be called under [transportMutex].
      *
      * @param notifyPermanent When `true`, emits a permanent disconnect state to [connectionState]. Set `false` during
@@ -331,6 +338,12 @@ class SharedRadioInterfaceService(
         }
     }
 
+    /**
+     * Initiates periodic monitoring of the radio connection's keep-alive status and liveness.
+     *
+     * Cancels any existing heartbeat loop and starts a new one that runs at regular intervals
+     * to detect and recover from stale connections.
+     */
     private fun startHeartbeat() {
         heartbeatJob?.cancel()
         lastDataReceivedMillis = now()
@@ -345,12 +358,14 @@ class SharedRadioInterfaceService(
     }
 
     /**
-     * Detects zombie connections where the BLE stack didn't report a disconnect.
+     * Detects zombie BLE connections where the stack did not report a disconnect.
      *
-     * If we believe we're connected but haven't received any data from the radio within [LIVENESS_TIMEOUT_MILLIS], the
-     * connection is likely dead. Signal a non-permanent disconnect so the reconnect machinery can take over.
+     * If the connection state is `Connected` but no data has been received from the radio within
+     * [LIVENESS_TIMEOUT_MILLIS], the connection is likely dead. Emits a non-permanent disconnect
+     * and restarts the transport. Only BLE transports are restarted; other transport types are
+     * ignored.
      *
-     * Uses [clockMillis] for the current time so tests can inject a deterministic clock.
+     * Uses [clockMillis] to determine the current time.
      */
     internal fun checkLiveness() {
         if (_connectionState.value != ConnectionState.Connected) return
@@ -401,6 +416,9 @@ class SharedRadioInterfaceService(
         }
     }
 
+    /**
+     * Sends a keep-alive signal to the radio transport if the heartbeat interval has elapsed.
+     */
     fun keepAlive(now: Long = now()) {
         if (now - lastHeartbeatMillis > HEARTBEAT_INTERVAL_MILLIS) {
             radioTransport?.keepAlive()
@@ -430,6 +448,11 @@ class SharedRadioInterfaceService(
         }
     }
 
+    /**
+     * Processes incoming bytes from the radio and enqueues them in arrival order.
+     *
+     * Updates the timestamp of the last received data and emits a receive activity event.
+     */
     @Suppress("TooGenericExceptionCaught")
     override fun handleFromRadio(bytes: ByteArray) {
         try {
@@ -456,6 +479,12 @@ class SharedRadioInterfaceService(
         while (_receivedData.tryReceive().isSuccess) Unit
     }
 
+    /**
+     * Marks the radio connection as established.
+     *
+     * Updates the connection state to [ConnectionState.Connected] and resets the
+     * liveness-check timer.
+     */
     override fun onConnect() {
         // MutableStateFlow.value is thread-safe (backed by atomics) — assign directly rather than
         // launching a coroutine. The async launch pattern introduced a window where a concurrent

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -332,15 +332,17 @@ class SharedRadioInterfaceService(
     }
 
     /**
-     * Detects zombie connections where the BLE stack didn't report a disconnect.
+     * Detects zombie connections where the BLE stack didn't reported a disconnect.
      *
      * If we believe we're connected but haven't received any data from the radio within [LIVENESS_TIMEOUT_MILLIS], the
      * connection is likely dead. Signal a non-permanent disconnect so the reconnect machinery can take over.
+     *
+     * @param now Injected clock value for testability. Defaults to [nowMillis] in production.
      */
-    private fun checkLiveness() {
+    internal fun checkLiveness(now: Long = nowMillis) {
         if (_connectionState.value != ConnectionState.Connected) return
 
-        val silenceMs = nowMillis - lastDataReceivedMillis
+        val silenceMs = now - lastDataReceivedMillis
         if (silenceMs > LIVENESS_TIMEOUT_MILLIS) {
             Logger.w {
                 "Liveness check failed: no data received for ${silenceMs}ms " +
@@ -349,15 +351,13 @@ class SharedRadioInterfaceService(
 
             // "Silence" = lastDataReceivedMillis not updated by handleFromRadio (no inbound
             // packets). Only BLE suffers from silent zombie sessions (no disconnect signal from
-            // stack). Healthy TCP/serial firmware responds to heartbeat ToRadio with a queueStatus
-            // FromRadio packet, so they should not go silent past LIVENESS_TIMEOUT_MILLIS.
-            // MockRadioTransport.handleSendToRadio ignores heartbeat traffic, so mock sessions can
-            // false-positive here — acceptable for debug-only transport.
-            if (runningTransportId != InterfaceId.BLUETOOTH) {
-                // Non-BLE: emit the disconnect notification (no restart mechanism for these transports).
-                onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
-                return
-            }
+            // stack), so the liveness-restart path is BLE-only. For non-BLE transports we return
+            // WITHOUT emitting a disconnect or mutating ConnectionState — there is no
+            // transport-level timeout contract proving that silence past this threshold means
+            // the session is dead. Healthy TCP/serial firmware responds to heartbeat ToRadio with
+            // a queueStatus FromRadio packet, so true silence likely indicates a different issue
+            // that the transport's own reconnect mechanism handles.
+            if (runningTransportId != InterfaceId.BLUETOOTH) return
 
             // Force transport restart to recover from silent zombie sessions where the BLE stack
             // did not report a disconnect. Uses the same processLifecycle scope and transportMutex

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -78,6 +78,12 @@ class SharedRadioInterfaceService(
     private val radioPrefs: RadioPrefs,
     private val transportFactory: RadioTransportFactory,
     private val analytics: PlatformAnalytics,
+    /**
+     * Injectable clock for deterministic testing. Defaults to [nowMillis] in production. Used by [onConnect],
+     * [handleFromRadio], [checkLiveness], and [keepAlive] so all four share one coherent time source — mixing real
+     * wall-clock with injected test time produces negative silence durations and false test results.
+     */
+    private val clockMillis: () -> Long = { nowMillis },
 ) : RadioInterfaceService {
 
     override val supportedDeviceTypes: List<DeviceType>
@@ -136,6 +142,9 @@ class SharedRadioInterfaceService(
     private var lastHeartbeatMillis = 0L
 
     @Volatile private var lastDataReceivedMillis = 0L
+
+    /** The current time from the injected clock. */
+    private fun now(): Long = clockMillis()
 
     companion object {
         private const val HEARTBEAT_INTERVAL_MILLIS = 30 * 1000L
@@ -320,7 +329,7 @@ class SharedRadioInterfaceService(
 
     private fun startHeartbeat() {
         heartbeatJob?.cancel()
-        lastDataReceivedMillis = nowMillis
+        lastDataReceivedMillis = now()
         heartbeatJob =
             serviceScope.launch {
                 while (true) {
@@ -339,10 +348,10 @@ class SharedRadioInterfaceService(
      *
      * @param now Injected clock value for testability. Defaults to [nowMillis] in production.
      */
-    internal fun checkLiveness(now: Long = nowMillis) {
+    internal fun checkLiveness() {
         if (_connectionState.value != ConnectionState.Connected) return
 
-        val silenceMs = now - lastDataReceivedMillis
+        val silenceMs = now() - lastDataReceivedMillis
         if (silenceMs > LIVENESS_TIMEOUT_MILLIS) {
             Logger.w {
                 "Liveness check failed: no data received for ${silenceMs}ms " +
@@ -383,7 +392,7 @@ class SharedRadioInterfaceService(
         }
     }
 
-    fun keepAlive(now: Long = nowMillis) {
+    fun keepAlive(now: Long = now()) {
         if (now - lastHeartbeatMillis > HEARTBEAT_INTERVAL_MILLIS) {
             radioTransport?.keepAlive()
             lastHeartbeatMillis = now
@@ -415,7 +424,7 @@ class SharedRadioInterfaceService(
     @Suppress("TooGenericExceptionCaught")
     override fun handleFromRadio(bytes: ByteArray) {
         try {
-            lastDataReceivedMillis = nowMillis
+            lastDataReceivedMillis = now()
             // trySend synchronously onto the unbounded Channel so packet order matches arrival
             // order. The previous `launch { emit() }` pattern dispatched each packet onto a
             // fresh coroutine, letting the scheduler reorder them — which broke the firmware
@@ -443,7 +452,7 @@ class SharedRadioInterfaceService(
         // launching a coroutine. The async launch pattern introduced a window where a concurrent
         // onDisconnect launch could execute AFTER an onConnect launch, leaving the service stuck
         // in Connected while the transport was actually disconnected.
-        lastDataReceivedMillis = nowMillis
+        lastDataReceivedMillis = now()
         if (_connectionState.value != ConnectionState.Connected) {
             Logger.d { "Broadcasting connection state change to Connected" }
             _connectionState.value = ConnectionState.Connected

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -378,6 +378,10 @@ class SharedRadioInterfaceService(
             // double liveness-timeout (timer not cancelled between fires) does not produce
             // duplicate disconnect notifications for a single restart cycle.
             if (isRestarting.compareAndSet(expect = false, update = true)) {
+                // Note: hardcoded error message follows the existing pattern used throughout the
+                // transport layer (BleExceptionClassifier, toDisconnectReason, etc.). Refactoring to
+                // typed DisconnectReason + string resources is a broader change across all transports.
+                @Suppress("StringLiteralDuplicate")
                 onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
                 processLifecycle.coroutineScope.launch {
                     try {

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -274,8 +274,16 @@ class SharedRadioInterfaceService(
         startHeartbeat()
     }
 
-    /** Must be called under [transportMutex]. */
-    private suspend fun stopTransportLocked() {
+    /**
+     * Must be called under [transportMutex].
+     *
+     * @param notifyPermanent When `true`, emits a permanent disconnect state to [connectionState]. Set `false` during
+     *   automatic liveness recovery to avoid surfacing a user-facing disconnect.
+     * @param sendPoliteDisconnect When `true`, sends a `ToRadio(disconnect = true)` frame to the firmware before
+     *   tearing down. Set `false` when the transport is already dead (zombie session) to avoid writing into a broken
+     *   link.
+     */
+    private suspend fun stopTransportLocked(notifyPermanent: Boolean = true, sendPoliteDisconnect: Boolean = true) {
         val currentTransport = radioTransport
         Logger.i { "Stopping transport $currentTransport" }
         // Best-effort polite goodbye: tell the firmware we're disconnecting on purpose so it can
@@ -287,7 +295,9 @@ class SharedRadioInterfaceService(
         // transport's own scope; the drain delay gives async transports a window to flush before
         // close() cancels their write scope. BLE's retry path backs off 500ms, so this window
         // also covers one retry on flaky GATT links.
-        if (currentTransport != null && _connectionState.value != ConnectionState.Disconnected) {
+        if (
+            sendPoliteDisconnect && currentTransport != null && _connectionState.value != ConnectionState.Disconnected
+        ) {
             isStopping = true
             ignoreExceptionSuspend {
                 currentTransport.handleSendToRadio(ToRadio(disconnect = true).encode())
@@ -303,7 +313,7 @@ class SharedRadioInterfaceService(
         _serviceScope.cancel("stopping transport")
         _serviceScope = CoroutineScope(dispatchers.io + SupervisorJob())
 
-        if (currentTransport != null) {
+        if (notifyPermanent && currentTransport != null) {
             onDisconnect(isPermanent = true)
         }
     }
@@ -337,6 +347,11 @@ class SharedRadioInterfaceService(
                     "(threshold: ${LIVENESS_TIMEOUT_MILLIS}ms). Treating as disconnect."
             }
             onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
+
+            // Only BLE transports suffer from silent zombie sessions (no disconnect signal from stack).
+            // TCP/serial/mock can legitimately idle >60s without inbound data.
+            if (runningTransportId != InterfaceId.BLUETOOTH) return
+
             // Force transport restart to recover from silent zombie sessions where the BLE stack
             // did not report a disconnect. Uses the same processLifecycle scope and transportMutex
             // pattern as setDeviceAddress() to guarantee clean teardown/restart sequencing.
@@ -344,7 +359,9 @@ class SharedRadioInterfaceService(
                 processLifecycle.coroutineScope.launch {
                     try {
                         transportMutex.withLock {
-                            ignoreExceptionSuspend { stopTransportLocked() }
+                            ignoreExceptionSuspend {
+                                stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false)
+                            }
                             startTransportLocked()
                         }
                     } finally {

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -346,16 +346,23 @@ class SharedRadioInterfaceService(
                 "Liveness check failed: no data received for ${silenceMs}ms " +
                     "(threshold: ${LIVENESS_TIMEOUT_MILLIS}ms). Treating as disconnect."
             }
-            onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
 
             // Only BLE transports suffer from silent zombie sessions (no disconnect signal from stack).
             // TCP/serial/mock can legitimately idle >60s without inbound data.
-            if (runningTransportId != InterfaceId.BLUETOOTH) return
+            if (runningTransportId != InterfaceId.BLUETOOTH) {
+                // Non-BLE: emit the disconnect notification (no restart mechanism for these transports).
+                onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
+                return
+            }
 
             // Force transport restart to recover from silent zombie sessions where the BLE stack
             // did not report a disconnect. Uses the same processLifecycle scope and transportMutex
             // pattern as setDeviceAddress() to guarantee clean teardown/restart sequencing.
+            // The onDisconnect notification is emitted INSIDE the compareAndSet guard so that a
+            // double liveness-timeout (timer not cancelled between fires) does not produce
+            // duplicate disconnect notifications for a single restart cycle.
             if (isRestarting.compareAndSet(expect = false, update = true)) {
+                onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
                 processLifecycle.coroutineScope.launch {
                     try {
                         transportMutex.withLock {

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -347,8 +347,12 @@ class SharedRadioInterfaceService(
                     "(threshold: ${LIVENESS_TIMEOUT_MILLIS}ms). Treating as disconnect."
             }
 
-            // Only BLE transports suffer from silent zombie sessions (no disconnect signal from stack).
-            // TCP/serial/mock can legitimately idle >60s without inbound data.
+            // "Silence" = lastDataReceivedMillis not updated by handleFromRadio (no inbound
+            // packets). Only BLE suffers from silent zombie sessions (no disconnect signal from
+            // stack). Healthy TCP/serial firmware responds to heartbeat ToRadio with a queueStatus
+            // FromRadio packet, so they should not go silent past LIVENESS_TIMEOUT_MILLIS.
+            // MockRadioTransport.handleSendToRadio ignores heartbeat traffic, so mock sessions can
+            // false-positive here — acceptable for debug-only transport.
             if (runningTransportId != InterfaceId.BLUETOOTH) {
                 // Non-BLE: emit the disconnect notification (no restart mechanism for these transports).
                 onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -344,12 +344,12 @@ class SharedRadioInterfaceService(
     }
 
     /**
-     * Detects zombie connections where the BLE stack didn't reported a disconnect.
+     * Detects zombie connections where the BLE stack didn't report a disconnect.
      *
      * If we believe we're connected but haven't received any data from the radio within [LIVENESS_TIMEOUT_MILLIS], the
      * connection is likely dead. Signal a non-permanent disconnect so the reconnect machinery can take over.
      *
-     * @param now Injected clock value for testability. Defaults to [nowMillis] in production.
+     * Uses [clockMillis] for the current time so tests can inject a deterministic clock.
      */
     internal fun checkLiveness() {
         if (_connectionState.value != ConnectionState.Connected) return

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -128,6 +128,9 @@ class SharedRadioInterfaceService(
      */
     @Volatile private var isStopping = false
 
+    /** Prevents concurrent liveness-induced transport restarts from stacking. */
+    private val isRestarting = atomic(false)
+
     private val listenersInitialized = atomic(false)
     private var heartbeatJob: Job? = null
     private var lastHeartbeatMillis = 0L
@@ -334,9 +337,21 @@ class SharedRadioInterfaceService(
                     "(threshold: ${LIVENESS_TIMEOUT_MILLIS}ms). Treating as disconnect."
             }
             onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
-            // TODO: If the zombie condition manifests as silence rather than a write/read exception,
-            // this liveness timeout should force a transport restart (stopTransportLocked +
-            // startTransportLocked) rather than just updating the UI connection state.
+            // Force transport restart to recover from silent zombie sessions where the BLE stack
+            // did not report a disconnect. Uses the same processLifecycle scope and transportMutex
+            // pattern as setDeviceAddress() to guarantee clean teardown/restart sequencing.
+            if (isRestarting.compareAndSet(expect = false, update = true)) {
+                processLifecycle.coroutineScope.launch {
+                    try {
+                        transportMutex.withLock {
+                            ignoreExceptionSuspend { stopTransportLocked() }
+                            startTransportLocked()
+                        }
+                    } finally {
+                        isRestarting.value = false
+                    }
+                }
+            }
         }
     }
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -334,6 +334,9 @@ class SharedRadioInterfaceService(
                     "(threshold: ${LIVENESS_TIMEOUT_MILLIS}ms). Treating as disconnect."
             }
             onDisconnect(isPermanent = false, errorMessage = "Connection timeout — no data received")
+            // TODO: If the zombie condition manifests as silence rather than a write/read exception,
+            // this liveness timeout should force a transport restart (stopTransportLocked +
+            // startTransportLocked) rather than just updating the UI connection state.
         }
     }
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -143,6 +143,7 @@ class SharedRadioInterfaceService(
      * time source. Not a constructor parameter to avoid breaking Koin @Single annotation generation (which would try to
      * resolve `() -> Long` from the DI graph).
      */
+    @Volatile
     @Suppress("MemberVisibilityCanBePrivate")
     internal var clockMillis: () -> Long = { nowMillis }
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -78,12 +78,6 @@ class SharedRadioInterfaceService(
     private val radioPrefs: RadioPrefs,
     private val transportFactory: RadioTransportFactory,
     private val analytics: PlatformAnalytics,
-    /**
-     * Injectable clock for deterministic testing. Defaults to [nowMillis] in production. Used by [onConnect],
-     * [handleFromRadio], [checkLiveness], and [keepAlive] so all four share one coherent time source — mixing real
-     * wall-clock with injected test time produces negative silence durations and false test results.
-     */
-    private val clockMillis: () -> Long = { nowMillis },
 ) : RadioInterfaceService {
 
     override val supportedDeviceTypes: List<DeviceType>
@@ -142,6 +136,15 @@ class SharedRadioInterfaceService(
     private var lastHeartbeatMillis = 0L
 
     @Volatile private var lastDataReceivedMillis = 0L
+
+    /**
+     * Internal test seam for deterministic clock injection. Production uses [nowMillis]; tests override this to a
+     * controllable clock so [onConnect], [handleFromRadio], [checkLiveness], and [keepAlive] all share one coherent
+     * time source. Not a constructor parameter to avoid breaking Koin @Single annotation generation (which would try to
+     * resolve `() -> Long` from the DI graph).
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    internal var clockMillis: () -> Long = { nowMillis }
 
     /** The current time from the injected clock. */
     private fun now(): Long = clockMillis()

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -115,22 +115,22 @@ class SharedRadioInterfaceServiceLivenessTest {
      * Test-only [RadioTransport] whose [close] suspends on a [CompletableDeferred] gate.
      *
      * The liveness restart path calls `stopTransportLocked` → `currentTransport.close()` inside a launched coroutine.
-     * With the default [FakeRadioTransport], `close()` returns without suspending, so under
-     * [UnconfinedTestDispatcher] the entire restart completes synchronously during `checkLiveness()` and a second
-     * `checkLiveness()` never observes an in-flight restart. By awaiting a gate inside `close()`, this fake holds the
-     * restart genuinely suspended mid-flight, letting a test deterministically exercise the in-flight overlap window
-     * and prove the second check does not stack another restart/close.
+     * With the default [FakeRadioTransport], `close()` returns without suspending, so under [UnconfinedTestDispatcher]
+     * the entire restart completes synchronously during `checkLiveness()` and a second `checkLiveness()` never observes
+     * an in-flight restart. By awaiting a gate inside `close()`, this fake holds the restart genuinely suspended
+     * mid-flight, letting a test deterministically exercise the in-flight overlap window and prove the second check
+     * does not stack another restart/close.
      *
      * The gate is shared across instances; once completed by the test, any pending or subsequent `close()` resumes
      * immediately.
      */
-    private class GatedFakeRadioTransport(
-        private val closeGate: CompletableDeferred<Unit>,
-    ) : RadioTransport {
+    private class GatedFakeRadioTransport(private val closeGate: CompletableDeferred<Unit>) : RadioTransport {
         var closeCalled = false
             private set
+
         var closeCount = 0
             private set
+
         var closeCompletedCount = 0
             private set
 
@@ -173,10 +173,7 @@ class SharedRadioInterfaceServiceLivenessTest {
         every { transportFactory.isMockTransport() } returns false
         every { transportFactory.isAddressValid(any()) } returns true
         every { transportFactory.toInterfaceAddress(any(), any()) } returns address
-        every { transportFactory.createTransport(any(), any()) } calls
-            {
-                transportProvider()
-            }
+        every { transportFactory.createTransport(any(), any()) } calls { transportProvider() }
 
         radioPrefs.setDevAddr(address)
 

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -84,13 +84,10 @@ class SharedRadioInterfaceServiceLivenessTest {
         // add testDispatcher.scheduler.runCurrent() here before runBlocking to avoid a mutex deadlock.
         activeCloseGate?.complete(Unit)
         activeCloseGate = null
-        // CRITICAL: Stop every service's heartbeat loop and transport. Destroying the process
-        // lifecycle below does NOT cancel SharedRadioInterfaceService._serviceScope, so leaked
-        // heartbeat loops would otherwise keep the forked test JVM alive between tests.
-        // NOTE: Cannot use runBlocking { services.forEach { it.disconnect() } } here — it
-        // deadlocks on Robolectric's main thread (androidHostTest target). Each test body
-        // already calls service.disconnect() + advanceTimeBy before exiting; this safety net
-        // is only for the failure path where a test throws before reaching disconnect().
+        // Service cleanup is handled per-test in try/finally blocks — each test calls
+        // service.disconnect() + advanceTimeBy in a finally clause. tearDown cannot use
+        // runBlocking { services.forEach { it.disconnect() } } because it deadlocks on
+        // Robolectric's main thread (androidHostTest target).
         services.clear()
         createdTransports.clear()
         // CRITICAL: Destroy the lifecycle to cancel processLifecycle.coroutineScope and all
@@ -233,23 +230,24 @@ class SharedRadioInterfaceServiceLivenessTest {
     fun `BLE liveness timeout closes old transport and creates fresh one`() = runTest(testDispatcher) {
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
-        assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
 
-        clock = 65_000L
-        service.checkLiveness()
-        // Under UnconfinedTestDispatcher the liveness restart (sendPoliteDisconnect = false) runs
-        // inline during checkLiveness(). runCurrent/advanceTimeBy are belt-and-suspenders; the
-        // real 500ms polite-disconnect delay is covered by the trailing service.disconnect() below.
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
+            clock = 65_000L
+            service.checkLiveness()
+            // Under UnconfinedTestDispatcher the liveness restart (sendPoliteDisconnect = false) runs
+            // inline during checkLiveness(). runCurrent/advanceTimeBy are belt-and-suspenders; the
+            // real 500ms polite-disconnect delay is covered by the trailing service.disconnect() below.
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
 
-        assertEquals(2, createdTransports.size, "Liveness restart should create exactly one fresh transport")
-        assertTrue(createdTransports.first().closeCalled, "Old transport must be closed")
-        assertEquals(1, createdTransports.first().closeCount, "Old transport closed exactly once")
-
-        // Stop the heartbeat loop before exiting so tearDown never sees an active service.
-        service.disconnect()
-        advanceTimeBy(1_000L)
+            assertEquals(2, createdTransports.size, "Liveness restart should create exactly one fresh transport")
+            assertTrue(createdTransports.first().closeCalled, "Old transport must be closed")
+            assertEquals(1, createdTransports.first().closeCount, "Old transport closed exactly once")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
     }
 
     @Test
@@ -257,49 +255,53 @@ class SharedRadioInterfaceServiceLivenessTest {
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        // Capture all state transitions during the liveness recovery
-        val stateEmissions = mutableListOf<ConnectionState>()
-        val collectJob = backgroundScope.launch { service.connectionState.collect { stateEmissions.add(it) } }
+        try {
+            // Capture all state transitions during the liveness recovery
+            val stateEmissions = mutableListOf<ConnectionState>()
+            val collectJob = backgroundScope.launch { service.connectionState.collect { stateEmissions.add(it) } }
 
-        clock = 65_000L
-        service.checkLiveness()
-        // The restart completes inline under UnconfinedTestDispatcher; runCurrent/advanceTimeBy
-        // are belt-and-suspenders. The trailing disconnect() covers its own 500ms polite delay.
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
+            clock = 65_000L
+            service.checkLiveness()
+            // The restart completes inline under UnconfinedTestDispatcher; runCurrent/advanceTimeBy
+            // are belt-and-suspenders. The trailing disconnect() covers its own 500ms polite delay.
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
 
-        collectJob.cancel()
+            collectJob.cancel()
 
-        // Recovery must NEVER emit permanent Disconnected
-        assertFalse(
-            ConnectionState.Disconnected in stateEmissions,
-            "Automatic recovery must not emit permanent Disconnected state " + "(emitted: $stateEmissions)",
-        )
-
-        service.disconnect()
-        advanceTimeBy(1_000L)
+            // Recovery must NEVER emit permanent Disconnected
+            assertFalse(
+                ConnectionState.Disconnected in stateEmissions,
+                "Automatic recovery must not emit permanent Disconnected state " + "(emitted: $stateEmissions)",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
     }
 
     @Test
     fun `BLE liveness restart does not send polite disconnect into zombie transport`() = runTest(testDispatcher) {
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
-        val oldTransport = createdTransports.first()
+        try {
+            val oldTransport = createdTransports.first()
 
-        oldTransport.sentData.clear()
+            oldTransport.sentData.clear()
 
-        clock = 65_000L
-        service.checkLiveness()
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
+            clock = 65_000L
+            service.checkLiveness()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
 
-        assertTrue(
-            oldTransport.sentData.isEmpty(),
-            "Polite disconnect frame must NOT be sent into zombie transport during liveness restart",
-        )
-
-        service.disconnect()
-        advanceTimeBy(1_000L)
+            assertTrue(
+                oldTransport.sentData.isEmpty(),
+                "Polite disconnect frame must NOT be sent into zombie transport during liveness restart",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
     }
 
     @Test
@@ -307,21 +309,23 @@ class SharedRadioInterfaceServiceLivenessTest {
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        clock = 65_000L
-        service.checkLiveness()
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
+        try {
+            clock = 65_000L
+            service.checkLiveness()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
 
-        clock = 66_000L
-        service.checkLiveness()
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
+            clock = 66_000L
+            service.checkLiveness()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
 
-        val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
-        assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
-
-        service.disconnect()
-        advanceTimeBy(1_000L)
+            val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
+            assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
     }
 
     @Test
@@ -345,71 +349,72 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF", transportProvider)
-        assertEquals(1, gatedTransports.size, "Initial connect should create one transport")
-        val initialTransport = gatedTransports.first()
-
-        // Past the 60s threshold → first checkLiveness triggers a restart whose close() suspends
-        // on closeGate. Under UnconfinedTestDispatcher the launched restart runs eagerly up to the
-        // suspension point, so by the time checkLiveness() returns the restart is in-flight.
-        clock = 65_000L
-        service.checkLiveness()
-
-        // Issue a second checkLiveness() while the first restart is still suspended in close().
-        // Do NOT advance time here — the overlap must happen with the first restart in-flight.
-        clock = 65_001L
-        service.checkLiveness()
-
-        // Assertions below run while the restart is held suspended on closeGate. They MUST be
-        // wrapped in try/finally so closeGate is completed even if one of them fails; otherwise
-        // tearDown's runBlocking { disconnect() } would hang forever on the gated close().
         try {
-            // While the first restart is suspended: exactly one transport created so far, and close()
-            // was entered exactly once and has NOT completed. The second check started no new cycle.
+            assertEquals(1, gatedTransports.size, "Initial connect should create one transport")
+            val initialTransport = gatedTransports.first()
+
+            // Past the 60s threshold → first checkLiveness triggers a restart whose close() suspends
+            // on closeGate. Under UnconfinedTestDispatcher the launched restart runs eagerly up to the
+            // suspension point, so by the time checkLiveness() returns the restart is in-flight.
+            clock = 65_000L
+            service.checkLiveness()
+
+            // Issue a second checkLiveness() while the first restart is still suspended in close().
+            // Do NOT advance time here — the overlap must happen with the first restart in-flight.
+            clock = 65_001L
+            service.checkLiveness()
+
+            // Assertions below run while the restart is held suspended on closeGate. They MUST be
+            // wrapped in try/finally so closeGate is completed even if one of them fails; otherwise
+            // tearDown's runBlocking { disconnect() } would hang forever on the gated close().
+            try {
+                // While the first restart is suspended: exactly one transport created so far, and close()
+                // was entered exactly once and has NOT completed. The second check started no new cycle.
+                assertEquals(
+                    1,
+                    gatedTransports.size,
+                    "Second check must not create a transport while the first restart is in-flight",
+                )
+                assertTrue(initialTransport.closeCalled, "First transport close must have been entered by the restart")
+                assertEquals(
+                    1,
+                    initialTransport.closeCount,
+                    "close() entered exactly once (no stacking of close calls)",
+                )
+                assertEquals(
+                    0,
+                    initialTransport.closeCompletedCount,
+                    "close() must still be suspended (restart held in-flight) before releasing the gate",
+                )
+            } finally {
+                // Release the gate unconditionally so the suspended restart can complete. tearDown
+                // also releases activeCloseGate, but completing it here is required for the post-finally
+                // assertions below to observe the resumed restart.
+                closeGate.complete(Unit)
+            }
+
+            // Release the gate: the suspended restart resumes, completes stopTransportLocked (whose
+            // polite-disconnect delay is 500ms — covered by the 1s below), and startTransportLocked
+            // creates the single fresh transport. isRestarting is reset in the finally block.
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            // Exactly 2 transports: 1 initial + 1 restart. A stacking bug would produce 3+.
             assertEquals(
-                1,
+                2,
                 gatedTransports.size,
-                "Second check must not create a transport while the first restart is in-flight",
+                "Exactly one fresh transport created after the restart resumes (1 initial + 1 restart)",
             )
-            assertTrue(initialTransport.closeCalled, "First transport close must have been entered by the restart")
             assertEquals(
                 1,
                 initialTransport.closeCount,
-                "close() entered exactly once (no stacking of close calls)",
+                "First transport still closed exactly once after restart completes",
             )
-            assertEquals(
-                0,
-                initialTransport.closeCompletedCount,
-                "close() must still be suspended (restart held in-flight) before releasing the gate",
-            )
+            assertEquals(1, initialTransport.closeCompletedCount, "First transport close completed exactly once")
         } finally {
-            // Release the gate unconditionally so the suspended restart can complete. tearDown
-            // also releases activeCloseGate, but completing it here is required for the post-finally
-            // assertions below to observe the resumed restart.
-            closeGate.complete(Unit)
+            service.disconnect()
+            advanceTimeBy(1_000L)
         }
-
-        // Release the gate: the suspended restart resumes, completes stopTransportLocked (whose
-        // polite-disconnect delay is 500ms — covered by the 1s below), and startTransportLocked
-        // creates the single fresh transport. isRestarting is reset in the finally block.
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
-
-        // Exactly 2 transports: 1 initial + 1 restart. A stacking bug would produce 3+.
-        assertEquals(
-            2,
-            gatedTransports.size,
-            "Exactly one fresh transport created after the restart resumes (1 initial + 1 restart)",
-        )
-        assertEquals(
-            1,
-            initialTransport.closeCount,
-            "First transport still closed exactly once after restart completes",
-        )
-        assertEquals(1, initialTransport.closeCompletedCount, "First transport close completed exactly once")
-
-        // Stop the heartbeat loop before exiting so tearDown never sees an active service.
-        service.disconnect()
-        advanceTimeBy(1_000L)
     }
 
     // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────
@@ -418,19 +423,21 @@ class SharedRadioInterfaceServiceLivenessTest {
     fun `non-BLE transport liveness timeout does not close transport or change state`() = runTest(testDispatcher) {
         clock = 0L
         val service = createConnectedService("t192.168.1.100")
-        val stateBefore = service.connectionState.value
+        try {
+            val stateBefore = service.connectionState.value
 
-        clock = 65_000L
-        service.checkLiveness()
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
+            clock = 65_000L
+            service.checkLiveness()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
 
-        assertEquals(stateBefore, service.connectionState.value, "Non-BLE state must not change")
-        assertFalse(createdTransports.first().closeCalled, "Non-BLE transport must NOT be closed")
-        assertEquals(1, createdTransports.size, "No restart should occur for non-BLE transport")
-
-        service.disconnect()
-        advanceTimeBy(1_000L)
+            assertEquals(stateBefore, service.connectionState.value, "Non-BLE state must not change")
+            assertFalse(createdTransports.first().closeCalled, "Non-BLE transport must NOT be closed")
+            assertEquals(1, createdTransports.size, "No restart should occur for non-BLE transport")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
     }
 
     // ─── handleFromRadio resets the liveness timer ──────────────────────────────────────────────
@@ -440,30 +447,32 @@ class SharedRadioInterfaceServiceLivenessTest {
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        // Advance 30s, then receive data (resets lastDataReceivedMillis to clock=30s)
-        clock = 30_000L
-        service.handleFromRadio(byteArrayOf(1, 2, 3))
+        try {
+            // Advance 30s, then receive data (resets lastDataReceivedMillis to clock=30s)
+            clock = 30_000L
+            service.handleFromRadio(byteArrayOf(1, 2, 3))
 
-        // 30s since last data → within 60s threshold → should NOT fire
-        clock = 60_000L
-        service.checkLiveness()
-        assertFalse(
-            createdTransports.first().closeCalled,
-            "Liveness must not fire when silence is within threshold after inbound data",
-        )
+            // 30s since last data → within 60s threshold → should NOT fire
+            clock = 60_000L
+            service.checkLiveness()
+            assertFalse(
+                createdTransports.first().closeCalled,
+                "Liveness must not fire when silence is within threshold after inbound data",
+            )
 
-        // 66s since last data (at t=30s) → past 60s threshold → should fire
-        clock = 96_000L
-        service.checkLiveness()
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
-        assertTrue(
-            createdTransports.first().closeCalled,
-            "Liveness should fire after silence exceeds threshold since last inbound data",
-        )
-
-        service.disconnect()
-        advanceTimeBy(1_000L)
+            // 66s since last data (at t=30s) → past 60s threshold → should fire
+            clock = 96_000L
+            service.checkLiveness()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+            assertTrue(
+                createdTransports.first().closeCalled,
+                "Liveness should fire after silence exceeds threshold since last inbound data",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
     }
 
     @Test
@@ -471,16 +480,18 @@ class SharedRadioInterfaceServiceLivenessTest {
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        service.onDisconnect(isPermanent = true)
-        assertFalse(service.connectionState.value == ConnectionState.Connected)
+        try {
+            service.onDisconnect(isPermanent = true)
+            assertFalse(service.connectionState.value == ConnectionState.Connected)
 
-        clock = 65_000L
-        service.checkLiveness()
-        testDispatcher.scheduler.runCurrent()
-        advanceTimeBy(1_000L)
-        assertFalse(createdTransports.first().closeCalled, "Liveness must not fire when not Connected")
-
-        service.disconnect()
-        advanceTimeBy(1_000L)
+            clock = 65_000L
+            service.checkLiveness()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+            assertFalse(createdTransports.first().closeCalled, "Liveness must not fire when not Connected")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
     }
 }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -216,51 +216,36 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE in-flight liveness restart prevents overlapping restart via isRestarting`() = runTest(testDispatcher) {
-        // This test uses a factory whose transport close() suspends behind a gate, so
-        // isRestarting stays true while the first restart is in-flight. A second
-        // checkLiveness() during that window must NOT trigger another restart.
-        val closeGate = kotlinx.coroutines.CompletableDeferred<Unit>()
-        val closeStarted = kotlinx.coroutines.CompletableDeferred<Unit>()
-
-        every { transportFactory.createTransport(any(), any()) } calls
-            {
-                object : org.meshtastic.core.repository.RadioTransport {
-                    val sentData = mutableListOf<ByteArray>()
-                    var closeCount = 0
-
-                    override fun handleSendToRadio(p: ByteArray) {
-                        sentData.add(p)
-                    }
-
-                    override fun keepAlive() {}
-
-                    override suspend fun close() {
-                        closeCount++
-                        closeStarted.complete(Unit)
-                        closeGate.await() // Suspend until the test releases the gate
-                    }
-                }
-                    .also { createdTransports.add(FakeRadioTransport().also { it.closeCount }) }
-            }
-
+        // This test verifies isRestarting prevents overlapping restarts. The simple stacking test
+        // above (which calls checkLiveness twice with advanceUntilIdle) doesn't prove the guard
+        // during an in-flight restart — it just proves no double-close after a completed restart.
+        //
+        // We can't easily make FakeRadioTransport.close() suspend with the existing test infra
+        // (the factory is mocked, not subclassed). Instead, we verify the isRestarting CAS
+        // behavior by calling checkLiveness() twice WITHOUT advanceUntilIdle between calls.
+        // On UnconfinedTestDispatcher, processLifecycle.coroutineScope.launch executes eagerly,
+        // so the restart coroutine starts immediately. The first checkLiveness wins the CAS
+        // and launches the restart. The second checkLiveness (same dispatcher tick) should find
+        // isRestarting still true (or the restart already completed).
+        //
+        // Key assertion: exactly 2 transports created (1 initial + 1 restart), proving no stacking.
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        // First liveness timeout — starts restart, which suspends in close()
         clock = 65_000L
         service.checkLiveness()
-        advanceUntilIdle()
-
-        // The restart coroutine is suspended in close(). Call checkLiveness() again —
-        // isRestarting should prevent a second restart.
-        clock = 66_000L
+        // Do NOT advance — call again immediately while the first restart may be in-flight
+        clock = 65_001L
         service.checkLiveness()
         advanceUntilIdle()
 
-        // Only one restart was initiated (only one transport was created beyond the initial one)
-        // Release the gate so the restart can complete
-        closeGate.complete(Unit)
-        advanceUntilIdle()
+        // Exactly 2 transports: 1 initial + 1 restart. A stacking bug would produce 3+.
+        assertEquals(
+            2,
+            createdTransports.size,
+            "Exactly 2 transports (1 initial + 1 restart). Stacking would produce 3+.",
+        )
+        assertEquals(1, createdTransports.first().closeCount, "First transport closed exactly once")
     }
 
     // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -80,6 +80,9 @@ class SharedRadioInterfaceServiceLivenessTest {
     fun tearDown() {
         // Release any suspended close gate so a held in-flight restart can complete; otherwise
         // disconnect() below would block forever on the gated transport's close().
+        // NOTE: relies on UnconfinedTestDispatcher resuming the gated close() inline when
+        // complete(Unit) is called — if testDispatcher is ever changed to StandardTestDispatcher,
+        // add testDispatcher.scheduler.runCurrent() here before runBlocking to avoid a mutex deadlock.
         activeCloseGate?.complete(Unit)
         activeCloseGate = null
         // CRITICAL: Stop every service's heartbeat loop and transport. Destroying the process
@@ -232,9 +235,9 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        // runCurrent lets the launched restart run up to its first suspension; advanceTimeBy(1s)
-        // covers the polite-disconnect delay (500ms) inside stopTransportLocked so the restart
-        // completes without draining the (still-active) heartbeat loop.
+        // Under UnconfinedTestDispatcher the liveness restart (sendPoliteDisconnect = false) runs
+        // inline during checkLiveness(). runCurrent/advanceTimeBy are belt-and-suspenders; the
+        // real 500ms polite-disconnect delay is covered by the trailing service.disconnect() below.
         testDispatcher.scheduler.runCurrent()
         advanceTimeBy(1_000L)
 
@@ -258,8 +261,8 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        // Let the liveness restart run to completion (500ms polite-disconnect + restart), then
-        // explicitly stop the heartbeat loop before re-entering tearDown.
+        // The restart completes inline under UnconfinedTestDispatcher; runCurrent/advanceTimeBy
+        // are belt-and-suspenders. The trailing disconnect() covers its own 500ms polite delay.
         testDispatcher.scheduler.runCurrent()
         advanceTimeBy(1_000L)
 

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -25,12 +25,15 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
@@ -40,6 +43,8 @@ import org.meshtastic.core.repository.RadioTransportFactory
 import org.meshtastic.core.testing.FakeBluetoothRepository
 import org.meshtastic.core.testing.FakeRadioPrefs
 import org.meshtastic.core.testing.FakeRadioTransport
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -59,6 +64,18 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val dispatchers = CoroutineDispatchers(io = testDispatcher, main = testDispatcher, default = testDispatcher)
+
+    @BeforeTest
+    fun setUp() {
+        // processLifecycle.coroutineScope uses Dispatchers.Main.immediate internally;
+        // JVM tests must install a Main dispatcher or get IllegalStateException.
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     private val bluetoothRepository = FakeBluetoothRepository()
     private val radioPrefs = FakeRadioPrefs()

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -25,6 +25,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -40,6 +41,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.network.repository.NetworkRepository
 import org.meshtastic.core.repository.PlatformAnalytics
+import org.meshtastic.core.repository.RadioTransport
 import org.meshtastic.core.repository.RadioTransportFactory
 import org.meshtastic.core.testing.FakeBluetoothRepository
 import org.meshtastic.core.testing.FakeRadioPrefs
@@ -109,6 +111,42 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     private val processLifecycleOwner = TestLifecycleOwner()
 
+    /**
+     * Test-only [RadioTransport] whose [close] suspends on a [CompletableDeferred] gate.
+     *
+     * The liveness restart path calls `stopTransportLocked` → `currentTransport.close()` inside a launched coroutine.
+     * With the default [FakeRadioTransport], `close()` returns without suspending, so under
+     * [UnconfinedTestDispatcher] the entire restart completes synchronously during `checkLiveness()` and a second
+     * `checkLiveness()` never observes an in-flight restart. By awaiting a gate inside `close()`, this fake holds the
+     * restart genuinely suspended mid-flight, letting a test deterministically exercise the in-flight overlap window
+     * and prove the second check does not stack another restart/close.
+     *
+     * The gate is shared across instances; once completed by the test, any pending or subsequent `close()` resumes
+     * immediately.
+     */
+    private class GatedFakeRadioTransport(
+        private val closeGate: CompletableDeferred<Unit>,
+    ) : RadioTransport {
+        var closeCalled = false
+            private set
+        var closeCount = 0
+            private set
+        var closeCompletedCount = 0
+            private set
+
+        // Liveness restart skips the polite-disconnect frame (sendPoliteDisconnect = false), so no
+        // outbound data is expected; satisfy the contract with a no-op.
+        override fun handleSendToRadio(p: ByteArray) = Unit
+
+        override suspend fun close() {
+            closeCalled = true
+            closeCount++
+            // Suspend here until the test releases the gate, holding the restart in-flight.
+            closeGate.await()
+            closeCompletedCount++
+        }
+    }
+
     /** Controllable clock — tests advance this manually so all time comparisons are deterministic. */
     private var clock: Long = 0L
 
@@ -120,8 +158,14 @@ class SharedRadioInterfaceServiceLivenessTest {
      * Creates a [SharedRadioInterfaceService] with a controllable clock and a factory that returns a fresh
      * [FakeRadioTransport] per createTransport() call. After construction, calls [connect] then explicitly [onConnect]
      * to bring the service to Connected state (FakeRadioTransport does not call onConnect itself).
+     *
+     * Pass [transportProvider] to swap in a custom test double (e.g. a suspending-close fake) instead of the default
+     * [FakeRadioTransport]; the default records each created transport in [createdTransports].
      */
-    private fun createConnectedService(address: String): SharedRadioInterfaceService {
+    private fun createConnectedService(
+        address: String,
+        transportProvider: () -> RadioTransport = { FakeRadioTransport().also { createdTransports.add(it) } },
+    ): SharedRadioInterfaceService {
         every { networkRepository.networkAvailable } returns MutableStateFlow(true)
         every { networkRepository.resolvedList } returns MutableSharedFlow()
         every { analytics.isPlatformServicesAvailable } returns false
@@ -131,7 +175,7 @@ class SharedRadioInterfaceServiceLivenessTest {
         every { transportFactory.toInterfaceAddress(any(), any()) } returns address
         every { transportFactory.createTransport(any(), any()) } calls
             {
-                FakeRadioTransport().also { createdTransports.add(it) }
+                transportProvider()
             }
 
         radioPrefs.setDevAddr(address)
@@ -228,31 +272,69 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE in-flight liveness restart prevents overlapping restart via isRestarting`() = runTest(testDispatcher) {
-        // This test verifies the end-state (no stacking) rather than strictly isolating the
-        // isRestarting CAS guard. With UnconfinedTestDispatcher, the restart coroutine runs
-        // eagerly — the second checkLiveness() returns early because connectionState is
-        // DeviceSleep (not Connected), not because isRestarting blocks it.
+        // Deterministic in-flight overlap: a GatedFakeRadioTransport holds the first restart
+        // genuinely suspended inside stopTransportLocked → close() (awaiting closeGate). This
+        // removes reliance on UnconfinedTestDispatcher scheduling so the overlap window is real.
         //
-        // Key assertion: exactly 2 transports created (1 initial + 1 restart), proving no stacking.
-        // To truly test the CAS in isolation, use a suspending restart via CompletableDeferred
-        // or a custom dispatcher that delays mid-restart.
-        clock = 0L
-        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        // The first checkLiveness() flips state to DeviceSleep and CAS-sets isRestarting before
+        // launching the restart coroutine, which then suspends in close(). The second
+        // checkLiveness() is issued while that restart is still suspended and must NOT begin
+        // another close/create cycle.
+        val gatedTransports = mutableListOf<GatedFakeRadioTransport>()
+        val closeGate = CompletableDeferred<Unit>()
+        val transportProvider: () -> RadioTransport = {
+            GatedFakeRadioTransport(closeGate).also { gatedTransports.add(it) }
+        }
 
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF", transportProvider)
+        assertEquals(1, gatedTransports.size, "Initial connect should create one transport")
+        val initialTransport = gatedTransports.first()
+
+        // Past the 60s threshold → first checkLiveness triggers a restart whose close() suspends
+        // on closeGate. Under UnconfinedTestDispatcher the launched restart runs eagerly up to the
+        // suspension point, so by the time checkLiveness() returns the restart is in-flight.
         clock = 65_000L
         service.checkLiveness()
-        // Do NOT advance — call again immediately while the first restart may be in-flight
+
+        // Issue a second checkLiveness() while the first restart is still suspended in close().
+        // Do NOT advanceUntilIdle here — the overlap must happen with the first restart in-flight.
         clock = 65_001L
         service.checkLiveness()
+
+        // While the first restart is suspended: exactly one transport created so far, and close()
+        // was entered exactly once and has NOT completed. The second check started no new cycle.
+        assertEquals(
+            1,
+            gatedTransports.size,
+            "Second check must not create a transport while the first restart is in-flight",
+        )
+        assertTrue(initialTransport.closeCalled, "First transport close must have been entered by the restart")
+        assertEquals(1, initialTransport.closeCount, "close() entered exactly once (no stacking of close calls)")
+        assertEquals(
+            0,
+            initialTransport.closeCompletedCount,
+            "close() must still be suspended (restart held in-flight) before releasing the gate",
+        )
+
+        // Release the gate: the suspended restart resumes, completes stopTransportLocked, and
+        // startTransportLocked creates the single fresh transport. isRestarting is reset in the
+        // finally block.
+        closeGate.complete(Unit)
         advanceUntilIdle()
 
         // Exactly 2 transports: 1 initial + 1 restart. A stacking bug would produce 3+.
         assertEquals(
             2,
-            createdTransports.size,
-            "Exactly 2 transports (1 initial + 1 restart). Stacking would produce 3+.",
+            gatedTransports.size,
+            "Exactly one fresh transport created after the restart resumes (1 initial + 1 restart)",
         )
-        assertEquals(1, createdTransports.first().closeCount, "First transport closed exactly once")
+        assertEquals(
+            1,
+            initialTransport.closeCount,
+            "First transport still closed exactly once after restart completes",
+        )
+        assertEquals(1, initialTransport.closeCompletedCount, "First transport close completed exactly once")
     }
 
     // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -120,7 +120,7 @@ class SharedRadioInterfaceServiceLivenessTest {
      * registered [LifecycleEventObserver]s so `lifecycleScope` cancels correctly.
      */
     private class TestLifecycleOwner : LifecycleOwner {
-        private val observers = java.util.concurrent.CopyOnWriteArrayList<LifecycleObserver>()
+        private val observers = mutableListOf<LifecycleObserver>()
         private var state = Lifecycle.State.RESUMED
 
         override val lifecycle: Lifecycle =

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
@@ -37,18 +38,20 @@ import org.meshtastic.core.repository.RadioTransportFactory
 import org.meshtastic.core.testing.FakeBluetoothRepository
 import org.meshtastic.core.testing.FakeRadioPrefs
 import org.meshtastic.core.testing.FakeRadioTransport
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Service-level tests for [SharedRadioInterfaceService.checkLiveness].
+ * Service-level tests for [SharedRadioInterfaceService] liveness detection.
  *
- * Verifies the BLE zombie-session recovery path: when a BLE transport is Connected but no inbound data arrives within
- * the liveness timeout, the service restarts the transport exactly once without emitting a permanent disconnect and
- * without sending a polite-disconnect frame into the dead link. Non-BLE transports are not affected by this
- * BLE-specific recovery.
+ * Uses a controllable clock injected via the constructor so [onConnect], [handleFromRadio], and [checkLiveness] all
+ * share one coherent time source — no mixing of real wall-clock with virtual test time.
+ *
+ * A counting transport factory returns a fresh [FakeRadioTransport] per createTransport() call so we can observe how
+ * many restarts actually occurred.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SharedRadioInterfaceServiceLivenessTest {
@@ -58,11 +61,9 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     private val bluetoothRepository = FakeBluetoothRepository()
     private val radioPrefs = FakeRadioPrefs()
-    private val fakeTransport = FakeRadioTransport()
 
     private val networkRepository: NetworkRepository = mock(MockMode.autofill)
     private val analytics: PlatformAnalytics = mock(MockMode.autofill)
-    private val transportFactory: RadioTransportFactory = mock(MockMode.autofill)
 
     private class TestLifecycleOwner : LifecycleOwner {
         val registry = LifecycleRegistry(this)
@@ -77,18 +78,30 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     private val processLifecycleOwner = TestLifecycleOwner()
 
-    /** A liveness-time constant: T0 = some baseline, T0+60s = liveness timeout. */
-    private val t0 = 1_000_000L
+    /** Controllable clock — tests advance this manually so all time comparisons are deterministic. */
+    private val clock = AtomicLong(0L)
 
-    private fun createService(address: String): SharedRadioInterfaceService {
+    /** Tracks all transports created by the factory so we can count restarts and inspect sent data. */
+    private val createdTransports = mutableListOf<FakeRadioTransport>()
+    private val transportFactory: RadioTransportFactory = mock(MockMode.autofill)
+
+    /**
+     * Creates a [SharedRadioInterfaceService] with a controllable clock and a factory that returns a fresh
+     * [FakeRadioTransport] per createTransport() call. After construction, calls [connect] then explicitly [onConnect]
+     * to bring the service to Connected state (FakeRadioTransport does not call onConnect itself).
+     */
+    private fun createConnectedService(address: String): SharedRadioInterfaceService {
         every { networkRepository.networkAvailable } returns MutableStateFlow(true)
         every { networkRepository.resolvedList } returns MutableSharedFlow()
         every { analytics.isPlatformServicesAvailable } returns false
         every { transportFactory.supportedDeviceTypes } returns listOf(DeviceType.BLE)
         every { transportFactory.isMockTransport() } returns false
         every { transportFactory.isAddressValid(any()) } returns true
-        every { transportFactory.createTransport(any(), any()) } returns fakeTransport
         every { transportFactory.toInterfaceAddress(any(), any()) } returns address
+        every { transportFactory.createTransport(any(), any()) } answers
+            {
+                FakeRadioTransport().also { createdTransports.add(it) }
+            }
 
         radioPrefs.setDevAddr(address)
 
@@ -101,55 +114,38 @@ class SharedRadioInterfaceServiceLivenessTest {
                 radioPrefs = radioPrefs,
                 transportFactory = transportFactory,
                 analytics = analytics,
+                clockMillis = { clock.get() },
             )
         service.connect()
+        service.onConnect()
         return service
-    }
-
-    /**
-     * Helper: bring the service to Connected state with lastDataReceivedMillis set to [t0], then call checkLiveness at
-     * [t0 + elapsedMs].
-     */
-    private fun SharedRadioInterfaceService.simulateLivenessCheck(elapsedMs: Long) {
-        // Force Connected state and simulate that we last received data at t0.
-        onConnect()
-        // onConnect sets lastDataReceivedMillis = nowMillis (real clock), so we override by
-        // simulating an inbound packet which sets it to the same real-clock value — both paths
-        // end up at nowMillis. For the liveness check to see "elapsed since t0", we pass a
-        // future clock value directly.
-        checkLiveness(now = t0 + elapsedMs)
     }
 
     // ─── BLE: Liveness timeout triggers recovery ───────────────────────────────────────────────
 
     @Test
-    fun `BLE liveness timeout triggers transport restart`() = runTest(testDispatcher) {
-        val service = createService("xAA:BB:CC:DD:EE:FF")
+    fun `BLE liveness timeout closes old transport and creates fresh one`() = runTest(testDispatcher) {
+        clock.set(0L)
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        assertEquals(1, createdTransports.size, "Initial connect should create one transport")
 
-        // Advance real time so nowMillis is at t0 (enough for connect() to complete).
-        advanceTimeBy(10_000L)
+        // Advance clock past 60s liveness threshold
+        clock.set(65_000L)
+        service.checkLiveness()
 
-        // Simulate Connected + 65s of silence (> 60s threshold)
-        service.simulateLivenessCheck(elapsedMs = 65_000L)
-
-        // Transport must have been closed (old transport torn down) and recreated.
-        assertTrue(fakeTransport.closeCalled, "Old transport must be closed on liveness restart")
+        assertTrue(createdTransports.size >= 2, "Liveness restart should create a fresh transport")
+        assertTrue(createdTransports.first().closeCalled, "Old transport must be closed")
+        assertEquals(1, createdTransports.first().closeCount, "Old transport closed exactly once")
     }
 
     @Test
-    fun `BLE liveness restart does not emit permanent disconnect`() = runTest(testDispatcher) {
-        val service = createService("xAA:BB:CC:DD:EE:FF")
-        advanceTimeBy(10_000L)
+    fun `BLE liveness restart does not emit permanent Disconnected`() = runTest(testDispatcher) {
+        clock.set(0L)
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        val stateBefore = service.connectionState.value
-        assertEquals(ConnectionState.Connected, stateBefore)
+        clock.set(65_000L)
+        service.checkLiveness()
 
-        // Trigger liveness timeout
-        service.simulateLivenessCheck(elapsedMs = 65_000L)
-
-        // Recovery emits DeviceSleep (transient), NOT Disconnected (permanent).
-        // The restart path uses notifyPermanent=false, so we should never see Disconnected
-        // from the automatic recovery path.
         assertFalse(
             service.connectionState.value == ConnectionState.Disconnected,
             "Automatic recovery must not emit permanent Disconnected state",
@@ -157,105 +153,91 @@ class SharedRadioInterfaceServiceLivenessTest {
     }
 
     @Test
-    fun `BLE liveness restart skips polite disconnect frame`() = runTest(testDispatcher) {
-        val service = createService("xAA:BB:CC:DD:EE:FF")
-        advanceTimeBy(10_000L)
+    fun `BLE liveness restart does not send polite disconnect into zombie transport`() = runTest(testDispatcher) {
+        clock.set(0L)
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        val oldTransport = createdTransports.first()
 
-        // Clear any data sent during connect (e.g. heartbeat)
-        fakeTransport.sentData.clear()
+        oldTransport.sentData.clear()
 
-        // Trigger liveness timeout
-        service.simulateLivenessCheck(elapsedMs = 65_000L)
+        clock.set(65_000L)
+        service.checkLiveness()
 
-        // The liveness restart uses sendPoliteDisconnect=false, so no ToRadio(disconnect=true)
-        // should have been sent into the zombie transport. The old transport's sentData should
-        // be empty (no polite disconnect).
         assertTrue(
-            fakeTransport.sentData.isEmpty(),
+            oldTransport.sentData.isEmpty(),
             "Polite disconnect frame must NOT be sent into zombie transport during liveness restart",
         )
     }
 
     @Test
-    fun `BLE repeated liveness checks before restart completes do not stack restarts`() = runTest(testDispatcher) {
-        val service = createService("xAA:BB:CC:DD:EE:FF")
-        advanceTimeBy(10_000L)
+    fun `BLE repeated liveness checks do not stack restarts`() = runTest(testDispatcher) {
+        clock.set(0L)
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        // First liveness timeout — triggers restart
-        service.simulateLivenessCheck(elapsedMs = 65_000L)
-        val closeCountAfterFirst = if (fakeTransport.closeCalled) 1 else 0
+        clock.set(65_000L)
+        service.checkLiveness()
 
-        // Second liveness check immediately after — isRestarting should prevent duplicate
-        service.simulateLivenessCheck(elapsedMs = 66_000L)
+        clock.set(66_000L)
+        service.checkLiveness()
 
-        assertEquals(
-            closeCountAfterFirst,
-            1,
-            "Transport should only be closed once (isRestarting prevents stacking)",
-        )
+        val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
+        assertTrue(firstTransportCloses <= 1, "First transport should be closed at most once (no stacking)")
     }
 
     // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────
 
     @Test
-    fun `non-BLE transport liveness timeout does not emit disconnect or change state`() = runTest(testDispatcher) {
-        val service = createService("t192.168.1.100")
-        advanceTimeBy(10_000L)
-
+    fun `non-BLE transport liveness timeout does not close transport or change state`() = runTest(testDispatcher) {
+        clock.set(0L)
+        val service = createConnectedService("t192.168.1.100")
         val stateBefore = service.connectionState.value
-        assertEquals(ConnectionState.Connected, stateBefore)
 
-        // Trigger liveness timeout — non-BLE should be a no-op
-        service.simulateLivenessCheck(elapsedMs = 65_000L)
+        clock.set(65_000L)
+        service.checkLiveness()
 
-        assertEquals(
-            stateBefore,
-            service.connectionState.value,
-            "Non-BLE liveness timeout must NOT mutate connection state",
-        )
-        assertFalse(fakeTransport.closeCalled, "Non-BLE transport must NOT be closed by BLE liveness recovery")
+        assertEquals(stateBefore, service.connectionState.value, "Non-BLE state must not change")
+        assertFalse(createdTransports.first().closeCalled, "Non-BLE transport must NOT be closed")
+        assertEquals(1, createdTransports.size, "No restart should occur for non-BLE transport")
     }
 
     // ─── handleFromRadio resets the liveness timer ──────────────────────────────────────────────
 
     @Test
     fun `inbound data resets liveness timer so timeout does not fire`() = runTest(testDispatcher) {
-        val service = createService("xAA:BB:CC:DD:EE:FF")
-        advanceTimeBy(10_000L)
+        clock.set(0L)
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        // Simulate Connected at t0
-        service.onConnect()
-
-        // Simulate inbound data at t0+30s (resets lastDataReceivedMillis)
-        // handleFromRadio sets lastDataReceivedMillis = nowMillis (real clock), but we can't
-        // control the real clock directly. Instead, call checkLiveness with a time that is
-        // 65s past t0 but only 35s past the reset (which happened at real nowMillis).
-        // Since handleFromRadio uses the real clock and checkLiveness uses our injected clock,
-        // we verify the contract differently: if we call handleFromRadio (updating the timer)
-        // and then checkLiveness with a time just past the threshold, it should still fire
-        // because the injected clock is independent. So instead, we verify that calling
-        // handleFromRadio doesn't break anything and liveness still works at 65s.
+        // Advance 30s, then receive data (resets lastDataReceivedMillis to clock=30s)
+        clock.set(30_000L)
         service.handleFromRadio(byteArrayOf(1, 2, 3))
 
-        // 65s of silence — should still fire (injected clock is t0+65s, which is far past
-        // both t0 and the real-clock-based reset from handleFromRadio)
-        service.checkLiveness(now = t0 + 65_000L)
+        // 30s since last data → within 60s threshold → should NOT fire
+        clock.set(60_000L)
+        service.checkLiveness()
+        assertFalse(
+            createdTransports.first().closeCalled,
+            "Liveness must not fire when silence is within threshold after inbound data",
+        )
 
-        // Verify liveness fired (transport was closed)
-        assertTrue(fakeTransport.closeCalled, "Liveness should fire after timeout even with prior inbound data")
+        // 66s since last data (at t=30s) → past 60s threshold → should fire
+        clock.set(96_000L)
+        service.checkLiveness()
+        assertTrue(
+            createdTransports.first().closeCalled,
+            "Liveness should fire after silence exceeds threshold since last inbound data",
+        )
     }
 
     @Test
     fun `BLE liveness does not fire when connection state is not Connected`() = runTest(testDispatcher) {
-        val service = createService("xAA:BB:CC:DD:EE:FF")
-        advanceTimeBy(10_000L)
+        clock.set(0L)
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        // Don't call onConnect — state should be Disconnected or DeviceSleep, not Connected
+        service.onDisconnect(isPermanent = true)
         assertFalse(service.connectionState.value == ConnectionState.Connected)
 
-        // checkLiveness should return early without doing anything
-        service.checkLiveness(now = t0 + 65_000L)
-
-        assertFalse(fakeTransport.closeCalled, "Liveness must not fire when not Connected")
+        clock.set(65_000L)
+        service.checkLiveness()
+        assertFalse(createdTransports.first().closeCalled, "Liveness must not fire when not Connected")
     }
 }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -375,7 +375,10 @@ class SharedRadioInterfaceServiceLivenessTest {
                     gatedTransports.size,
                     "Second check must not create a transport while the first restart is in-flight",
                 )
-                assertTrue(initialTransport.closeCalled, "First transport close must have been entered by the restart")
+                assertTrue(
+                    initialTransport.closeCalled,
+                    "First transport close must have been entered by the restart",
+                )
                 assertEquals(
                     1,
                     initialTransport.closeCount,

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -228,19 +228,14 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE in-flight liveness restart prevents overlapping restart via isRestarting`() = runTest(testDispatcher) {
-        // This test verifies isRestarting prevents overlapping restarts. The simple stacking test
-        // above (which calls checkLiveness twice with advanceUntilIdle) doesn't prove the guard
-        // during an in-flight restart — it just proves no double-close after a completed restart.
-        //
-        // We can't easily make FakeRadioTransport.close() suspend with the existing test infra
-        // (the factory is mocked, not subclassed). Instead, we verify the isRestarting CAS
-        // behavior by calling checkLiveness() twice WITHOUT advanceUntilIdle between calls.
-        // On UnconfinedTestDispatcher, processLifecycle.coroutineScope.launch executes eagerly,
-        // so the restart coroutine starts immediately. The first checkLiveness wins the CAS
-        // and launches the restart. The second checkLiveness (same dispatcher tick) should find
-        // isRestarting still true (or the restart already completed).
+        // This test verifies the end-state (no stacking) rather than strictly isolating the
+        // isRestarting CAS guard. With UnconfinedTestDispatcher, the restart coroutine runs
+        // eagerly — the second checkLiveness() returns early because connectionState is
+        // DeviceSleep (not Connected), not because isRestarting blocks it.
         //
         // Key assertion: exactly 2 transports created (1 initial + 1 restart), proving no stacking.
+        // To truly test the CAS in isolation, use a suspending restart via CompletableDeferred
+        // or a custom dispatcher that delays mid-restart.
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -82,7 +82,7 @@ class SharedRadioInterfaceServiceLivenessTest {
         processLifecycleOwner.destroy()
         // Allow pending cancellation to propagate before resetting the Main dispatcher.
         // Without this, resetMain() can prevent the cancellation from reaching collectors.
-        testDispatcher.advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
     }
 

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -31,8 +31,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -77,14 +78,25 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @AfterTest
     fun tearDown() {
+        // Release any suspended close gate so a held in-flight restart can complete; otherwise
+        // disconnect() below would block forever on the gated transport's close().
+        activeCloseGate?.complete(Unit)
+        activeCloseGate = null
+        // CRITICAL: Stop every service's heartbeat loop and transport. Destroying the process
+        // lifecycle below does NOT cancel SharedRadioInterfaceService._serviceScope, so leaked
+        // heartbeat loops would otherwise keep the forked test JVM alive between tests.
+        runBlocking { services.forEach { it.disconnect() } }
+        services.clear()
+        createdTransports.clear()
         // CRITICAL: Destroy the lifecycle to cancel processLifecycle.coroutineScope and all
         // leaked collectors (devAddr, bluetoothRepository.state, networkRepository.networkAvailable).
         // Without this, those infinite flow collectors keep the forked test JVM alive after tests
         // complete, causing Gradle to hang at subsequent :core:*:allTests tasks.
         processLifecycleOwner.destroy()
-        // Allow pending cancellation to propagate before resetting the Main dispatcher.
-        // Without this, resetMain() can prevent the cancellation from reaching collectors.
-        testDispatcher.scheduler.advanceUntilIdle()
+        // Let pending cancellations propagate before resetting the Main dispatcher. Use runCurrent
+        // (NOT advanceUntilIdle): the test bodies already disconnect every service, so no heartbeat
+        // loop should be active here — advanceUntilIdle would hang if one somehow survived.
+        testDispatcher.scheduler.runCurrent()
         Dispatchers.resetMain()
     }
 
@@ -150,6 +162,20 @@ class SharedRadioInterfaceServiceLivenessTest {
     /** Controllable clock — tests advance this manually so all time comparisons are deterministic. */
     private var clock: Long = 0L
 
+    /**
+     * Tracks every [SharedRadioInterfaceService] created via [createConnectedService] so [tearDown] can disconnect them
+     * deterministically. Destroying the process lifecycle does NOT cancel the service's private `_serviceScope` (which
+     * hosts the heartbeat loop), so we must call `disconnect()` explicitly.
+     */
+    private val services = mutableListOf<SharedRadioInterfaceService>()
+
+    /**
+     * Tracks the suspended close gate for the in-flight restart test so [tearDown] can release it even if the test body
+     * throws. Without this, a failed assertion before `closeGate.complete(Unit)` would leave a restart suspended
+     * forever and hang teardown.
+     */
+    private var activeCloseGate: CompletableDeferred<Unit>? = null
+
     /** Tracks all transports created by the factory so we can count restarts and inspect sent data. */
     private val createdTransports = mutableListOf<FakeRadioTransport>()
     private val transportFactory: RadioTransportFactory = mock(MockMode.autofill)
@@ -188,6 +214,9 @@ class SharedRadioInterfaceServiceLivenessTest {
                 analytics = analytics,
             )
         service.clockMillis = { clock }
+        // Register the service so tearDown can disconnect it deterministically (the heartbeat loop
+        // launched in _serviceScope would otherwise outlive the test).
+        services.add(service)
         service.connect()
         service.onConnect()
         return service
@@ -203,11 +232,19 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        // runCurrent lets the launched restart run up to its first suspension; advanceTimeBy(1s)
+        // covers the polite-disconnect delay (500ms) inside stopTransportLocked so the restart
+        // completes without draining the (still-active) heartbeat loop.
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
 
         assertEquals(2, createdTransports.size, "Liveness restart should create exactly one fresh transport")
         assertTrue(createdTransports.first().closeCalled, "Old transport must be closed")
         assertEquals(1, createdTransports.first().closeCount, "Old transport closed exactly once")
+
+        // Stop the heartbeat loop before exiting so tearDown never sees an active service.
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 
     @Test
@@ -221,7 +258,10 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        // Let the liveness restart run to completion (500ms polite-disconnect + restart), then
+        // explicitly stop the heartbeat loop before re-entering tearDown.
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
 
         collectJob.cancel()
 
@@ -230,6 +270,9 @@ class SharedRadioInterfaceServiceLivenessTest {
             ConnectionState.Disconnected in stateEmissions,
             "Automatic recovery must not emit permanent Disconnected state " + "(emitted: $stateEmissions)",
         )
+
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 
     @Test
@@ -242,12 +285,16 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
 
         assertTrue(
             oldTransport.sentData.isEmpty(),
             "Polite disconnect frame must NOT be sent into zombie transport during liveness restart",
         )
+
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 
     @Test
@@ -257,14 +304,19 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
 
         clock = 66_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
 
         val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
         assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
+
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 
     @Test
@@ -279,6 +331,9 @@ class SharedRadioInterfaceServiceLivenessTest {
         // another close/create cycle.
         val gatedTransports = mutableListOf<GatedFakeRadioTransport>()
         val closeGate = CompletableDeferred<Unit>()
+        // Publish the gate to activeCloseGate so tearDown can release it even if an assertion below
+        // throws before we reach the try/finally — otherwise disconnect() would hang on close().
+        activeCloseGate = closeGate
         val transportProvider: () -> RadioTransport = {
             GatedFakeRadioTransport(closeGate).also { gatedTransports.add(it) }
         }
@@ -295,30 +350,44 @@ class SharedRadioInterfaceServiceLivenessTest {
         service.checkLiveness()
 
         // Issue a second checkLiveness() while the first restart is still suspended in close().
-        // Do NOT advanceUntilIdle here — the overlap must happen with the first restart in-flight.
+        // Do NOT advance time here — the overlap must happen with the first restart in-flight.
         clock = 65_001L
         service.checkLiveness()
 
-        // While the first restart is suspended: exactly one transport created so far, and close()
-        // was entered exactly once and has NOT completed. The second check started no new cycle.
-        assertEquals(
-            1,
-            gatedTransports.size,
-            "Second check must not create a transport while the first restart is in-flight",
-        )
-        assertTrue(initialTransport.closeCalled, "First transport close must have been entered by the restart")
-        assertEquals(1, initialTransport.closeCount, "close() entered exactly once (no stacking of close calls)")
-        assertEquals(
-            0,
-            initialTransport.closeCompletedCount,
-            "close() must still be suspended (restart held in-flight) before releasing the gate",
-        )
+        // Assertions below run while the restart is held suspended on closeGate. They MUST be
+        // wrapped in try/finally so closeGate is completed even if one of them fails; otherwise
+        // tearDown's runBlocking { disconnect() } would hang forever on the gated close().
+        try {
+            // While the first restart is suspended: exactly one transport created so far, and close()
+            // was entered exactly once and has NOT completed. The second check started no new cycle.
+            assertEquals(
+                1,
+                gatedTransports.size,
+                "Second check must not create a transport while the first restart is in-flight",
+            )
+            assertTrue(initialTransport.closeCalled, "First transport close must have been entered by the restart")
+            assertEquals(
+                1,
+                initialTransport.closeCount,
+                "close() entered exactly once (no stacking of close calls)",
+            )
+            assertEquals(
+                0,
+                initialTransport.closeCompletedCount,
+                "close() must still be suspended (restart held in-flight) before releasing the gate",
+            )
+        } finally {
+            // Release the gate unconditionally so the suspended restart can complete. tearDown
+            // also releases activeCloseGate, but completing it here is required for the post-finally
+            // assertions below to observe the resumed restart.
+            closeGate.complete(Unit)
+        }
 
-        // Release the gate: the suspended restart resumes, completes stopTransportLocked, and
-        // startTransportLocked creates the single fresh transport. isRestarting is reset in the
-        // finally block.
-        closeGate.complete(Unit)
-        advanceUntilIdle()
+        // Release the gate: the suspended restart resumes, completes stopTransportLocked (whose
+        // polite-disconnect delay is 500ms — covered by the 1s below), and startTransportLocked
+        // creates the single fresh transport. isRestarting is reset in the finally block.
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
 
         // Exactly 2 transports: 1 initial + 1 restart. A stacking bug would produce 3+.
         assertEquals(
@@ -332,6 +401,10 @@ class SharedRadioInterfaceServiceLivenessTest {
             "First transport still closed exactly once after restart completes",
         )
         assertEquals(1, initialTransport.closeCompletedCount, "First transport close completed exactly once")
+
+        // Stop the heartbeat loop before exiting so tearDown never sees an active service.
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 
     // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────
@@ -344,11 +417,15 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
 
         assertEquals(stateBefore, service.connectionState.value, "Non-BLE state must not change")
         assertFalse(createdTransports.first().closeCalled, "Non-BLE transport must NOT be closed")
         assertEquals(1, createdTransports.size, "No restart should occur for non-BLE transport")
+
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 
     // ─── handleFromRadio resets the liveness timer ──────────────────────────────────────────────
@@ -373,11 +450,15 @@ class SharedRadioInterfaceServiceLivenessTest {
         // 66s since last data (at t=30s) → past 60s threshold → should fire
         clock = 96_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
         assertTrue(
             createdTransports.first().closeCalled,
             "Liveness should fire after silence exceeds threshold since last inbound data",
         )
+
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 
     @Test
@@ -390,7 +471,11 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         clock = 65_000L
         service.checkLiveness()
-        advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
+        advanceTimeBy(1_000L)
         assertFalse(createdTransports.first().closeCalled, "Liveness must not fire when not Connected")
+
+        service.disconnect()
+        advanceTimeBy(1_000L)
     }
 }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -151,7 +152,7 @@ class SharedRadioInterfaceServiceLivenessTest {
         service.checkLiveness()
         advanceUntilIdle()
 
-        assertTrue(createdTransports.size >= 2, "Liveness restart should create a fresh transport")
+        assertEquals(2, createdTransports.size, "Liveness restart should create exactly one fresh transport")
         assertTrue(createdTransports.first().closeCalled, "Old transport must be closed")
         assertEquals(1, createdTransports.first().closeCount, "Old transport closed exactly once")
     }
@@ -161,13 +162,20 @@ class SharedRadioInterfaceServiceLivenessTest {
         clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
+        // Capture all state transitions during the liveness recovery
+        val stateEmissions = mutableListOf<ConnectionState>()
+        val collectJob = backgroundScope.launch { service.connectionState.collect { stateEmissions.add(it) } }
+
         clock = 65_000L
         service.checkLiveness()
         advanceUntilIdle()
 
+        collectJob.cancel()
+
+        // Recovery must NEVER emit permanent Disconnected
         assertFalse(
-            service.connectionState.value == ConnectionState.Disconnected,
-            "Automatic recovery must not emit permanent Disconnected state",
+            ConnectionState.Disconnected in stateEmissions,
+            "Automatic recovery must not emit permanent Disconnected state " + "(emitted: $stateEmissions)",
         )
     }
 
@@ -203,7 +211,7 @@ class SharedRadioInterfaceServiceLivenessTest {
         advanceUntilIdle()
 
         val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
-        assertTrue(firstTransportCloses <= 1, "First transport should be closed at most once (no stacking)")
+        assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
     }
 
     // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
@@ -88,7 +87,10 @@ class SharedRadioInterfaceServiceLivenessTest {
         // CRITICAL: Stop every service's heartbeat loop and transport. Destroying the process
         // lifecycle below does NOT cancel SharedRadioInterfaceService._serviceScope, so leaked
         // heartbeat loops would otherwise keep the forked test JVM alive between tests.
-        runBlocking { services.forEach { it.disconnect() } }
+        // NOTE: Cannot use runBlocking { services.forEach { it.disconnect() } } here — it
+        // deadlocks on Robolectric's main thread (androidHostTest target). Each test body
+        // already calls service.disconnect() + advanceTimeBy before exiting; this safety net
+        // is only for the failure path where a test throws before reaching disconnect().
         services.clear()
         createdTransports.clear()
         // CRITICAL: Destroy the lifecycle to cancel processLifecycle.coroutineScope and all

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -68,11 +68,16 @@ class SharedRadioInterfaceServiceLivenessTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private val dispatchers = CoroutineDispatchers(io = testDispatcher, main = testDispatcher, default = testDispatcher)
 
+    private lateinit var processLifecycleOwner: TestLifecycleOwner
+
     @BeforeTest
     fun setUp() {
         // processLifecycle.coroutineScope uses Dispatchers.Main.immediate internally;
         // JVM tests must install a Main dispatcher or get IllegalStateException.
         Dispatchers.setMain(testDispatcher)
+        // Create the lifecycle owner AFTER setMain so Robolectric's main thread is ready.
+        // Field initializers run before @BeforeTest, which is too early for Robolectric.
+        processLifecycleOwner = TestLifecycleOwner()
     }
 
     @AfterTest
@@ -122,8 +127,6 @@ class SharedRadioInterfaceServiceLivenessTest {
         override val lifecycle: Lifecycle
             get() = registry
     }
-
-    private val processLifecycleOwner = TestLifecycleOwner()
 
     /**
      * Test-only [RadioTransport] whose [close] suspends on a [CompletableDeferred] gate.

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.service
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import dev.mokkery.MockMode
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.DeviceType
+import org.meshtastic.core.network.repository.NetworkRepository
+import org.meshtastic.core.repository.PlatformAnalytics
+import org.meshtastic.core.repository.RadioTransportFactory
+import org.meshtastic.core.testing.FakeBluetoothRepository
+import org.meshtastic.core.testing.FakeRadioPrefs
+import org.meshtastic.core.testing.FakeRadioTransport
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Service-level tests for [SharedRadioInterfaceService.checkLiveness].
+ *
+ * Verifies the BLE zombie-session recovery path: when a BLE transport is Connected but no inbound data arrives within
+ * the liveness timeout, the service restarts the transport exactly once without emitting a permanent disconnect and
+ * without sending a polite-disconnect frame into the dead link. Non-BLE transports are not affected by this
+ * BLE-specific recovery.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SharedRadioInterfaceServiceLivenessTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(io = testDispatcher, main = testDispatcher, default = testDispatcher)
+
+    private val bluetoothRepository = FakeBluetoothRepository()
+    private val radioPrefs = FakeRadioPrefs()
+    private val fakeTransport = FakeRadioTransport()
+
+    private val networkRepository: NetworkRepository = mock(MockMode.autofill)
+    private val analytics: PlatformAnalytics = mock(MockMode.autofill)
+    private val transportFactory: RadioTransportFactory = mock(MockMode.autofill)
+
+    private class TestLifecycleOwner : LifecycleOwner {
+        val registry = LifecycleRegistry(this)
+
+        init {
+            registry.currentState = Lifecycle.State.RESUMED
+        }
+
+        override val lifecycle: Lifecycle
+            get() = registry
+    }
+
+    private val processLifecycleOwner = TestLifecycleOwner()
+
+    /** A liveness-time constant: T0 = some baseline, T0+60s = liveness timeout. */
+    private val t0 = 1_000_000L
+
+    private fun createService(address: String): SharedRadioInterfaceService {
+        every { networkRepository.networkAvailable } returns MutableStateFlow(true)
+        every { networkRepository.resolvedList } returns MutableSharedFlow()
+        every { analytics.isPlatformServicesAvailable } returns false
+        every { transportFactory.supportedDeviceTypes } returns listOf(DeviceType.BLE)
+        every { transportFactory.isMockTransport() } returns false
+        every { transportFactory.isAddressValid(any()) } returns true
+        every { transportFactory.createTransport(any(), any()) } returns fakeTransport
+        every { transportFactory.toInterfaceAddress(any(), any()) } returns address
+
+        radioPrefs.setDevAddr(address)
+
+        val service =
+            SharedRadioInterfaceService(
+                dispatchers = dispatchers,
+                bluetoothRepository = bluetoothRepository,
+                networkRepository = networkRepository,
+                processLifecycle = processLifecycleOwner.lifecycle,
+                radioPrefs = radioPrefs,
+                transportFactory = transportFactory,
+                analytics = analytics,
+            )
+        service.connect()
+        return service
+    }
+
+    /**
+     * Helper: bring the service to Connected state with lastDataReceivedMillis set to [t0], then call checkLiveness at
+     * [t0 + elapsedMs].
+     */
+    private fun SharedRadioInterfaceService.simulateLivenessCheck(elapsedMs: Long) {
+        // Force Connected state and simulate that we last received data at t0.
+        onConnect()
+        // onConnect sets lastDataReceivedMillis = nowMillis (real clock), so we override by
+        // simulating an inbound packet which sets it to the same real-clock value — both paths
+        // end up at nowMillis. For the liveness check to see "elapsed since t0", we pass a
+        // future clock value directly.
+        checkLiveness(now = t0 + elapsedMs)
+    }
+
+    // ─── BLE: Liveness timeout triggers recovery ───────────────────────────────────────────────
+
+    @Test
+    fun `BLE liveness timeout triggers transport restart`() = runTest(testDispatcher) {
+        val service = createService("xAA:BB:CC:DD:EE:FF")
+
+        // Advance real time so nowMillis is at t0 (enough for connect() to complete).
+        advanceTimeBy(10_000L)
+
+        // Simulate Connected + 65s of silence (> 60s threshold)
+        service.simulateLivenessCheck(elapsedMs = 65_000L)
+
+        // Transport must have been closed (old transport torn down) and recreated.
+        assertTrue(fakeTransport.closeCalled, "Old transport must be closed on liveness restart")
+    }
+
+    @Test
+    fun `BLE liveness restart does not emit permanent disconnect`() = runTest(testDispatcher) {
+        val service = createService("xAA:BB:CC:DD:EE:FF")
+        advanceTimeBy(10_000L)
+
+        val stateBefore = service.connectionState.value
+        assertEquals(ConnectionState.Connected, stateBefore)
+
+        // Trigger liveness timeout
+        service.simulateLivenessCheck(elapsedMs = 65_000L)
+
+        // Recovery emits DeviceSleep (transient), NOT Disconnected (permanent).
+        // The restart path uses notifyPermanent=false, so we should never see Disconnected
+        // from the automatic recovery path.
+        assertFalse(
+            service.connectionState.value == ConnectionState.Disconnected,
+            "Automatic recovery must not emit permanent Disconnected state",
+        )
+    }
+
+    @Test
+    fun `BLE liveness restart skips polite disconnect frame`() = runTest(testDispatcher) {
+        val service = createService("xAA:BB:CC:DD:EE:FF")
+        advanceTimeBy(10_000L)
+
+        // Clear any data sent during connect (e.g. heartbeat)
+        fakeTransport.sentData.clear()
+
+        // Trigger liveness timeout
+        service.simulateLivenessCheck(elapsedMs = 65_000L)
+
+        // The liveness restart uses sendPoliteDisconnect=false, so no ToRadio(disconnect=true)
+        // should have been sent into the zombie transport. The old transport's sentData should
+        // be empty (no polite disconnect).
+        assertTrue(
+            fakeTransport.sentData.isEmpty(),
+            "Polite disconnect frame must NOT be sent into zombie transport during liveness restart",
+        )
+    }
+
+    @Test
+    fun `BLE repeated liveness checks before restart completes do not stack restarts`() = runTest(testDispatcher) {
+        val service = createService("xAA:BB:CC:DD:EE:FF")
+        advanceTimeBy(10_000L)
+
+        // First liveness timeout — triggers restart
+        service.simulateLivenessCheck(elapsedMs = 65_000L)
+        val closeCountAfterFirst = if (fakeTransport.closeCalled) 1 else 0
+
+        // Second liveness check immediately after — isRestarting should prevent duplicate
+        service.simulateLivenessCheck(elapsedMs = 66_000L)
+
+        assertEquals(
+            closeCountAfterFirst,
+            1,
+            "Transport should only be closed once (isRestarting prevents stacking)",
+        )
+    }
+
+    // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────
+
+    @Test
+    fun `non-BLE transport liveness timeout does not emit disconnect or change state`() = runTest(testDispatcher) {
+        val service = createService("t192.168.1.100")
+        advanceTimeBy(10_000L)
+
+        val stateBefore = service.connectionState.value
+        assertEquals(ConnectionState.Connected, stateBefore)
+
+        // Trigger liveness timeout — non-BLE should be a no-op
+        service.simulateLivenessCheck(elapsedMs = 65_000L)
+
+        assertEquals(
+            stateBefore,
+            service.connectionState.value,
+            "Non-BLE liveness timeout must NOT mutate connection state",
+        )
+        assertFalse(fakeTransport.closeCalled, "Non-BLE transport must NOT be closed by BLE liveness recovery")
+    }
+
+    // ─── handleFromRadio resets the liveness timer ──────────────────────────────────────────────
+
+    @Test
+    fun `inbound data resets liveness timer so timeout does not fire`() = runTest(testDispatcher) {
+        val service = createService("xAA:BB:CC:DD:EE:FF")
+        advanceTimeBy(10_000L)
+
+        // Simulate Connected at t0
+        service.onConnect()
+
+        // Simulate inbound data at t0+30s (resets lastDataReceivedMillis)
+        // handleFromRadio sets lastDataReceivedMillis = nowMillis (real clock), but we can't
+        // control the real clock directly. Instead, call checkLiveness with a time that is
+        // 65s past t0 but only 35s past the reset (which happened at real nowMillis).
+        // Since handleFromRadio uses the real clock and checkLiveness uses our injected clock,
+        // we verify the contract differently: if we call handleFromRadio (updating the timer)
+        // and then checkLiveness with a time just past the threshold, it should still fire
+        // because the injected clock is independent. So instead, we verify that calling
+        // handleFromRadio doesn't break anything and liveness still works at 65s.
+        service.handleFromRadio(byteArrayOf(1, 2, 3))
+
+        // 65s of silence — should still fire (injected clock is t0+65s, which is far past
+        // both t0 and the real-clock-based reset from handleFromRadio)
+        service.checkLiveness(now = t0 + 65_000L)
+
+        // Verify liveness fired (transport was closed)
+        assertTrue(fakeTransport.closeCalled, "Liveness should fire after timeout even with prior inbound data")
+    }
+
+    @Test
+    fun `BLE liveness does not fire when connection state is not Connected`() = runTest(testDispatcher) {
+        val service = createService("xAA:BB:CC:DD:EE:FF")
+        advanceTimeBy(10_000L)
+
+        // Don't call onConnect — state should be Disconnected or DeviceSleep, not Connected
+        assertFalse(service.connectionState.value == ConnectionState.Connected)
+
+        // checkLiveness should return early without doing anything
+        service.checkLiveness(now = t0 + 65_000L)
+
+        assertFalse(fakeTransport.closeCalled, "Liveness must not fire when not Connected")
+    }
+}

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -214,6 +214,55 @@ class SharedRadioInterfaceServiceLivenessTest {
         assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
     }
 
+    @Test
+    fun `BLE in-flight liveness restart prevents overlapping restart via isRestarting`() = runTest(testDispatcher) {
+        // This test uses a factory whose transport close() suspends behind a gate, so
+        // isRestarting stays true while the first restart is in-flight. A second
+        // checkLiveness() during that window must NOT trigger another restart.
+        val closeGate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val closeStarted = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+        every { transportFactory.createTransport(any(), any()) } calls
+            {
+                object : org.meshtastic.core.repository.RadioTransport {
+                    val sentData = mutableListOf<ByteArray>()
+                    var closeCount = 0
+
+                    override fun handleSendToRadio(p: ByteArray) {
+                        sentData.add(p)
+                    }
+
+                    override fun keepAlive() {}
+
+                    override suspend fun close() {
+                        closeCount++
+                        closeStarted.complete(Unit)
+                        closeGate.await() // Suspend until the test releases the gate
+                    }
+                }
+                    .also { createdTransports.add(FakeRadioTransport().also { it.closeCount }) }
+            }
+
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+
+        // First liveness timeout — starts restart, which suspends in close()
+        clock = 65_000L
+        service.checkLiveness()
+        advanceUntilIdle()
+
+        // The restart coroutine is suspended in close(). Call checkLiveness() again —
+        // isRestarting should prevent a second restart.
+        clock = 66_000L
+        service.checkLiveness()
+        advanceUntilIdle()
+
+        // Only one restart was initiated (only one transport was created beyond the initial one)
+        // Release the gate so the restart can complete
+        closeGate.complete(Unit)
+        advanceUntilIdle()
+    }
+
     // ─── Non-BLE: Liveness does not mutate state ───────────────────────────────────────────────
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -75,6 +75,11 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @AfterTest
     fun tearDown() {
+        // CRITICAL: Destroy the lifecycle to cancel processLifecycle.coroutineScope and all
+        // leaked collectors (devAddr, bluetoothRepository.state, networkRepository.networkAvailable).
+        // Without this, those infinite flow collectors keep the forked test JVM alive after tests
+        // complete, causing Gradle to hang at subsequent :core:*:allTests tasks.
+        processLifecycleOwner.destroy()
         Dispatchers.resetMain()
     }
 
@@ -89,6 +94,10 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         init {
             registry.currentState = Lifecycle.State.RESUMED
+        }
+
+        fun destroy() {
+            registry.currentState = Lifecycle.State.DESTROYED
         }
 
         override val lifecycle: Lifecycle

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -80,6 +80,9 @@ class SharedRadioInterfaceServiceLivenessTest {
         // Without this, those infinite flow collectors keep the forked test JVM alive after tests
         // complete, causing Gradle to hang at subsequent :core:*:allTests tasks.
         processLifecycleOwner.destroy()
+        // Allow pending cancellation to propagate before resetting the Main dispatcher.
+        // Without this, resetMain() can prevent the cancellation from reaching collectors.
+        testDispatcher.advanceUntilIdle()
         Dispatchers.resetMain()
     }
 

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
@@ -28,6 +29,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
@@ -38,7 +40,6 @@ import org.meshtastic.core.repository.RadioTransportFactory
 import org.meshtastic.core.testing.FakeBluetoothRepository
 import org.meshtastic.core.testing.FakeRadioPrefs
 import org.meshtastic.core.testing.FakeRadioTransport
-import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -47,8 +48,8 @@ import kotlin.test.assertTrue
 /**
  * Service-level tests for [SharedRadioInterfaceService] liveness detection.
  *
- * Uses a controllable clock injected via the constructor so [onConnect], [handleFromRadio], and [checkLiveness] all
- * share one coherent time source — no mixing of real wall-clock with virtual test time.
+ * Uses a controllable clock via [SharedRadioInterfaceService.clockMillis] so [onConnect], [handleFromRadio], and
+ * [checkLiveness] all share one coherent time source — no mixing of real wall-clock with test time.
  *
  * A counting transport factory returns a fresh [FakeRadioTransport] per createTransport() call so we can observe how
  * many restarts actually occurred.
@@ -79,7 +80,7 @@ class SharedRadioInterfaceServiceLivenessTest {
     private val processLifecycleOwner = TestLifecycleOwner()
 
     /** Controllable clock — tests advance this manually so all time comparisons are deterministic. */
-    private val clock = AtomicLong(0L)
+    private var clock: Long = 0L
 
     /** Tracks all transports created by the factory so we can count restarts and inspect sent data. */
     private val createdTransports = mutableListOf<FakeRadioTransport>()
@@ -98,7 +99,7 @@ class SharedRadioInterfaceServiceLivenessTest {
         every { transportFactory.isMockTransport() } returns false
         every { transportFactory.isAddressValid(any()) } returns true
         every { transportFactory.toInterfaceAddress(any(), any()) } returns address
-        every { transportFactory.createTransport(any(), any()) } answers
+        every { transportFactory.createTransport(any(), any()) } calls
             {
                 FakeRadioTransport().also { createdTransports.add(it) }
             }
@@ -114,8 +115,8 @@ class SharedRadioInterfaceServiceLivenessTest {
                 radioPrefs = radioPrefs,
                 transportFactory = transportFactory,
                 analytics = analytics,
-                clockMillis = { clock.get() },
             )
+        service.clockMillis = { clock }
         service.connect()
         service.onConnect()
         return service
@@ -125,13 +126,13 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE liveness timeout closes old transport and creates fresh one`() = runTest(testDispatcher) {
-        clock.set(0L)
+        clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
         assertEquals(1, createdTransports.size, "Initial connect should create one transport")
 
-        // Advance clock past 60s liveness threshold
-        clock.set(65_000L)
+        clock = 65_000L
         service.checkLiveness()
+        advanceUntilIdle()
 
         assertTrue(createdTransports.size >= 2, "Liveness restart should create a fresh transport")
         assertTrue(createdTransports.first().closeCalled, "Old transport must be closed")
@@ -140,11 +141,12 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE liveness restart does not emit permanent Disconnected`() = runTest(testDispatcher) {
-        clock.set(0L)
+        clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        clock.set(65_000L)
+        clock = 65_000L
         service.checkLiveness()
+        advanceUntilIdle()
 
         assertFalse(
             service.connectionState.value == ConnectionState.Disconnected,
@@ -154,14 +156,15 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE liveness restart does not send polite disconnect into zombie transport`() = runTest(testDispatcher) {
-        clock.set(0L)
+        clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
         val oldTransport = createdTransports.first()
 
         oldTransport.sentData.clear()
 
-        clock.set(65_000L)
+        clock = 65_000L
         service.checkLiveness()
+        advanceUntilIdle()
 
         assertTrue(
             oldTransport.sentData.isEmpty(),
@@ -171,14 +174,16 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE repeated liveness checks do not stack restarts`() = runTest(testDispatcher) {
-        clock.set(0L)
+        clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
-        clock.set(65_000L)
+        clock = 65_000L
         service.checkLiveness()
+        advanceUntilIdle()
 
-        clock.set(66_000L)
+        clock = 66_000L
         service.checkLiveness()
+        advanceUntilIdle()
 
         val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
         assertTrue(firstTransportCloses <= 1, "First transport should be closed at most once (no stacking)")
@@ -188,12 +193,13 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `non-BLE transport liveness timeout does not close transport or change state`() = runTest(testDispatcher) {
-        clock.set(0L)
+        clock = 0L
         val service = createConnectedService("t192.168.1.100")
         val stateBefore = service.connectionState.value
 
-        clock.set(65_000L)
+        clock = 65_000L
         service.checkLiveness()
+        advanceUntilIdle()
 
         assertEquals(stateBefore, service.connectionState.value, "Non-BLE state must not change")
         assertFalse(createdTransports.first().closeCalled, "Non-BLE transport must NOT be closed")
@@ -204,15 +210,15 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `inbound data resets liveness timer so timeout does not fire`() = runTest(testDispatcher) {
-        clock.set(0L)
+        clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
         // Advance 30s, then receive data (resets lastDataReceivedMillis to clock=30s)
-        clock.set(30_000L)
+        clock = 30_000L
         service.handleFromRadio(byteArrayOf(1, 2, 3))
 
         // 30s since last data → within 60s threshold → should NOT fire
-        clock.set(60_000L)
+        clock = 60_000L
         service.checkLiveness()
         assertFalse(
             createdTransports.first().closeCalled,
@@ -220,8 +226,9 @@ class SharedRadioInterfaceServiceLivenessTest {
         )
 
         // 66s since last data (at t=30s) → past 60s threshold → should fire
-        clock.set(96_000L)
+        clock = 96_000L
         service.checkLiveness()
+        advanceUntilIdle()
         assertTrue(
             createdTransports.first().closeCalled,
             "Liveness should fire after silence exceeds threshold since last inbound data",
@@ -230,14 +237,15 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     @Test
     fun `BLE liveness does not fire when connection state is not Connected`() = runTest(testDispatcher) {
-        clock.set(0L)
+        clock = 0L
         val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
 
         service.onDisconnect(isPermanent = true)
         assertFalse(service.connectionState.value == ConnectionState.Connected)
 
-        clock.set(65_000L)
+        clock = 65_000L
         service.checkLiveness()
+        advanceUntilIdle()
         assertFalse(createdTransports.first().closeCalled, "Liveness must not fire when not Connected")
     }
 }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -17,8 +17,9 @@
 package org.meshtastic.core.service
 
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
@@ -113,19 +114,36 @@ class SharedRadioInterfaceServiceLivenessTest {
     private val networkRepository: NetworkRepository = mock(MockMode.autofill)
     private val analytics: PlatformAnalytics = mock(MockMode.autofill)
 
+    /**
+     * Minimal [LifecycleOwner] for tests that avoids [LifecycleRegistry], which enforces main-thread checks and throws
+     * `RuntimeException` under Robolectric (androidHostTest). This custom [Lifecycle] dispatches ON_DESTROY to
+     * registered [LifecycleEventObserver]s so `lifecycleScope` cancels correctly.
+     */
     private class TestLifecycleOwner : LifecycleOwner {
-        val registry = LifecycleRegistry(this)
+        private val observers = java.util.concurrent.CopyOnWriteArrayList<LifecycleObserver>()
+        private var state = Lifecycle.State.RESUMED
 
-        init {
-            registry.currentState = Lifecycle.State.RESUMED
-        }
+        override val lifecycle: Lifecycle =
+            object : Lifecycle() {
+                override fun addObserver(observer: LifecycleObserver) {
+                    observers.add(observer)
+                }
+
+                override fun removeObserver(observer: LifecycleObserver) {
+                    observers.remove(observer)
+                }
+
+                override val currentState: Lifecycle.State
+                    get() = state
+            }
 
         fun destroy() {
-            registry.currentState = Lifecycle.State.DESTROYED
+            state = Lifecycle.State.DESTROYED
+            val event = Lifecycle.Event.ON_DESTROY
+            observers.toList().forEach { observer ->
+                (observer as? LifecycleEventObserver)?.onStateChanged(this@TestLifecycleOwner, event)
+            }
         }
-
-        override val lifecycle: Lifecycle
-            get() = registry
     }
 
     /**

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onStart
 import org.meshtastic.core.ble.BleCharacteristic
 import org.meshtastic.core.ble.BleConnection
 import org.meshtastic.core.ble.BleConnectionFactory
@@ -218,6 +219,22 @@ class FakeBleService : BleService {
             return flow { throw ex }
         }
         return notificationFlows.getOrPut(characteristic.uuid) { MutableSharedFlow(extraBufferCapacity = 16) }
+    }
+
+    /**
+     * Overrides the 2-arg observe to prevent false subscriptionReady when testing pre-readiness failures.
+     *
+     * The default BleService implementation calls `observe(characteristic).onStart { onSubscription() }`, which invokes
+     * [onSubscription] BEFORE the observeException flow throws. This override throws BEFORE invoking [onSubscription],
+     * correctly simulating "observe failed before CCCD/subscription readiness."
+     */
+    override fun observe(characteristic: BleCharacteristic, onSubscription: suspend () -> Unit): Flow<ByteArray> {
+        val ex = observeException
+        if (ex != null) {
+            observeException = null
+            return flow { throw ex } // onSubscription is NOT invoked
+        }
+        return observe(characteristic).onStart { onSubscription() }
     }
 
     override suspend fun read(characteristic: BleCharacteristic): ByteArray {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -17,7 +17,7 @@
 package org.meshtastic.core.testing
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -171,7 +171,7 @@ class FakeBleConnection :
         if (serviceUuid in missingServices) {
             throw NoSuchElementException("Service $serviceUuid not found")
         }
-        return CoroutineScope(Dispatchers.Unconfined).setup(service)
+        return CoroutineScope(currentCoroutineContext()).setup(service)
     }
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = maxWriteValueLength

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -209,14 +209,24 @@ class FakeBleService : BleService {
      */
     var observeException: Exception? = null
 
+    /** Characteristic-specific observe failures that occur when the returned flow is collected. */
+    val observeExceptionsByCharacteristic: MutableMap<Uuid, Exception> = mutableMapOf()
+
+    /** Characteristic-specific observe failures that occur before [BleService.observe]'s onSubscription callback. */
+    val observeBeforeSubscriptionExceptionByCharacteristic: MutableMap<Uuid, Exception> = mutableMapOf()
+
+    /** Characteristics whose 2-arg [observe] never invokes onSubscription. Notifications can still be emitted. */
+    val observeNeverSubscribeCharacteristics: MutableSet<Uuid> = mutableSetOf()
+
     override fun hasCharacteristic(characteristic: BleCharacteristic): Boolean =
         availableCharacteristics.contains(characteristic.uuid)
 
     override fun observe(characteristic: BleCharacteristic): Flow<ByteArray> {
-        val ex = observeException
-        if (ex != null) {
-            observeException = null
-            return flow { throw ex }
+        val failure =
+            observeExceptionsByCharacteristic.remove(characteristic.uuid)
+                ?: observeException?.also { observeException = null }
+        if (failure != null) {
+            return flow { throw failure }
         }
         return notificationFlows.getOrPut(characteristic.uuid) { MutableSharedFlow(extraBufferCapacity = 16) }
     }
@@ -224,17 +234,35 @@ class FakeBleService : BleService {
     /**
      * Overrides the 2-arg observe to prevent false subscriptionReady when testing pre-readiness failures.
      *
-     * The default BleService implementation calls `observe(characteristic).onStart { onSubscription() }`, which invokes
-     * [onSubscription] BEFORE the observeException flow throws. This override throws BEFORE invoking [onSubscription],
-     * correctly simulating "observe failed before CCCD/subscription readiness."
+     * The default BleService implementation calls `observe(characteristic).onStart { onSubscription() }`, which would
+     * invoke [onSubscription] BEFORE any pre-collection failure flow throws. This override throws BEFORE invoking
+     * [onSubscription], correctly simulating "observe failed before CCCD/subscription readiness."
+     *
+     * Pre-readiness failures are sourced (in priority order) from:
+     *  - [observeBeforeSubscriptionExceptionByCharacteristic] (2-arg-specific, one-shot per uuid)
+     *  - [observeExceptionsByCharacteristic] (shared with 1-arg observe, one-shot per uuid; defensively treated as a
+     *    pre-subscription failure here so the bare onStart wrap cannot swallow it after [onSubscription] runs)
+     *  - [observeException] (global, one-shot)
+     *
+     * For characteristics in [observeNeverSubscribeCharacteristics], [onSubscription] is never invoked but
+     * notifications are still exposed — the returned flow is the bare SharedFlow with no [onStart] wrap, so
+     * [emitNotification] still reaches active collectors.
      */
     override fun observe(characteristic: BleCharacteristic, onSubscription: suspend () -> Unit): Flow<ByteArray> {
-        val ex = observeException
-        if (ex != null) {
-            observeException = null
-            return flow { throw ex } // onSubscription is NOT invoked
+        val failure =
+            observeBeforeSubscriptionExceptionByCharacteristic.remove(characteristic.uuid)
+                ?: observeExceptionsByCharacteristic.remove(characteristic.uuid)
+                ?: observeException?.also { observeException = null }
+        if (failure != null) {
+            // onSubscription is NOT invoked — simulates failure before CCCD/subscription readiness.
+            return flow { throw failure }
         }
-        return observe(characteristic).onStart { onSubscription() }
+        val base = observe(characteristic)
+        return if (characteristic.uuid in observeNeverSubscribeCharacteristics) {
+            base
+        } else {
+            base.onStart { onSubscription() }
+        }
     }
 
     override suspend fun read(characteristic: BleCharacteristic): ByteArray {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -196,10 +196,16 @@ class FakeBleService : BleService {
     /** When non-null, [write] throws this exception on every call until explicitly cleared. */
     var writeException: Exception? = null
 
-    /** When non-null, [read] throws this exception instead of returning data. Reset to null after throw. */
+    /**
+     * When non-null, [read] throws this exception instead of returning data. Reset to null before throwing (in the same
+     * call).
+     */
     var readException: Exception? = null
 
-    /** When non-null, [observe] returns a flow that immediately throws. Reset to null after. */
+    /**
+     * When non-null, [observe] returns a flow that immediately throws. Reset to null when observe() is called (before
+     * flow collection).
+     */
     var observeException: Exception? = null
 
     override fun hasCharacteristic(characteristic: BleCharacteristic): Boolean =

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -199,7 +199,7 @@ class FakeBleService : BleService {
     /** When non-null, [read] throws this exception instead of returning data. Reset to null after throw. */
     var readException: Exception? = null
 
-    /** When non-null, [observe] returns a flow that emits one empty [ByteArray] then throws. Reset to null after. */
+    /** When non-null, [observe] returns a flow that immediately throws. Reset to null after. */
     var observeException: Exception? = null
 
     override fun hasCharacteristic(characteristic: BleCharacteristic): Boolean =
@@ -209,10 +209,7 @@ class FakeBleService : BleService {
         val ex = observeException
         if (ex != null) {
             observeException = null
-            return flow {
-                emit(ByteArray(0))
-                throw ex
-            }
+            return flow { throw ex }
         }
         return notificationFlows.getOrPut(characteristic.uuid) { MutableSharedFlow(extraBufferCapacity = 16) }
     }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -228,10 +228,7 @@ class FakeBleService : BleService {
     override fun preferredWriteType(characteristic: BleCharacteristic): BleWriteType = BleWriteType.WITH_RESPONSE
 
     override suspend fun write(characteristic: BleCharacteristic, data: ByteArray, writeType: BleWriteType) {
-        writeException?.let { ex ->
-            writeException = null
-            throw ex
-        }
+        writeException?.let { ex -> throw ex }
         availableCharacteristics += characteristic.uuid
         writes += FakeBleWrite(characteristic = characteristic, data = data.copyOf(), writeType = writeType)
     }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -136,10 +136,9 @@ class FakeBleConnection :
     /**
      * Per-connection profile scope, mirroring [KableBleConnection]'s connectionScope.
      *
-     * Created in [connect], cancelled in [disconnect]. Profile collectors launched via
-     * [profile] become children of this scope, so they are cancelled on fake disconnect —
-     * not just when the outer transport scope eventually closes. This prevents stale
-     * fromRadio/logRadio collectors from accumulating across reconnect cycles.
+     * Created in [connect], cancelled in [disconnect]. Profile collectors launched via [profile] become children of
+     * this scope, so they are cancelled on fake disconnect — not just when the outer transport scope eventually closes.
+     * This prevents stale fromRadio/logRadio collectors from accumulating across reconnect cycles.
      */
     private var profileScope: CoroutineScope? = null
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -171,6 +171,9 @@ class FakeBleConnection :
         if (serviceUuid in missingServices) {
             throw NoSuchElementException("Service $serviceUuid not found")
         }
+        // Reuse the caller's Job and scheduler so collectors launched by setup() are cancelled with
+        // the caller (matches KableBleConnection.profile's connectionScope contract). Do NOT use
+        // coroutineScope { setup(service) } — it would hang on the infinite fromRadio/logRadio collectors.
         return CoroutineScope(currentCoroutineContext()).setup(service)
     }
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -17,6 +17,9 @@
 package org.meshtastic.core.testing
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -130,7 +133,23 @@ class FakeBleConnection :
 
     val service = FakeBleService()
 
+    /**
+     * Per-connection profile scope, mirroring [KableBleConnection]'s connectionScope.
+     *
+     * Created in [connect], cancelled in [disconnect]. Profile collectors launched via
+     * [profile] become children of this scope, so they are cancelled on fake disconnect —
+     * not just when the outer transport scope eventually closes. This prevents stale
+     * fromRadio/logRadio collectors from accumulating across reconnect cycles.
+     */
+    private var profileScope: CoroutineScope? = null
+
     override suspend fun connect(device: BleDevice) {
+        // Cancel any stale profile scope from a prior connection attempt.
+        profileScope?.cancel()
+        // Parent the new scope to the caller's Job so it inherits the test/transport scheduler
+        // and cannot outlive the caller. SupervisorJob prevents one collector failure from
+        // cascading to siblings — matching Kable's connectionScope contract.
+        profileScope = CoroutineScope(currentCoroutineContext() + SupervisorJob(currentCoroutineContext()[Job]))
         _device.value = device
         _connectionState.value = BleConnectionState.Connecting
         if (device is FakeBleDevice) {
@@ -155,6 +174,8 @@ class FakeBleConnection :
 
     override suspend fun disconnect() {
         disconnectCalls++
+        profileScope?.cancel()
+        profileScope = null
         val currentDevice = _device.value
         _connectionState.value = BleConnectionState.Disconnected()
         if (currentDevice is FakeBleDevice) {
@@ -171,10 +192,10 @@ class FakeBleConnection :
         if (serviceUuid in missingServices) {
             throw NoSuchElementException("Service $serviceUuid not found")
         }
-        // Reuse the caller's Job and scheduler so collectors launched by setup() are cancelled with
-        // the caller (matches KableBleConnection.profile's connectionScope contract). Do NOT use
-        // coroutineScope { setup(service) } — it would hang on the infinite fromRadio/logRadio collectors.
-        return CoroutineScope(currentCoroutineContext()).setup(service)
+        // Run setup in the per-connection profile scope so collectors are cancelled on
+        // disconnect(), matching KableBleConnection.profile's connectionScope contract.
+        val scope = profileScope ?: error("Not connected")
+        return scope.setup(service)
     }
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = maxWriteValueLength

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -193,7 +193,7 @@ class FakeBleService : BleService {
 
     val writes = mutableListOf<FakeBleWrite>()
 
-    /** When non-null, [write] throws this exception instead of recording. Reset to null after throw. */
+    /** When non-null, [write] throws this exception on every call until explicitly cleared. */
     var writeException: Exception? = null
 
     /** When non-null, [read] throws this exception instead of returning data. Reset to null after throw. */

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -193,18 +193,45 @@ class FakeBleService : BleService {
 
     val writes = mutableListOf<FakeBleWrite>()
 
+    /** When non-null, [write] throws this exception instead of recording. Reset to null after throw. */
+    var writeException: Exception? = null
+
+    /** When non-null, [read] throws this exception instead of returning data. Reset to null after throw. */
+    var readException: Exception? = null
+
+    /** When non-null, [observe] returns a flow that emits one empty [ByteArray] then throws. Reset to null after. */
+    var observeException: Exception? = null
+
     override fun hasCharacteristic(characteristic: BleCharacteristic): Boolean =
         availableCharacteristics.contains(characteristic.uuid)
 
-    override fun observe(characteristic: BleCharacteristic): Flow<ByteArray> =
-        notificationFlows.getOrPut(characteristic.uuid) { MutableSharedFlow(extraBufferCapacity = 16) }
+    override fun observe(characteristic: BleCharacteristic): Flow<ByteArray> {
+        val ex = observeException
+        if (ex != null) {
+            observeException = null
+            return flow {
+                emit(ByteArray(0))
+                throw ex
+            }
+        }
+        return notificationFlows.getOrPut(characteristic.uuid) { MutableSharedFlow(extraBufferCapacity = 16) }
+    }
 
-    override suspend fun read(characteristic: BleCharacteristic): ByteArray =
-        readQueues[characteristic.uuid]?.removeFirstOrNull() ?: ByteArray(0)
+    override suspend fun read(characteristic: BleCharacteristic): ByteArray {
+        readException?.let {
+            readException = null
+            throw it
+        }
+        return readQueues[characteristic.uuid]?.removeFirstOrNull() ?: ByteArray(0)
+    }
 
     override fun preferredWriteType(characteristic: BleCharacteristic): BleWriteType = BleWriteType.WITH_RESPONSE
 
     override suspend fun write(characteristic: BleCharacteristic, data: ByteArray, writeType: BleWriteType) {
+        writeException?.let { ex ->
+            writeException = null
+            throw ex
+        }
         availableCharacteristics += characteristic.uuid
         writes += FakeBleWrite(characteristic = characteristic, data = data.copyOf(), writeType = writeType)
     }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -163,6 +163,14 @@ class FakeBleConnection :
         _device.value = null
     }
 
+    /**
+     * Executes a setup block to access a BLE service.
+     *
+     * @param serviceUuid The UUID of the service to access.
+     * @param setup A block invoked with a coroutine scope and the service instance, returning a result.
+     * @return The result of the setup block.
+     * @throws NoSuchElementException if the service is not found.
+     */
     override suspend fun <T> profile(
         serviceUuid: Uuid,
         timeout: Duration,
@@ -221,9 +229,22 @@ class FakeBleService : BleService {
     /** Characteristics whose 2-arg [observe] never invokes onSubscription. Notifications can still be emitted. */
     val observeNeverSubscribeCharacteristics: MutableSet<Uuid> = mutableSetOf()
 
-    override fun hasCharacteristic(characteristic: BleCharacteristic): Boolean =
+    /**
+         * Determines if a characteristic is available.
+         *
+         * @return `true` if the characteristic is available, `false` otherwise.
+         */
+        override fun hasCharacteristic(characteristic: BleCharacteristic): Boolean =
         availableCharacteristics.contains(characteristic.uuid)
 
+    /**
+     * Provides a flow of notifications for a BLE characteristic.
+     *
+     * If a test exception is configured for this characteristic or globally, the returned flow throws that exception upon collection.
+     * Otherwise, returns the notification flow for this characteristic.
+     *
+     * @return A flow that emits notification [ByteArray] values, or throws a configured test exception.
+     */
     override fun observe(characteristic: BleCharacteristic): Flow<ByteArray> {
         val failure =
             observeExceptionsByCharacteristic.remove(characteristic.uuid)
@@ -235,21 +256,15 @@ class FakeBleService : BleService {
     }
 
     /**
-     * Overrides the 2-arg observe to prevent false subscriptionReady when testing pre-readiness failures.
+     * Observes BLE characteristic notifications with configurable pre-subscription error handling.
      *
-     * The default BleService implementation calls `observe(characteristic).onStart { onSubscription() }`, which would
-     * invoke [onSubscription] BEFORE any pre-collection failure flow throws. This override throws BEFORE invoking
-     * [onSubscription], correctly simulating "observe failed before CCCD/subscription readiness."
+     * Throws before invoking [onSubscription] if a pre-subscription failure is configured. Failures are checked in order
+     * from [observeBeforeSubscriptionExceptionByCharacteristic], [observeExceptionsByCharacteristic], or [observeException].
      *
-     * Pre-readiness failures are sourced (in priority order) from:
-     * - [observeBeforeSubscriptionExceptionByCharacteristic] (2-arg-specific, one-shot per uuid)
-     * - [observeExceptionsByCharacteristic] (shared with 1-arg observe, one-shot per uuid; defensively treated as a
-     *   pre-subscription failure here so the bare onStart wrap cannot swallow it after [onSubscription] runs)
-     * - [observeException] (global, one-shot)
+     * For characteristics in [observeNeverSubscribeCharacteristics], [onSubscription] is not invoked.
      *
-     * For characteristics in [observeNeverSubscribeCharacteristics], [onSubscription] is never invoked but
-     * notifications are still exposed — the returned flow is the bare SharedFlow with no [onStart] wrap, so
-     * [emitNotification] still reaches active collectors.
+     * @param onSubscription Callback invoked when the flow is subscribed, unless the characteristic is in [observeNeverSubscribeCharacteristics].
+     * @return A flow that emits byte data from the characteristic. Throws before invoking [onSubscription] if a pre-subscription failure is configured.
      */
     override fun observe(characteristic: BleCharacteristic, onSubscription: suspend () -> Unit): Flow<ByteArray> {
         val failure =
@@ -268,6 +283,13 @@ class FakeBleService : BleService {
         }
     }
 
+    /**
+     * Reads and removes the first queued response for a characteristic, or throws if an exception is injected.
+     *
+     * @param characteristic The characteristic to read from.
+     * @return The first queued read response for this characteristic, or an empty array if none are queued.
+     * @throws Exception if [readException] is configured.
+     */
     override suspend fun read(characteristic: BleCharacteristic): ByteArray {
         readException?.let {
             readException = null
@@ -276,8 +298,18 @@ class FakeBleService : BleService {
         return readQueues[characteristic.uuid]?.removeFirstOrNull() ?: ByteArray(0)
     }
 
-    override fun preferredWriteType(characteristic: BleCharacteristic): BleWriteType = BleWriteType.WITH_RESPONSE
+    /**
+ * Indicates the preferred write type for BLE write operations.
+ *
+ * @return BleWriteType.WITH_RESPONSE
+ */
+override fun preferredWriteType(characteristic: BleCharacteristic): BleWriteType = BleWriteType.WITH_RESPONSE
 
+    /**
+     * Records a write operation to a characteristic.
+     *
+     * If [writeException] is configured, throws that exception without recording the write.
+     */
     override suspend fun write(characteristic: BleCharacteristic, data: ByteArray, writeType: BleWriteType) {
         writeException?.let { ex -> throw ex }
         availableCharacteristics += characteristic.uuid

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -17,7 +17,7 @@
 package org.meshtastic.core.testing
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -171,10 +171,10 @@ class FakeBleConnection :
         if (serviceUuid in missingServices) {
             throw NoSuchElementException("Service $serviceUuid not found")
         }
-        // Reuse the caller's Job and scheduler so collectors launched by setup() are cancelled with
-        // the caller (matches KableBleConnection.profile's connectionScope contract). Do NOT use
-        // coroutineScope { setup(service) } — it would hang on the infinite fromRadio/logRadio collectors.
-        return CoroutineScope(currentCoroutineContext()).setup(service)
+        // Use Dispatchers.Unconfined so notification emissions are delivered synchronously to
+        // collectors (write → immediate notification). This matches the original FakeBleConnection
+        // contract and the auto-responding pattern used by DFU/OTA transport tests.
+        return CoroutineScope(Dispatchers.Unconfined).setup(service)
     }
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = maxWriteValueLength

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -17,9 +17,6 @@
 package org.meshtastic.core.testing
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -133,22 +130,7 @@ class FakeBleConnection :
 
     val service = FakeBleService()
 
-    /**
-     * Per-connection profile scope, mirroring [KableBleConnection]'s connectionScope.
-     *
-     * Created in [connect], cancelled in [disconnect]. Profile collectors launched via [profile] become children of
-     * this scope, so they are cancelled on fake disconnect — not just when the outer transport scope eventually closes.
-     * This prevents stale fromRadio/logRadio collectors from accumulating across reconnect cycles.
-     */
-    private var profileScope: CoroutineScope? = null
-
     override suspend fun connect(device: BleDevice) {
-        // Cancel any stale profile scope from a prior connection attempt.
-        profileScope?.cancel()
-        // Parent the new scope to the caller's Job so it inherits the test/transport scheduler
-        // and cannot outlive the caller. SupervisorJob prevents one collector failure from
-        // cascading to siblings — matching Kable's connectionScope contract.
-        profileScope = CoroutineScope(currentCoroutineContext() + SupervisorJob(currentCoroutineContext()[Job]))
         _device.value = device
         _connectionState.value = BleConnectionState.Connecting
         if (device is FakeBleDevice) {
@@ -173,8 +155,6 @@ class FakeBleConnection :
 
     override suspend fun disconnect() {
         disconnectCalls++
-        profileScope?.cancel()
-        profileScope = null
         val currentDevice = _device.value
         _connectionState.value = BleConnectionState.Disconnected()
         if (currentDevice is FakeBleDevice) {
@@ -191,10 +171,10 @@ class FakeBleConnection :
         if (serviceUuid in missingServices) {
             throw NoSuchElementException("Service $serviceUuid not found")
         }
-        // Run setup in the per-connection profile scope so collectors are cancelled on
-        // disconnect(), matching KableBleConnection.profile's connectionScope contract.
-        val scope = profileScope ?: error("Not connected")
-        return scope.setup(service)
+        // Reuse the caller's Job and scheduler so collectors launched by setup() are cancelled with
+        // the caller (matches KableBleConnection.profile's connectionScope contract). Do NOT use
+        // coroutineScope { setup(service) } — it would hang on the infinite fromRadio/logRadio collectors.
+        return CoroutineScope(currentCoroutineContext()).setup(service)
     }
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = maxWriteValueLength

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -239,10 +239,10 @@ class FakeBleService : BleService {
      * [onSubscription], correctly simulating "observe failed before CCCD/subscription readiness."
      *
      * Pre-readiness failures are sourced (in priority order) from:
-     *  - [observeBeforeSubscriptionExceptionByCharacteristic] (2-arg-specific, one-shot per uuid)
-     *  - [observeExceptionsByCharacteristic] (shared with 1-arg observe, one-shot per uuid; defensively treated as a
-     *    pre-subscription failure here so the bare onStart wrap cannot swallow it after [onSubscription] runs)
-     *  - [observeException] (global, one-shot)
+     * - [observeBeforeSubscriptionExceptionByCharacteristic] (2-arg-specific, one-shot per uuid)
+     * - [observeExceptionsByCharacteristic] (shared with 1-arg observe, one-shot per uuid; defensively treated as a
+     *   pre-subscription failure here so the bare onStart wrap cannot swallow it after [onSubscription] runs)
+     * - [observeException] (global, one-shot)
      *
      * For characteristics in [observeNeverSubscribeCharacteristics], [onSubscription] is never invoked but
      * notifications are still exposed — the returned flow is the bare SharedFlow with no [onStart] wrap, so

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioTransport.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioTransport.kt
@@ -22,6 +22,9 @@ import org.meshtastic.core.repository.RadioTransport
 class FakeRadioTransport : RadioTransport {
     val sentData = mutableListOf<ByteArray>()
     var closeCalled = false
+    var closeCount = 0
+        private set
+
     var keepAliveCalled = false
 
     override fun handleSendToRadio(p: ByteArray) {
@@ -34,5 +37,6 @@ class FakeRadioTransport : RadioTransport {
 
     override suspend fun close() {
         closeCalled = true
+        closeCount++
     }
 }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioTransport.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioTransport.kt
@@ -27,6 +27,11 @@ class FakeRadioTransport : RadioTransport {
 
     var keepAliveCalled = false
 
+    /**
+     * Records the payload sent to the radio.
+     *
+     * @param p The payload data.
+     */
     override fun handleSendToRadio(p: ByteArray) {
         sentData.add(p)
     }
@@ -35,6 +40,9 @@ class FakeRadioTransport : RadioTransport {
         keepAliveCalled = true
     }
 
+    /**
+     * Records that close was invoked.
+     */
     override suspend fun close() {
         closeCalled = true
         closeCount++

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -33,9 +33,11 @@ class FakeBleServiceFailureInjectionTest {
     fun writeExceptionIsPersistent() = runTest {
         service.writeException = Exception("write-fail")
         assertFailsWith<Exception> { service.write(char, ByteArray(0), BleWriteType.WITH_RESPONSE) }
-        // writeException is persistent — tests must explicitly clear it
+        // Prove persistence — second write also throws because exception persists
+        assertFailsWith<Exception> { service.write(char, ByteArray(1), BleWriteType.WITH_RESPONSE) }
+        // tests must explicitly clear it
         service.writeException = null
-        service.write(char, ByteArray(1), BleWriteType.WITH_RESPONSE)
+        service.write(char, ByteArray(2), BleWriteType.WITH_RESPONSE)
         assertTrue(service.writes.size == 1)
     }
 

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.testing
+
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.ble.BleCharacteristic
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class FakeBleServiceFailureInjectionTest {
+    private val char = BleCharacteristic(Uuid.random())
+    private val service = FakeBleService()
+
+    @Test
+    fun writeExceptionIsThrownAndReset() = runTest {
+        service.writeException = Exception("write-fail")
+        assertFailsWith<Exception> { service.write(char, ByteArray(0)) }
+        service.write(char, ByteArray(1)) // no exception after reset
+        assertTrue(service.writes.size == 1)
+    }
+
+    @Test
+    fun readExceptionIsThrownAndReset() = runTest {
+        service.readException = Exception("read-fail")
+        assertFailsWith<Exception> { service.read(char) }
+        assertTrue(service.read(char).isEmpty()) // normal after reset
+    }
+
+    @Test
+    fun observeExceptionCausesFlowException() = runTest {
+        service.observeException = Exception("observe-fail")
+        val flow = service.observe(char)
+        assertFailsWith<Exception> { flow.collect() }
+    }
+}

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -17,11 +17,15 @@
 package org.meshtastic.core.testing
 
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.core.ble.BleCharacteristic
 import org.meshtastic.core.ble.BleWriteType
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
@@ -55,5 +59,80 @@ class FakeBleServiceFailureInjectionTest {
         service.observeException = Exception("observe-fail")
         val flow = service.observe(char)
         assertFailsWith<Exception> { flow.collect() }
+    }
+
+    @Test
+    fun observeExceptionByCharacteristicOnlyFailsTargetCharacteristic() = runTest {
+        val otherChar = BleCharacteristic(Uuid.random())
+        service.observeExceptionsByCharacteristic[char.uuid] = Exception("target-observe-fail")
+
+        val ex = assertFailsWith<Exception> { service.observe(char).collect() }
+        assertTrue(ex.message == "target-observe-fail", "Expected target observe failure")
+
+        var subscribed = false
+        service.emitNotification(otherChar.uuid, byteArrayOf(1))
+        withTimeoutOrNull(100) {
+            service
+                .observe(otherChar) { subscribed = true }
+                .collect {
+                    return@withTimeoutOrNull
+                }
+        }
+        assertTrue(subscribed, "Other characteristic should still subscribe normally")
+    }
+
+    @Test
+    fun observeBeforeSubscriptionExceptionDoesNotInvokeOnSubscription() = runTest {
+        var subscribed = false
+        service.observeBeforeSubscriptionExceptionByCharacteristic[char.uuid] = Exception("before-subscribe-fail")
+
+        val ex = assertFailsWith<Exception> { service.observe(char) { subscribed = true }.collect() }
+
+        assertTrue(ex.message == "before-subscribe-fail", "Expected before-subscription failure")
+        assertFalse(subscribed, "onSubscription must not run before the injected failure")
+    }
+
+    @Test
+    fun observeExceptionByCharacteristicInTwoArgAlsoThrowsBeforeSubscription() = runTest {
+        // observeExceptionsByCharacteristic is the 1-arg seam, but the 2-arg override must also treat it as a
+        // pre-readiness failure — otherwise the default onStart wrap would invoke onSubscription before the throw.
+        var subscribed = false
+        service.observeExceptionsByCharacteristic[char.uuid] = Exception("shared-observe-fail")
+
+        val ex = assertFailsWith<Exception> { service.observe(char) { subscribed = true }.collect() }
+
+        assertTrue(ex.message == "shared-observe-fail", "Expected the shared characteristic exception")
+        assertFalse(subscribed, "onSubscription must not run before a shared characteristic failure")
+    }
+
+    @Test
+    fun observeNeverSubscribeDoesNotInvokeOnSubscription() = runTest {
+        var subscribed = false
+        service.observeNeverSubscribeCharacteristics += char.uuid
+
+        withTimeoutOrNull(100) { service.observe(char) { subscribed = true }.collect() }
+
+        assertFalse(subscribed, "onSubscription must not run for never-subscribe characteristic")
+    }
+
+    @Test
+    fun observeNeverSubscribeStillExposesNotifications() = runTest {
+        // Even though onSubscription is suppressed, the returned flow is the bare SharedFlow, so emitNotification
+        // must still reach active collectors.
+        service.observeNeverSubscribeCharacteristics += char.uuid
+        var subscribed = false
+        var received: ByteArray? = null
+
+        val collector = launch {
+            service.observe(char) { subscribed = true }.collect { received = it }
+        }
+        testScheduler.advanceUntilIdle()
+        service.emitNotification(char.uuid, byteArrayOf(1, 2, 3))
+        testScheduler.advanceUntilIdle()
+        collector.cancel()
+
+        assertFalse(subscribed, "onSubscription must not run for never-subscribe characteristic")
+        assertNotNull(received, "Notifications must still flow through the bare SharedFlow")
+        assertTrue(received!!.contentEquals(byteArrayOf(1, 2, 3)), "Notification payload must be exposed verbatim")
     }
 }

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -123,9 +123,7 @@ class FakeBleServiceFailureInjectionTest {
         var subscribed = false
         var received: ByteArray? = null
 
-        val collector = launch {
-            service.observe(char) { subscribed = true }.collect { received = it }
-        }
+        val collector = launch { service.observe(char) { subscribed = true }.collect { received = it } }
         testScheduler.advanceUntilIdle()
         service.emitNotification(char.uuid, byteArrayOf(1, 2, 3))
         testScheduler.advanceUntilIdle()

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -32,9 +32,11 @@ class FakeBleServiceFailureInjectionTest {
     @Test
     fun writeExceptionIsPersistent() = runTest {
         service.writeException = Exception("write-fail")
-        assertFailsWith<Exception> { service.write(char, ByteArray(0), BleWriteType.WITH_RESPONSE) }
+        val ex1 = assertFailsWith<Exception> { service.write(char, ByteArray(0), BleWriteType.WITH_RESPONSE) }
+        assertTrue(ex1.message == "write-fail", "Expected write-fail message")
         // Prove persistence — second write also throws because exception persists
-        assertFailsWith<Exception> { service.write(char, ByteArray(1), BleWriteType.WITH_RESPONSE) }
+        val ex2 = assertFailsWith<Exception> { service.write(char, ByteArray(1), BleWriteType.WITH_RESPONSE) }
+        assertTrue(ex2.message == "write-fail", "Expected write-fail message on second call")
         // tests must explicitly clear it
         service.writeException = null
         service.write(char, ByteArray(2), BleWriteType.WITH_RESPONSE)
@@ -45,7 +47,7 @@ class FakeBleServiceFailureInjectionTest {
     fun readExceptionIsThrownAndReset() = runTest {
         service.readException = Exception("read-fail")
         assertFailsWith<Exception> { service.read(char) }
-        assertTrue(service.read(char).isEmpty()) // normal after reset
+        assertTrue(service.read(char).isEmpty(), "Read should return empty after exception reset")
     }
 
     @Test

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.testing
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.ble.BleCharacteristic
+import org.meshtastic.core.ble.BleWriteType
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -31,10 +32,10 @@ class FakeBleServiceFailureInjectionTest {
     @Test
     fun writeExceptionIsPersistent() = runTest {
         service.writeException = Exception("write-fail")
-        assertFailsWith<Exception> { service.write(char, ByteArray(0)) }
+        assertFailsWith<Exception> { service.write(char, ByteArray(0), BleWriteType.WITH_RESPONSE) }
         // writeException is persistent — tests must explicitly clear it
         service.writeException = null
-        service.write(char, ByteArray(1))
+        service.write(char, ByteArray(1), BleWriteType.WITH_RESPONSE)
         assertTrue(service.writes.size == 1)
     }
 

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.core.testing
 
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
@@ -71,13 +72,7 @@ class FakeBleServiceFailureInjectionTest {
 
         var subscribed = false
         service.emitNotification(otherChar.uuid, byteArrayOf(1))
-        withTimeoutOrNull(100) {
-            service
-                .observe(otherChar) { subscribed = true }
-                .collect {
-                    return@withTimeoutOrNull
-                }
-        }
+        withTimeoutOrNull(100) { service.observe(otherChar) { subscribed = true }.first() }
         assertTrue(subscribed, "Other characteristic should still subscribe normally")
     }
 

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeBleServiceFailureInjectionTest.kt
@@ -29,10 +29,12 @@ class FakeBleServiceFailureInjectionTest {
     private val service = FakeBleService()
 
     @Test
-    fun writeExceptionIsThrownAndReset() = runTest {
+    fun writeExceptionIsPersistent() = runTest {
         service.writeException = Exception("write-fail")
         assertFailsWith<Exception> { service.write(char, ByteArray(0)) }
-        service.write(char, ByteArray(1)) // no exception after reset
+        // writeException is persistent — tests must explicitly clear it
+        service.writeException = null
+        service.write(char, ByteArray(1))
         assertTrue(service.writes.size == 1)
     }
 

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransportTest.kt
@@ -21,6 +21,7 @@ package org.meshtastic.feature.firmware.ota.dfu
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
@@ -538,7 +539,7 @@ class LegacyDfuTransportTest {
             serviceUuid: kotlin.uuid.Uuid,
             timeout: Duration,
             setup: suspend CoroutineScope.(BleService) -> T,
-        ): T = CoroutineScope(Dispatchers.Unconfined).setup(autoService)
+        ): T = CoroutineScope(currentCoroutineContext()).setup(autoService)
 
         override fun maximumWriteValueLength(writeType: BleWriteType): Int? =
             delegate.maximumWriteValueLength(writeType)

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransportTest.kt
@@ -21,7 +21,6 @@ package org.meshtastic.feature.firmware.ota.dfu
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
@@ -539,7 +538,7 @@ class LegacyDfuTransportTest {
             serviceUuid: kotlin.uuid.Uuid,
             timeout: Duration,
             setup: suspend CoroutineScope.(BleService) -> T,
-        ): T = CoroutineScope(currentCoroutineContext()).setup(autoService)
+        ): T = CoroutineScope(Dispatchers.Unconfined).setup(autoService)
 
         override fun maximumWriteValueLength(writeType: BleWriteType): Int? =
             delegate.maximumWriteValueLength(writeType)

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuTransportTest.kt
@@ -20,7 +20,6 @@ package org.meshtastic.feature.firmware.ota.dfu
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
@@ -650,7 +649,7 @@ class SecureDfuTransportTest {
             serviceUuid: kotlin.uuid.Uuid,
             timeout: Duration,
             setup: suspend CoroutineScope.(BleService) -> T,
-        ): T = CoroutineScope(currentCoroutineContext()).setup(autoService)
+        ): T = CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined).setup(autoService)
 
         override fun maximumWriteValueLength(writeType: BleWriteType): Int? =
             delegate.maximumWriteValueLength(writeType)

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuTransportTest.kt
@@ -20,6 +20,7 @@ package org.meshtastic.feature.firmware.ota.dfu
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
@@ -649,7 +650,7 @@ class SecureDfuTransportTest {
             serviceUuid: kotlin.uuid.Uuid,
             timeout: Duration,
             setup: suspend CoroutineScope.(BleService) -> T,
-        ): T = CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined).setup(autoService)
+        ): T = CoroutineScope(currentCoroutineContext()).setup(autoService)
 
         override fun maximumWriteValueLength(writeType: BleWriteType): Int? =
             delegate.maximumWriteValueLength(writeType)

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuTransportTest.kt
@@ -499,8 +499,8 @@ class SecureDfuTransportTest {
      * emits a DFU notification response. This solves the coroutine ordering problem where `sendCommand()` writes then
      * suspends on `notificationChannel.receive()` — the response must be in the channel before the receive.
      *
-     * Because [FakeBleConnection.profile] runs with [kotlinx.coroutines.Dispatchers.Unconfined], the notification
-     * emitted here propagates immediately through the observation flow into the transport's `notificationChannel`.
+     * Because the transport is constructed with [kotlinx.coroutines.Dispatchers.Unconfined], the notification emitted
+     * here propagates immediately through the observation flow into the transport's `notificationChannel`.
      */
     private class AutoRespondingBleService(val delegate: FakeBleService) : BleService {
         var responder: DfuResponder? = null


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR addresses BLE connection reliability issues in the Meshtastic Android app, focusing on improved exception handling during BLE communication, session-failure recovery, and liveness monitoring. The changes distinguish between fatal BLE failures (which require session restart) and transient errors (which can be retried), implement atomic deduplication to prevent duplicate disconnect callbacks, and add comprehensive test coverage for reconnection scenarios. These fixes also address a test-hanging regression caused by improper use of `CoroutineScope(Dispatchers.Unconfined)` without test scheduler context.

## Key Changes

### Fixes
- **BLE exception classification**: Added `isSessionFatalBleException()` extension to reliably identify session-fatal BLE conditions (`NotConnectedException`, specific GATT status codes) versus transient errors
- **KableMeshtasticRadioProfile**: Refactored exception handling in `fromRadio` setup and read loops to propagate fatal exceptions while suppressing and retrying transient BLE errors with configurable delay
- **BleRadioTransport**: Implemented atomic `sessionFailed` CAS-based deduplication to ensure only the first session failure triggers disconnect cleanup, preventing duplicate `onDisconnect` callbacks and stale service state
- **BleRadioTransport send path**: Rewrote to check for null/stale profiles before write attempts and ignore stale write failures, preventing operations on cleared sessions
- **BleRadioTransport subscription readiness**: Added bounded timeout (`SUBSCRIPTION_READY_TIMEOUT`) with cleanup to prevent half-initialized write state when subscription setup hangs
- **BleRadioTransport connected gate**: Added bounded timeout (`CONNECTED_GATE_TIMEOUT`) to prevent reconnect hangs on missing connection state transitions
- **SharedRadioInterfaceService liveness**: Refactored timeout/recovery logic with single-guarded restart via `isRestarting` CAS, non-permanent disconnect emission, and suppression of polite-disconnect frames during recovery to avoid stale payload sends

### Enhancements
- **FakeBleService failure injection**: Added configurable `writeException`, `readException`, `observeException` fields with per-characteristic maps to enable precise failure-injection testing
- **FakeBleService observation**: Added `onStart` callbacks with pre-subscription failure injection to test subscription-setup failures
- **Atomic counters**: Converted packet/throughput counters from volatile primitives to `AtomicLong` for more reliable concurrent access
- **SharedRadioInterfaceService clock injection**: Added injectable `clockMillis` seam to allow tests to control liveness timing deterministically
- **TestCoroutineScheduler compatibility**: Ensured BLE test helpers maintain proper coroutine context inheritance so `TestCoroutineScheduler` can drive timeouts (fixing test hangs)

### Test Coverage
- **KableMeshtasticRadioProfileExceptionTest**: New test class covering fatal/non-fatal `fromRadio` read exceptions, recovery after transient errors, `logRadio` observation failures, and subscription-readiness blocking
- **BleExceptionClassifierTest**: New coverage for fatal/transient GATT status detection and cause-chain traversal
- **BleRadioTransportReconnectCrashTest**: Expanded from 45 → 813 lines with 15 new test cases covering write-path session failures, `CancellationException` suppression, stale service cleanup, `FROMNUM` readiness timeouts, connected-gate timeout, and concurrent read/write failure deduplication
- **FakeBleServiceFailureInjectionTest**: New test class validating exception injection semantics for reads, writes, and observations including pre-subscription failures and "never subscribe" characteristics
- **SharedRadioInterfaceServiceLivenessTest**: New comprehensive test suite covering BLE liveness timeout/restart, prevention of overlapping restarts via atomic guard, permanent/non-permanent disconnect distinction, and non-BLE transport isolation

### Refactors
- **FakeBleConnection.profile()**: Added clarifying comments on continued use of `Dispatchers.Unconfined` for synchronous notification delivery (test-side only)
- **SharedRadioInterfaceService.stopTransportLocked()**: Added explicit parameters (`notifyPermanent`, `sendPoliteDisconnect`) to control disconnect semantics during recovery paths
- **BleRadioTransport handleFailure()**: Unified failure path with dedup guard, explicit `sessionFailureCause` storage, and async cleanup under `NonCancellable`
- **Build dependencies**: Added `kotlinx.atomicfu` to `core/network` and `core/testing` test dependencies

### Minor Updates
- **FDroidNetworkModule**: Updated API stub to return empty/default responses instead of throwing exceptions, avoiding unnecessary stack traces on refresh
- **AndroidCompose**: Removed `androidx.compose.runtime:runtime-tracing` to prevent debug UI stutter; can be re-enabled via `debugRuntimeOnly` for profiling

## Breaking Changes

None. No public API signatures were altered; changes are internal refinements to BLE connection handling and test infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->