### PR TITLE
Set single connection pool and defer search-index backfill

### DIFF
--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/Converters.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/Converters.kt
@@ -16,7 +16,7 @@
  */
 package org.meshtastic.core.database
 
-import androidx.room3.TypeConverter
+import androidx.room3.ColumnTypeConverter
 import co.touchlab.kermit.Logger
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -42,41 +42,43 @@ class Converters {
         exceptionsWithDebugInfo = false
     }
 
-    @TypeConverter fun dataFromString(value: String): DataPacket = json.decodeFromString(DataPacket.serializer(), value)
+    @ColumnTypeConverter
+    fun dataFromString(value: String): DataPacket = json.decodeFromString(DataPacket.serializer(), value)
 
-    @TypeConverter fun dataToString(value: DataPacket): String = json.encodeToString(DataPacket.serializer(), value)
+    @ColumnTypeConverter
+    fun dataToString(value: DataPacket): String = json.encodeToString(DataPacket.serializer(), value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun bytesToFromRadio(bytes: ByteArray): FromRadio = FromRadio.ADAPTER.decodeOrNull(bytes, Logger) ?: FromRadio()
 
-    @TypeConverter fun fromRadioToBytes(value: FromRadio): ByteArray = FromRadio.ADAPTER.encode(value)
+    @ColumnTypeConverter fun fromRadioToBytes(value: FromRadio): ByteArray = FromRadio.ADAPTER.encode(value)
 
-    @TypeConverter fun bytesToUser(bytes: ByteArray): User = User.ADAPTER.decodeOrNull(bytes, Logger) ?: User()
+    @ColumnTypeConverter fun bytesToUser(bytes: ByteArray): User = User.ADAPTER.decodeOrNull(bytes, Logger) ?: User()
 
-    @TypeConverter fun userToBytes(value: User): ByteArray = User.ADAPTER.encode(value)
+    @ColumnTypeConverter fun userToBytes(value: User): ByteArray = User.ADAPTER.encode(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun bytesToPosition(bytes: ByteArray): Position = Position.ADAPTER.decodeOrNull(bytes, Logger) ?: Position()
 
-    @TypeConverter fun positionToBytes(value: Position): ByteArray = Position.ADAPTER.encode(value)
+    @ColumnTypeConverter fun positionToBytes(value: Position): ByteArray = Position.ADAPTER.encode(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun bytesToTelemetry(bytes: ByteArray): Telemetry = Telemetry.ADAPTER.decodeOrNull(bytes, Logger) ?: Telemetry()
 
-    @TypeConverter fun telemetryToBytes(value: Telemetry): ByteArray = Telemetry.ADAPTER.encode(value)
+    @ColumnTypeConverter fun telemetryToBytes(value: Telemetry): ByteArray = Telemetry.ADAPTER.encode(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun bytesToPaxcounter(bytes: ByteArray): Paxcount = Paxcount.ADAPTER.decodeOrNull(bytes, Logger) ?: Paxcount()
 
-    @TypeConverter fun paxCounterToBytes(value: Paxcount): ByteArray = Paxcount.ADAPTER.encode(value)
+    @ColumnTypeConverter fun paxCounterToBytes(value: Paxcount): ByteArray = Paxcount.ADAPTER.encode(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun bytesToMetadata(bytes: ByteArray): DeviceMetadata =
         DeviceMetadata.ADAPTER.decodeOrNull(bytes, Logger) ?: DeviceMetadata()
 
-    @TypeConverter fun metadataToBytes(value: DeviceMetadata): ByteArray = DeviceMetadata.ADAPTER.encode(value)
+    @ColumnTypeConverter fun metadataToBytes(value: DeviceMetadata): ByteArray = DeviceMetadata.ADAPTER.encode(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromStringList(value: String?): List<String>? {
         if (value == null) {
             return null
@@ -84,7 +86,7 @@ class Converters {
         return Json.decodeFromString<List<String>>(value)
     }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toStringList(list: List<String>?): String? {
         if (list == null) {
             return null
@@ -92,12 +94,13 @@ class Converters {
         return Json.encodeToString(list)
     }
 
-    @TypeConverter fun bytesToByteString(bytes: ByteArray?): ByteString? = bytes?.toByteString()
+    @ColumnTypeConverter fun bytesToByteString(bytes: ByteArray?): ByteString? = bytes?.toByteString()
 
-    @TypeConverter fun byteStringToBytes(value: ByteString?): ByteArray? = value?.toByteArray()
+    @ColumnTypeConverter fun byteStringToBytes(value: ByteString?): ByteArray? = value?.toByteArray()
 
-    @TypeConverter fun messageStatusToInt(value: MessageStatus?): Int = value?.ordinal ?: MessageStatus.UNKNOWN.ordinal
+    @ColumnTypeConverter
+    fun messageStatusToInt(value: MessageStatus?): Int = value?.ordinal ?: MessageStatus.UNKNOWN.ordinal
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun intToMessageStatus(value: Int): MessageStatus = MessageStatus.entries.getOrElse(value) { MessageStatus.UNKNOWN }
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -44,6 +44,7 @@ import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.di.CoroutineDispatchers
+import kotlin.concurrent.Volatile
 import org.meshtastic.core.common.database.DatabaseManager as SharedDatabaseManager
 
 /** Manages per-device Room database instances for node data, with LRU eviction. */
@@ -63,6 +64,12 @@ open class DatabaseManager(
     private val legacyCleanedKey = booleanPreferencesKey(DatabaseConstants.LEGACY_DB_CLEANED_KEY)
 
     private fun lastUsedKey(dbName: String) = longPreferencesKey("db_last_used:$dbName")
+
+    companion object {
+        private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
+    }
+
+    @Volatile private var hasSwitchedOnce = false
 
     override val cacheLimit: StateFlow<Int> =
         datastore.data
@@ -150,8 +157,15 @@ open class DatabaseManager(
         // One-time cleanup: remove legacy DB if present and not active
         managerScope.launch(dispatchers.io) { cleanupLegacyDbIfNeeded(activeDbName = dbName) }
 
-        // Backfill FTS search index for any text messages missing messageText
-        managerScope.launch(dispatchers.io) { backfillSearchIndexIfNeeded(db) }
+        // Backfill FTS search index for any text messages missing messageText.
+        // On cold start, defer this so it does not starve the single DB connection while
+        // the UI is collecting startup flows. Mid-session switches keep fire-and-forget behavior.
+        val isFirstSwitch = !hasSwitchedOnce
+        hasSwitchedOnce = true
+        managerScope.launch(dispatchers.io) {
+            if (isFirstSwitch) delay(BACKFILL_COLD_START_DELAY_MS)
+            backfillSearchIndexIfNeeded(db)
+        }
 
         Logger.i { "Switched active DB to ${anonymizeDbName(dbName)} for address ${anonymizeAddress(address)}" }
     }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -143,13 +143,14 @@ abstract class MeshtasticDatabase : RoomDatabase() {
          * Configures a [RoomDatabase.Builder] with standard settings for this project.
          *
          * @param multiConnection when `true` (default), opens a multi-reader connection pool (`maxNumOfReaders = 4`,
-         *   `maxNumOfWriters = 1`) so reads can run concurrently. Pass `false` to serialize all reads and writes
-         *   through a single connection (no separate reader pool).
+         *   `maxNumOfWriters = 1`) so reads can run concurrently. Pass `false` to explicitly force
+         *   [setSingleConnectionPool], serializing all reads and writes through one connection.
          *
-         * **Android production passes `false`.** Under coroutine cancellation churn (e.g. DB switches via
-         * `flatMapLatest`), the Room KMP reader-pool permit semaphore can wedge: all reader connections report `Free`
-         * but `permits=0`, so every read acquisition times out indefinitely. Single-connection mode eliminates the
-         * separate reader permit pool. See `DatabaseBuilder.kt` (androidMain).
+         * **Android production passes `false`.** Without the explicit `setSingleConnectionPool()` call, Room defaults
+         * to a 4-reader pool for named databases regardless of whether `setMultipleConnectionPool` was called. Under
+         * coroutine cancellation churn (e.g. DB switches via `flatMapLatest`), the reader-pool permit semaphore can
+         * wedge: all reader connections report `Free` but `permits=0`, so every read acquisition times out
+         * indefinitely. Forcing single-connection eliminates the separate reader permit pool entirely.
          *
          * **In-memory databases MUST pass `false`** for deterministic read-after-write: a pooled reader connection can
          * serve a snapshot older than the latest write on the writer connection, so a read immediately after a write
@@ -162,8 +163,18 @@ abstract class MeshtasticDatabase : RoomDatabase() {
         fun <T : RoomDatabase> RoomDatabase.Builder<T>.configureCommon(
             multiConnection: Boolean = true,
         ): RoomDatabase.Builder<T> = this.fallbackToDestructiveMigration(dropAllTables = false)
-            .apply { if (multiConnection) setMultipleConnectionPool(maxNumOfReaders = 4, maxNumOfWriters = 1) }
-            .setQueryCoroutineContext(ioDispatcher)
+            .apply {
+                if (multiConnection) {
+                    setMultipleConnectionPool(maxNumOfReaders = 4, maxNumOfWriters = 1)
+                } else {
+                    setSingleConnectionPool()
+                }
+            }
+            .setQueryCoroutineContext(
+                // limitedParallelism(1) has the same throughput ceiling as the single-connection pool
+                // (already serialized), so this only blocks the cancellation pileup — not real I/O concurrency.
+                if (multiConnection) ioDispatcher else ioDispatcher.limitedParallelism(1),
+            )
     }
 }
 

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -17,11 +17,11 @@
 package org.meshtastic.core.database
 
 import androidx.room3.AutoMigration
+import androidx.room3.ColumnTypeConverters
 import androidx.room3.Database
 import androidx.room3.DeleteColumn
 import androidx.room3.DeleteTable
 import androidx.room3.RoomDatabase
-import androidx.room3.TypeConverters
 import androidx.room3.migration.AutoMigrationSpec
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.database.dao.DeviceHardwareDao
@@ -117,7 +117,7 @@ import org.meshtastic.core.database.entity.TracerouteNodePositionEntity
     exportSchema = true,
 )
 @androidx.room3.ConstructedBy(MeshtasticDatabaseConstructor::class)
-@TypeConverters(Converters::class)
+@ColumnTypeConverters(Converters::class)
 @androidx.room3.DaoReturnTypeConverters(androidx.room3.paging.PagingSourceDaoReturnTypeConverter::class)
 abstract class MeshtasticDatabase : RoomDatabase() {
     abstract fun nodeInfoDao(): NodeInfoDao

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ lifecycle = "2.11.0"
 jetbrains-lifecycle = "2.11.0-beta02"
 navigation3 = "1.1.1"
 paging = "3.5.0"
-room = "3.0.0-alpha06"
+room = "3.0.0-rc01"
 koin = "4.2.2"
 koin-plugin = "1.0.1"
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR addresses Room database connection pooling behavior in the Meshtastic Android project and tightens related coroutine execution so database access doesn’t contend for multiple connections when only single-connection operation is desired. It also adjusts how/when the FTS index backfill runs during the first database switch to avoid competing with initial read flows.

## Key changes
**Fixes**
- `MeshtasticDatabase.configureCommon(...)`:
  - When `multiConnection=false`, explicitly calls `setSingleConnectionPool()` to override Room’s default 4-reader pool behavior.
  - Sets the query coroutine context using `ioDispatcher.limitedParallelism(1)` when `multiConnection=false` (while preserving the existing behavior for `multiConnection=true`).
- `DatabaseManager`:
  - Tracks whether `switchActiveDatabase` has run at least once per process using a `@Volatile` boolean.
  - Defers `backfillSearchIndexIfNeeded(...)` on the cold-start (first switch) by adding a `BACKFILL_COLD_START_DELAY_MS` delay, while keeping the asynchronous backfill approach otherwise.

**Refactors / Documentation**
- Rewrote/expanded `configureCommon` KDoc to document Room’s default 4-reader pool behavior when `setSingleConnectionPool()` is not used, including the described coroutine-cancellation “permit semaphore wedge” failure mode.

## Breaking changes / migration
- No database schema or migration changes are indicated. The main impact is runtime behavior: reduced concurrency for DB queries when `multiConnection=false` and a different timing for initial FTS backfill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->