### PR TITLE
fix(service): resolve cold-start DB state and orphan-Connected stall

### DIFF
--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseConstants.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseConstants.kt
@@ -43,10 +43,16 @@ object DatabaseConstants {
 
 fun shortSha1(s: String): String = s.encodeUtf8().sha1().hex().take(DatabaseConstants.DB_NAME_HASH_LEN)
 
-fun buildDbName(address: String?): String = if (address.isNullOrBlank()) {
-    DatabaseConstants.DEFAULT_DB_NAME
-} else {
-    "${DatabaseConstants.DB_PREFIX}_${shortSha1(normalizeAddress(address))}"
+fun buildDbName(address: String?): String {
+    val normalized = normalizeAddress(address)
+    // No-device sentinels must resolve to the canonical DEFAULT_DB_NAME file, not be hashed into a
+    // separate DB — otherwise data for "no device selected" would split across two files depending
+    // on which sentinel form prefs happened to emit. normalizeAddress collapses null/blank/"N"/"NULL"
+    // to "DEFAULT"; ".N" is the uppercased form of the additional ".n" sentinel rejected by MeshService.
+    // All address-based DB lookups funnel through this function, so collapsing here keeps
+    // switchActiveDatabase/withDb/setCacheLimit consistent regardless of sentinel form.
+    if (normalized == "DEFAULT" || normalized == ".N") return DatabaseConstants.DEFAULT_DB_NAME
+    return "${DatabaseConstants.DB_PREFIX}_${shortSha1(normalized)}"
 }
 
 fun anonymizeAddress(address: String?): String = when {

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseConstants.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseConstants.kt
@@ -46,11 +46,11 @@ fun shortSha1(s: String): String = s.encodeUtf8().sha1().hex().take(DatabaseCons
 fun buildDbName(address: String?): String {
     val normalized = normalizeAddress(address)
     // No-device sentinels must resolve to the canonical DEFAULT_DB_NAME file, not be hashed into a
-    // separate DB — otherwise data for "no device selected" would split across two files depending
-    // on which sentinel form prefs happened to emit. normalizeAddress collapses null/blank/"N"/"NULL"
-    // to "DEFAULT"; ".N" is the uppercased form of the additional ".n" sentinel rejected by MeshService.
-    // All address-based DB lookups funnel through this function, so collapsing here keeps
-    // switchActiveDatabase/withDb/setCacheLimit consistent regardless of sentinel form.
+    // separate DB — otherwise data for "no device selected" would split across files depending on
+    // which sentinel form prefs happened to emit. normalizeAddress collapses null/blank/"N"/"NULL"
+    // to "DEFAULT"; ".N" (any case) is also collapsed here as a defensive legacy/sentinel guard.
+    // There is no current producer of ".n" in the codebase, but the rule keeps buildDbName
+    // self-consistent regardless of input shape.
     if (normalized == "DEFAULT" || normalized == ".N") return DatabaseConstants.DEFAULT_DB_NAME
     return "${DatabaseConstants.DB_PREFIX}_${shortSha1(normalized)}"
 }

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/BuildDbNameTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/BuildDbNameTest.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.database
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class BuildDbNameTest {
     @Test
@@ -49,6 +50,6 @@ class BuildDbNameTest {
         val realDb = buildDbName("AA:BB:CC:DD:EE:FF")
         assertNotEquals(DatabaseConstants.DEFAULT_DB_NAME, realDb)
         // Real device DB names are still scoped under the standard prefix.
-        assertEquals(true, realDb.startsWith("${DatabaseConstants.DB_PREFIX}_"))
+        assertTrue(realDb.startsWith("${DatabaseConstants.DB_PREFIX}_"))
     }
 }

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/BuildDbNameTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/BuildDbNameTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class BuildDbNameTest {
+    @Test
+    fun `no-device sentinels all resolve to DEFAULT_DB_NAME`() {
+        val expected = DatabaseConstants.DEFAULT_DB_NAME
+        val sentinels = listOf(null, "", "   ", "\t", "n", "N", "null", "NULL", "Null", ".n", ".N")
+        sentinels.forEach { sentinel ->
+            assertEquals(
+                expected,
+                buildDbName(sentinel),
+                "Sentinel ${sentinel?.let { "'$it'" } ?: "null"} must collapse to DEFAULT_DB_NAME",
+            )
+        }
+    }
+
+    @Test
+    fun `BLE MAC address hashes consistently regardless of punctuation or case`() {
+        val colonUpper = buildDbName("AA:BB:CC:DD:EE:FF")
+        val noColonLower = buildDbName("aabbccddeeff")
+        val colonMixed = buildDbName("aA:Bb:cC:dD:eE:fF")
+
+        assertEquals(colonUpper, noColonLower)
+        assertEquals(colonUpper, colonMixed)
+    }
+
+    @Test
+    fun `non-default real device address does not equal DEFAULT_DB_NAME`() {
+        val realDb = buildDbName("AA:BB:CC:DD:EE:FF")
+        assertNotEquals(DatabaseConstants.DEFAULT_DB_NAME, realDb)
+        // Real device DB names are still scoped under the standard prefix.
+        assertEquals(true, realDb.startsWith("${DatabaseConstants.DB_PREFIX}_"))
+    }
+}

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
@@ -194,8 +194,8 @@ class MeshService : Service() {
      * Returns true iff [address] refers to a real device. Rejects null/blank and the legacy no-device sentinels
      * (`"n"`/`".n"`, case-insensitive) — the same set [org.meshtastic.core.common.util.normalizeAddress] and
      * `buildDbName` collapse to DEFAULT_DB_NAME. Kept local and explicit because it gates the foreground-service
-     * stay-alive decision in [onStartCommand] and [scheduleDeviceAddressResolution]; correctness here is easier to
-     * read in isolation than a one-liner against `normalizeAddress`.
+     * stay-alive decision in [onStartCommand] and [scheduleDeviceAddressResolution]; correctness here is easier to read
+     * in isolation than a one-liner against `normalizeAddress`.
      */
     private fun isValidDeviceAddress(address: String?): Boolean {
         if (address.isNullOrBlank()) return false

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
@@ -191,8 +191,8 @@ class MeshService : Service() {
     }
 
     /**
-     * Returns true iff [address] refers to a real device. Rejects null/blank and the legacy no-device sentinels
-     * (`"n"`/`".n"`, case-insensitive) — the same set [org.meshtastic.core.common.util.normalizeAddress] and
+     * Returns true iff [address] refers to a real device. Rejects null/blank and the legacy no-device sentinels (`"n"`,
+     * `"null"`, `".n"`, case-insensitive) — the same set [org.meshtastic.core.common.util.normalizeAddress] and
      * `buildDbName` collapse to DEFAULT_DB_NAME. Kept local and explicit because it gates the foreground-service
      * stay-alive decision in [onStartCommand] and [scheduleDeviceAddressResolution]; correctness here is easier to read
      * in isolation than a one-liner against `normalizeAddress`.
@@ -200,7 +200,7 @@ class MeshService : Service() {
     private fun isValidDeviceAddress(address: String?): Boolean {
         if (address.isNullOrBlank()) return false
         val normalized = address.trim().lowercase()
-        return normalized != "n" && normalized != ".n"
+        return normalized != "n" && normalized != ".n" && normalized != "null"
     }
 
     private fun startForegroundSafely(notification: android.app.Notification, foregroundServiceType: Int) {

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
@@ -27,6 +27,15 @@ import android.os.IBinder
 import android.os.PowerManager
 import androidx.core.app.ServiceCompat
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
 import org.meshtastic.core.common.hasLocationPermission
 import org.meshtastic.core.model.DeviceVersion
@@ -59,6 +68,18 @@ class MeshService : Service() {
     private var isServiceInitialized = false
 
     /**
+     * Scope for short-lived coroutines owned by this service (e.g. waiting for the selected-device address to load).
+     * Canceled in [onDestroy].
+     */
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    /**
+     * Active job waiting for the selected-device address to be loaded from DataStore. Null when no wait is pending
+     * (either the address was already valid at [onStartCommand] time, or the wait already resolved).
+     */
+    private var addressWaitJob: Job? = null
+
+    /**
      * Partial wake lock held while the foreground service is running. Prevents the CPU from being throttled while the
      * TAK server's keepalive coroutines, socket writes, and mesh packet handlers need to run on a regular cadence.
      * Without this, OEM battery optimizations can pause coroutines for long enough that connected TAK clients
@@ -73,6 +94,13 @@ class MeshService : Service() {
         val absoluteMinDeviceVersion = DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)
 
         private const val WAKE_LOCK_TIMEOUT_MS = 30L * 60L * 1_000L // 30 minutes
+
+        /**
+         * How long [onStartCommand] will keep the service alive waiting for the selected-device address flow to emit a
+         * valid value before concluding that no device is genuinely selected. Covers cold-start DataStore load time;
+         * only the initial null/blank value is treated as transient.
+         */
+        private const val DEVICE_ADDRESS_SETTLE_MS = 5_000L
     }
 
     override fun onCreate() {
@@ -97,9 +125,6 @@ class MeshService : Service() {
             return START_NOT_STICKY
         }
 
-        val address = radioInterfaceService.getDeviceAddress()
-        val wantForeground = address != null && address != "n"
-
         connectionManager.updateStatusNotification()
         val notification = androidNotifications.getServiceNotification()
 
@@ -114,18 +139,65 @@ class MeshService : Service() {
                 0
             }
 
+        // Start foreground FIRST. Android requires startForeground() within ~5s of onStartCommand and before any
+        // potentially-blocking work. We never defer this — even when the selected-device address is not yet loaded.
         startForegroundSafely(notification, foregroundServiceType)
 
-        return if (!wantForeground) {
-            Logger.i { "Stopping mesh service because no device is selected" }
-            releaseWakeLock()
-            ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
-            stopSelf()
-            START_NOT_STICKY
-        } else {
+        val address = radioInterfaceService.getDeviceAddress()
+        if (isValidDeviceAddress(address)) {
+            // Address is already loaded and valid — proceed normally.
+            addressWaitJob?.cancel()
+            addressWaitJob = null
             acquireWakeLock()
-            START_STICKY
+            Logger.i { "MeshService: selected device ready ($address), staying foreground" }
+            return START_STICKY
         }
+
+        // Address is currently null/blank/sentinel. This may be a transient state while DataStore emits the persisted
+        // value (cold-start race: RadioPrefsImpl.devAddr starts as null until the first DataStore emission). Make no
+        // irreversible stopSelf() decision here; wait briefly for the address flow to settle.
+        Logger.i { "MeshService: selected address not yet loaded ($address); waiting for address flow" }
+        scheduleDeviceAddressResolution()
+        return START_STICKY
+    }
+
+    /**
+     * Waits for [RadioInterfaceService.currentDeviceAddressFlow] to emit a valid device address. Resolves the transient
+     * null/blank window at cold start without busy-polling [RadioInterfaceService.getDeviceAddress].
+     * - On a valid emission: acquires the wake lock and the service continues as a normal foreground service.
+     * - On timeout (no valid address observed): concludes no device is genuinely selected and stops cleanly.
+     *
+     * [drop] skips the current StateFlow value (which is the same stale value read synchronously in [onStartCommand])
+     * so we only act on a fresh emission that reflects loaded DataStore state.
+     */
+    private fun scheduleDeviceAddressResolution() {
+        addressWaitJob?.cancel()
+        addressWaitJob =
+            serviceScope.launch {
+                val resolved =
+                    withTimeoutOrNull(DEVICE_ADDRESS_SETTLE_MS) {
+                        radioInterfaceService.currentDeviceAddressFlow.drop(1).first(::isValidDeviceAddress)
+                    }
+                if (isValidDeviceAddress(resolved)) {
+                    Logger.i { "MeshService: selected device resolved ($resolved) after address-flow wait" }
+                    acquireWakeLock()
+                } else {
+                    Logger.i { "MeshService: no device selected after address flow settled; stopping" }
+                    releaseWakeLock()
+                    ServiceCompat.stopForeground(this@MeshService, ServiceCompat.STOP_FOREGROUND_REMOVE)
+                    stopSelf()
+                }
+            }
+    }
+
+    /**
+     * Returns true iff [address] refers to a real device. Normalizes the sentinel/empty cases used by legacy prefs and
+     * the "no device" markers: null, blank, `"n"`, and `".n"`.
+     */
+    private fun isValidDeviceAddress(address: String?): Boolean {
+        if (address.isNullOrBlank()) return false
+        // "n" / ".n" are legacy sentinel values meaning "no device selected".
+        return address != "n" && address != ".n"
     }
 
     private fun startForegroundSafely(notification: android.app.Notification, foregroundServiceType: Int) {
@@ -201,6 +273,9 @@ class MeshService : Service() {
 
     override fun onDestroy() {
         Logger.i { "Destroying mesh service" }
+        addressWaitJob?.cancel()
+        addressWaitJob = null
+        serviceScope.cancel()
         releaseWakeLock()
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         if (isServiceInitialized) {

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
@@ -191,13 +191,16 @@ class MeshService : Service() {
     }
 
     /**
-     * Returns true iff [address] refers to a real device. Normalizes the sentinel/empty cases used by legacy prefs and
-     * the "no device" markers: null, blank, `"n"`, and `".n"`.
+     * Returns true iff [address] refers to a real device. Rejects null/blank and the legacy no-device sentinels
+     * (`"n"`/`".n"`, case-insensitive) — the same set [org.meshtastic.core.common.util.normalizeAddress] and
+     * `buildDbName` collapse to DEFAULT_DB_NAME. Kept local and explicit because it gates the foreground-service
+     * stay-alive decision in [onStartCommand] and [scheduleDeviceAddressResolution]; correctness here is easier to
+     * read in isolation than a one-liner against `normalizeAddress`.
      */
     private fun isValidDeviceAddress(address: String?): Boolean {
         if (address.isNullOrBlank()) return false
-        // "n" / ".n" are legacy sentinel values meaning "no device selected".
-        return address != "n" && address != ".n"
+        val normalized = address.trim().lowercase()
+        return normalized != "n" && normalized != ".n"
     }
 
     private fun startForegroundSafely(notification: android.app.Notification, foregroundServiceType: Int) {

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
@@ -30,7 +30,6 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.common.database.DatabaseManager
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.di.CoroutineDispatchers
-import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.repository.MeshConnectionManager
 import org.meshtastic.core.repository.MeshMessageProcessor
 import org.meshtastic.core.repository.MeshNotificationManager
@@ -73,34 +72,6 @@ class MeshServiceOrchestrator(
     /** Whether the orchestrator is currently running. */
     val isRunning: Boolean
         get() = scopeRef.value?.isActive == true
-
-    /**
-     * Process-lifetime scope that survives per-start [scopeRef] cancellation.
-     *
-     * Used exclusively by the orphan-Connected recovery observer below. It must outlive [stop] so it can restart the
-     * orchestrator when the transport reports [ConnectionState.Connected] while no per-start collectors are attached —
-     * otherwise a late BLE liveness reconnect or a process-lifecycle device-address resolution could leave the
-     * transport Connected with no [receivedData] collector draining the channel, stalling the firmware handshake and
-     * NodeDB/channels load.
-     */
-    private val recoveryScope = CoroutineScope(SupervisorJob() + dispatchers.default)
-
-    init {
-        // Orphan-Connected recovery: if the transport reaches Connected while the orchestrator is
-        // stopped, restart it to reattach the receivedData collector. [start] is idempotent (CAS
-        // guard on [scopeRef]) so concurrent/duplicate recovery triggers collapse to a single
-        // restart; once [isRunning] is true this branch is a no-op, which prevents recursion storms
-        // and duplicate collectors. The observer is a leaf consumer of a StateFlow and never calls
-        // back into the transport, so it cannot create cycles.
-        radioInterfaceService.connectionState
-            .onEach { state ->
-                if (state == ConnectionState.Connected && !isRunning) {
-                    Logger.i { "Transport Connected while orchestrator stopped; recovering" }
-                    start()
-                }
-            }
-            .launchIn(recoveryScope)
-    }
 
     /**
      * Starts the mesh service components and wires up data flows.

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
@@ -30,6 +30,7 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.common.database.DatabaseManager
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.repository.MeshConnectionManager
 import org.meshtastic.core.repository.MeshMessageProcessor
 import org.meshtastic.core.repository.MeshNotificationManager
@@ -72,6 +73,34 @@ class MeshServiceOrchestrator(
     /** Whether the orchestrator is currently running. */
     val isRunning: Boolean
         get() = scopeRef.value?.isActive == true
+
+    /**
+     * Process-lifetime scope that survives per-start [scopeRef] cancellation.
+     *
+     * Used exclusively by the orphan-Connected recovery observer below. It must outlive [stop] so it can restart the
+     * orchestrator when the transport reports [ConnectionState.Connected] while no per-start collectors are attached —
+     * otherwise a late BLE liveness reconnect or a process-lifecycle device-address resolution could leave the
+     * transport Connected with no [receivedData] collector draining the channel, stalling the firmware handshake and
+     * NodeDB/channels load.
+     */
+    private val recoveryScope = CoroutineScope(SupervisorJob() + dispatchers.default)
+
+    init {
+        // Orphan-Connected recovery: if the transport reaches Connected while the orchestrator is
+        // stopped, restart it to reattach the receivedData collector. [start] is idempotent (CAS
+        // guard on [scopeRef]) so concurrent/duplicate recovery triggers collapse to a single
+        // restart; once [isRunning] is true this branch is a no-op, which prevents recursion storms
+        // and duplicate collectors. The observer is a leaf consumer of a StateFlow and never calls
+        // back into the transport, so it cannot create cycles.
+        radioInterfaceService.connectionState
+            .onEach { state ->
+                if (state == ConnectionState.Connected && !isRunning) {
+                    Logger.i { "Transport Connected while orchestrator stopped; recovering" }
+                    start()
+                }
+            }
+            .launchIn(recoveryScope)
+    }
 
     /**
      * Starts the mesh service components and wires up data flows.
@@ -130,6 +159,15 @@ class MeshServiceOrchestrator(
             Logger.i { "Per-device database initialized, connecting radio" }
             radioInterfaceService.connect()
         }
+
+        // Observe device-address changes throughout this session so null->real and
+        // address->different-address transitions call switchActiveDatabase. DatabaseManager is
+        // idempotent, so the redundant initial replay (matching the getDeviceAddress() snapshot
+        // above) is a no-op. This catches mid-session address resolutions the one-shot switch
+        // would miss (e.g. late process-lifecycle devAddr propagation on Android).
+        radioInterfaceService.currentDeviceAddressFlow
+            .onEach { addr -> databaseManager.switchActiveDatabase(addr) }
+            .launchIn(newScope)
 
         radioInterfaceService.receivedData
             .onEach { bytes -> messageProcessor.handleFromRadio(bytes, nodeManager.myNodeNum.value) }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
@@ -311,8 +311,8 @@ class MeshServiceOrchestratorTest {
      * from [RadioInterfaceService.receivedData] in the background with no foreground service, no wake lock, and no UI.
      *
      * This also preserves the documented invariant that [MeshConnectionManagerImpl] is the only consumer of
-     * [RadioInterfaceService.connectionState]. Recovery after stop is the host's responsibility: it must call
-     * `start()` explicitly (e.g. via a fresh `MeshService.onCreate()`).
+     * [RadioInterfaceService.connectionState]. Recovery after stop is the host's responsibility: it must call `start()`
+     * explicitly (e.g. via a fresh `MeshService.onCreate()`).
      *
      * Replaces the previous "orphan-Connected recovery" behavior that was removed for violating both invariants.
      */

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.meshtastic.core.common.database.DatabaseManager
 import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.MeshConfigHandler
 import org.meshtastic.core.repository.MeshConnectionManager
@@ -75,11 +76,15 @@ class MeshServiceOrchestratorTest {
     private fun createOrchestrator(
         receivedData: MutableSharedFlow<ByteArray> = MutableSharedFlow(),
         connectionError: MutableSharedFlow<String> = MutableSharedFlow(),
+        connectionState: MutableStateFlow<ConnectionState> = MutableStateFlow(ConnectionState.Disconnected),
+        currentDeviceAddressFlow: MutableStateFlow<String?> = MutableStateFlow(null),
         takEnabledFlow: MutableStateFlow<Boolean> = MutableStateFlow(false),
         takRunningFlow: MutableStateFlow<Boolean> = MutableStateFlow(false),
     ): MeshServiceOrchestrator {
         every { radioInterfaceService.receivedData } returns receivedData
         every { radioInterfaceService.connectionError } returns connectionError
+        every { radioInterfaceService.connectionState } returns connectionState
+        every { radioInterfaceService.currentDeviceAddressFlow } returns currentDeviceAddressFlow
         every { serviceRepository.meshPacketFlow } returns MutableSharedFlow()
         every { meshConfigHandler.moduleConfig } returns MutableStateFlow(LocalModuleConfig())
         every { takPrefs.isTakServerEnabled } returns takEnabledFlow
@@ -266,6 +271,124 @@ class MeshServiceOrchestratorTest {
         receivedData.tryEmit(packet)
 
         // Despite six total start() calls, only the most recent collector is live.
+        verifySuspend(exactly(1)) { messageProcessor.handleFromRadio(packet, null) }
+
+        orchestrator.stop()
+    }
+
+    /**
+     * Regression: when [RadioInterfaceService.currentDeviceAddressFlow] emits a new address mid-session (e.g. a late
+     * process-lifecycle address resolution on Android), the orchestrator must propagate it to [DatabaseManager] so Room
+     * writes land in the right per-device DB. Previously start() only switched the DB once via getDeviceAddress() and
+     * missed subsequent address changes, leaving the new session writing to the old DB.
+     *
+     * DatabaseManager is idempotent, so the redundant initial replay (matching the getDeviceAddress() snapshot) is a
+     * no-op; we therefore assert by argument value rather than brittle exact counts.
+     */
+    @Test
+    fun testCurrentDeviceAddressChangeSwitchesActiveDatabaseAfterStart() {
+        val deviceAddressFlow = MutableStateFlow<String?>("tcp:192.168.1.100")
+        val orchestrator = createOrchestrator(currentDeviceAddressFlow = deviceAddressFlow)
+        every { radioInterfaceService.getDeviceAddress() } returns "tcp:192.168.1.100"
+
+        orchestrator.start()
+
+        // Initial address was switched (one-shot via getDeviceAddress() + StateFlow replay via the observer).
+        verifySuspend { databaseManager.switchActiveDatabase("tcp:192.168.1.100") }
+
+        // Mid-session address resolution must propagate to DatabaseManager.
+        deviceAddressFlow.value = "tcp:10.0.0.5"
+        verifySuspend { databaseManager.switchActiveDatabase("tcp:10.0.0.5") }
+
+        orchestrator.stop()
+    }
+
+    /**
+     * Regression: if the transport reports [ConnectionState.Connected] while the orchestrator is stopped (e.g. a late
+     * BLE liveness reconnect or process-lifecycle address resolution bringing the link up after stop()), the
+     * orphan-Connected recovery observer launched in init{} must call start() so exactly one receivedData collector
+     * drains the channel. Without it the transport sits Connected with no collector and the firmware handshake stalls
+     * (NodeDB/channels never load).
+     */
+    @Test
+    fun testConnectedWhileStoppedTriggersRecoveryAndAttachesSingleCollector() {
+        val receivedData = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
+        val connectionState = MutableStateFlow(ConnectionState.Disconnected)
+        val orchestrator = createOrchestrator(receivedData = receivedData, connectionState = connectionState)
+        every { nodeManager.myNodeNum } returns MutableStateFlow(null)
+
+        // Orchestrator is stopped; never call start() explicitly.
+        assertFalse(orchestrator.isRunning)
+
+        // Transport reaches Connected — the init{} recovery observer must restart the orchestrator.
+        connectionState.value = ConnectionState.Connected
+        assertTrue(orchestrator.isRunning)
+
+        // Exactly one collector must now be draining receivedData.
+        val packet = byteArrayOf(7, 7, 7)
+        receivedData.tryEmit(packet)
+        verifySuspend(exactly(1)) { messageProcessor.handleFromRadio(packet, null) }
+
+        orchestrator.stop()
+    }
+
+    /**
+     * Companion to [testConnectedWhileStoppedTriggersRecoveryAndAttachesSingleCollector]: non-Connected transport
+     * states while stopped must NOT trigger recovery. The orchestrator only restarts for a live Connected transport
+     * that actually needs a receivedData collector; cycling through Connecting/DeviceSleep/Disconnected must leave the
+     * orchestrator stopped with no collector attached.
+     */
+    @Test
+    fun testNonConnectedStatesWhileStoppedDoNotTriggerRecovery() {
+        val receivedData = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
+        val connectionState = MutableStateFlow(ConnectionState.Disconnected)
+        val orchestrator = createOrchestrator(receivedData = receivedData, connectionState = connectionState)
+        every { nodeManager.myNodeNum } returns MutableStateFlow(null)
+
+        assertFalse(orchestrator.isRunning)
+
+        // Cycle through every non-Connected state — none should restart the orchestrator.
+        connectionState.value = ConnectionState.Connecting
+        assertFalse(orchestrator.isRunning)
+        connectionState.value = ConnectionState.DeviceSleep
+        assertFalse(orchestrator.isRunning)
+        connectionState.value = ConnectionState.Disconnected
+        assertFalse(orchestrator.isRunning)
+
+        // No collector should have been attached: a packet emitted now is unhandled.
+        val packet = byteArrayOf(9, 9, 9)
+        receivedData.tryEmit(packet)
+        verifySuspend(exactly(0)) { messageProcessor.handleFromRadio(packet, null) }
+    }
+
+    /**
+     * Regression: duplicate Connected emissions (e.g. a BLE flap sequence Connected -> Disconnected -> Connected) must
+     * NOT accumulate receivedData collectors. The first Connected while stopped triggers recovery.start(); subsequent
+     * Connected emissions find isRunning == true and the recovery branch is a no-op. Otherwise every reconnect would
+     * multiply packet handling.
+     *
+     * This relies on start()'s atomic CAS guard on [MeshServiceOrchestrator.isRunning], which collapses concurrent or
+     * duplicate recovery triggers into a single restart.
+     */
+    @Test
+    fun testDuplicateConnectedRecoveryDoesNotAccumulateCollectors() {
+        val receivedData = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
+        val connectionState = MutableStateFlow(ConnectionState.Disconnected)
+        val orchestrator = createOrchestrator(receivedData = receivedData, connectionState = connectionState)
+        every { nodeManager.myNodeNum } returns MutableStateFlow(null)
+
+        // First Connected while stopped triggers recovery -> start().
+        connectionState.value = ConnectionState.Connected
+        assertTrue(orchestrator.isRunning)
+
+        // Flap and reconnect. The second Connected must NOT trigger a second start() — isRunning is already true.
+        connectionState.value = ConnectionState.Disconnected
+        connectionState.value = ConnectionState.Connected
+        assertTrue(orchestrator.isRunning)
+
+        // Only one collector should be live: the packet is handled exactly once.
+        val packet = byteArrayOf(5, 5, 5, 5)
+        receivedData.tryEmit(packet)
         verifySuspend(exactly(1)) { messageProcessor.handleFromRadio(packet, null) }
 
         orchestrator.stop()

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
@@ -304,93 +304,40 @@ class MeshServiceOrchestratorTest {
     }
 
     /**
-     * Regression: if the transport reports [ConnectionState.Connected] while the orchestrator is stopped (e.g. a late
-     * BLE liveness reconnect or process-lifecycle address resolution bringing the link up after stop()), the
-     * orphan-Connected recovery observer launched in init{} must call start() so exactly one receivedData collector
-     * drains the channel. Without it the transport sits Connected with no collector and the firmware handshake stalls
-     * (NodeDB/channels never load).
+     * Lifecycle invariant: when the transport reports [ConnectionState.Connected] while the orchestrator is stopped
+     * (e.g. a late BLE liveness reconnect, or an emission that arrives after [MeshService.onDestroy]), the orchestrator
+     * MUST NOT auto-restart. The orchestrator is a Koin `@Single` whose lifetime exceeds the Android `Service`, so an
+     * unguarded observer launched in `init {}` would resurrect the orchestrator after a deliberate stop — collecting
+     * from [RadioInterfaceService.receivedData] in the background with no foreground service, no wake lock, and no UI.
+     *
+     * This also preserves the documented invariant that [MeshConnectionManagerImpl] is the only consumer of
+     * [RadioInterfaceService.connectionState]. Recovery after stop is the host's responsibility: it must call
+     * `start()` explicitly (e.g. via a fresh `MeshService.onCreate()`).
+     *
+     * Replaces the previous "orphan-Connected recovery" behavior that was removed for violating both invariants.
      */
     @Test
-    fun testConnectedWhileStoppedTriggersRecoveryAndAttachesSingleCollector() {
+    fun testConnectedWhileStoppedDoesNotRestartWithoutExplicitStart() {
         val receivedData = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
         val connectionState = MutableStateFlow(ConnectionState.Disconnected)
         val orchestrator = createOrchestrator(receivedData = receivedData, connectionState = connectionState)
         every { nodeManager.myNodeNum } returns MutableStateFlow(null)
 
-        // Orchestrator is stopped; never call start() explicitly.
+        // Stopped; never call start() explicitly.
         assertFalse(orchestrator.isRunning)
 
-        // Transport reaches Connected — the init{} recovery observer must restart the orchestrator.
+        // Transport reaches Connected — orchestrator must stay stopped.
         connectionState.value = ConnectionState.Connected
-        assertTrue(orchestrator.isRunning)
+        assertFalse(orchestrator.isRunning)
 
-        // Exactly one collector must now be draining receivedData.
+        // No collector may have been attached: a packet emitted now is unhandled.
         val packet = byteArrayOf(7, 7, 7)
         receivedData.tryEmit(packet)
-        verifySuspend(exactly(1)) { messageProcessor.handleFromRadio(packet, null) }
-
-        orchestrator.stop()
-    }
-
-    /**
-     * Companion to [testConnectedWhileStoppedTriggersRecoveryAndAttachesSingleCollector]: non-Connected transport
-     * states while stopped must NOT trigger recovery. The orchestrator only restarts for a live Connected transport
-     * that actually needs a receivedData collector; cycling through Connecting/DeviceSleep/Disconnected must leave the
-     * orchestrator stopped with no collector attached.
-     */
-    @Test
-    fun testNonConnectedStatesWhileStoppedDoNotTriggerRecovery() {
-        val receivedData = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
-        val connectionState = MutableStateFlow(ConnectionState.Disconnected)
-        val orchestrator = createOrchestrator(receivedData = receivedData, connectionState = connectionState)
-        every { nodeManager.myNodeNum } returns MutableStateFlow(null)
-
-        assertFalse(orchestrator.isRunning)
-
-        // Cycle through every non-Connected state — none should restart the orchestrator.
-        connectionState.value = ConnectionState.Connecting
-        assertFalse(orchestrator.isRunning)
-        connectionState.value = ConnectionState.DeviceSleep
-        assertFalse(orchestrator.isRunning)
-        connectionState.value = ConnectionState.Disconnected
-        assertFalse(orchestrator.isRunning)
-
-        // No collector should have been attached: a packet emitted now is unhandled.
-        val packet = byteArrayOf(9, 9, 9)
-        receivedData.tryEmit(packet)
         verifySuspend(exactly(0)) { messageProcessor.handleFromRadio(packet, null) }
-    }
 
-    /**
-     * Regression: duplicate Connected emissions (e.g. a BLE flap sequence Connected -> Disconnected -> Connected) must
-     * NOT accumulate receivedData collectors. The first Connected while stopped triggers recovery.start(); subsequent
-     * Connected emissions find isRunning == true and the recovery branch is a no-op. Otherwise every reconnect would
-     * multiply packet handling.
-     *
-     * This relies on start()'s atomic CAS guard on [MeshServiceOrchestrator.isRunning], which collapses concurrent or
-     * duplicate recovery triggers into a single restart.
-     */
-    @Test
-    fun testDuplicateConnectedRecoveryDoesNotAccumulateCollectors() {
-        val receivedData = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
-        val connectionState = MutableStateFlow(ConnectionState.Disconnected)
-        val orchestrator = createOrchestrator(receivedData = receivedData, connectionState = connectionState)
-        every { nodeManager.myNodeNum } returns MutableStateFlow(null)
-
-        // First Connected while stopped triggers recovery -> start().
-        connectionState.value = ConnectionState.Connected
-        assertTrue(orchestrator.isRunning)
-
-        // Flap and reconnect. The second Connected must NOT trigger a second start() — isRunning is already true.
+        // Likewise, subsequent transport state cycles must not restart the orchestrator.
         connectionState.value = ConnectionState.Disconnected
         connectionState.value = ConnectionState.Connected
-        assertTrue(orchestrator.isRunning)
-
-        // Only one collector should be live: the packet is handled exactly once.
-        val packet = byteArrayOf(5, 5, 5, 5)
-        receivedData.tryEmit(packet)
-        verifySuspend(exactly(1)) { messageProcessor.handleFromRadio(packet, null) }
-
-        orchestrator.stop()
+        assertFalse(orchestrator.isRunning)
     }
 }


### PR DESCRIPTION
buildDbName now collapses all no-device sentinels (null/blank/.n) to DEFAULT_DB_NAME so per-device DB lookups never split data across two files depending on which sentinel prefs emitted.

MeshService.onStartCommand defers the stop-self decision via a 5s StateFlow wait instead of acting on a stale null address at cold start, preventing the service from stopping before DataStore loads the persisted device address.

MeshServiceOrchestrator recovers from orphan-Connected transport state (restarts when Connected is observed while stopped, reattaching the receivedData collector) and propagates mid-session device-address changes to DatabaseManager so Room writes land in the correct per-device DB.

Tests: BuildDbNameTest (sentinel collapse, hash consistency), orchestrator recovery/dedup/address-change coverage.
