### PR TITLE
fix(database): defer FTS backfill on cold start and enforce single-connection pool

### DIFF
--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -44,6 +44,7 @@ import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.di.CoroutineDispatchers
+import kotlin.concurrent.Volatile
 import org.meshtastic.core.common.database.DatabaseManager as SharedDatabaseManager
 
 /** Manages per-device Room database instances for node data, with LRU eviction. */
@@ -63,6 +64,12 @@ open class DatabaseManager(
     private val legacyCleanedKey = booleanPreferencesKey(DatabaseConstants.LEGACY_DB_CLEANED_KEY)
 
     private fun lastUsedKey(dbName: String) = longPreferencesKey("db_last_used:$dbName")
+
+    companion object {
+        private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
+    }
+
+    @Volatile private var hasSwitchedOnce = false
 
     override val cacheLimit: StateFlow<Int> =
         datastore.data
@@ -150,8 +157,15 @@ open class DatabaseManager(
         // One-time cleanup: remove legacy DB if present and not active
         managerScope.launch(dispatchers.io) { cleanupLegacyDbIfNeeded(activeDbName = dbName) }
 
-        // Backfill FTS search index for any text messages missing messageText
-        managerScope.launch(dispatchers.io) { backfillSearchIndexIfNeeded(db) }
+        // Backfill FTS search index for any text messages missing messageText.
+        // On cold start, defer this so it does not starve the single DB connection while
+        // the UI is collecting startup flows. Mid-session switches keep fire-and-forget behavior.
+        val isFirstSwitch = !hasSwitchedOnce
+        hasSwitchedOnce = true
+        managerScope.launch(dispatchers.io) {
+            if (isFirstSwitch) delay(BACKFILL_COLD_START_DELAY_MS)
+            backfillSearchIndexIfNeeded(db)
+        }
 
         Logger.i { "Switched active DB to ${anonymizeDbName(dbName)} for address ${anonymizeAddress(address)}" }
     }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -119,6 +119,7 @@ open class DatabaseManager(
         dbCache.getOrPut(dbName) { getDatabaseBuilder(dbName).build() }
 
     /** Switch active database to the one associated with [address]. Serialized via mutex. */
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun switchActiveDatabase(address: String?) = mutex.withLock {
         val dbName = buildDbName(address)
 

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -119,7 +119,6 @@ open class DatabaseManager(
         dbCache.getOrPut(dbName) { getDatabaseBuilder(dbName).build() }
 
     /** Switch active database to the one associated with [address]. Serialized via mutex. */
-    @Suppress("TooGenericExceptionCaught")
     override suspend fun switchActiveDatabase(address: String?) = mutex.withLock {
         val dbName = buildDbName(address)
 
@@ -163,19 +162,7 @@ open class DatabaseManager(
         // the UI is collecting startup flows. The default DB should not consume the cold-start delay.
         val shouldDelayBackfill = dbName != DatabaseConstants.DEFAULT_DB_NAME && !hasDelayedFirstDeviceBackfill
         if (shouldDelayBackfill) hasDelayedFirstDeviceBackfill = true
-        backfillJob?.cancel()
-        backfillJob =
-            managerScope.launch(dispatchers.io) {
-                try {
-                    if (shouldDelayBackfill) delay(BACKFILL_COLD_START_DELAY_MS)
-                    if (_currentDb.value !== db) return@launch
-                    backfillSearchIndexIfNeeded(db)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Logger.w(e) { "Failed to backfill search index for ${anonymizeDbName(dbName)}" }
-                }
-            }
+        scheduleSearchIndexBackfill(dbName = dbName, db = db, shouldDelayBackfill = shouldDelayBackfill)
 
         Logger.i { "Switched active DB to ${anonymizeDbName(dbName)} for address ${anonymizeAddress(address)}" }
     }
@@ -332,6 +319,23 @@ open class DatabaseManager(
                 .onFailure { Logger.w(it) { "Failed to delete legacy database ${anonymizeDbName(legacy)}" } }
         }
         datastore.edit { it[legacyCleanedKey] = true }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun scheduleSearchIndexBackfill(dbName: String, db: MeshtasticDatabase, shouldDelayBackfill: Boolean) {
+        backfillJob?.cancel()
+        backfillJob =
+            managerScope.launch(dispatchers.io) {
+                try {
+                    if (shouldDelayBackfill) delay(BACKFILL_COLD_START_DELAY_MS)
+                    if (_currentDb.value !== db) return@launch
+                    backfillSearchIndexIfNeeded(db)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e) { "Failed to backfill search index for ${anonymizeDbName(dbName)}" }
+                }
+            }
     }
 
     /**

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -26,9 +26,11 @@ import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -65,11 +67,9 @@ open class DatabaseManager(
 
     private fun lastUsedKey(dbName: String) = longPreferencesKey("db_last_used:$dbName")
 
-    companion object {
-        private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
-    }
+    private var backfillJob: Job? = null
 
-    @Volatile private var hasSwitchedOnce = false
+    @Volatile private var hasDelayedFirstDeviceBackfill = false
 
     override val cacheLimit: StateFlow<Int> =
         datastore.data
@@ -158,14 +158,23 @@ open class DatabaseManager(
         managerScope.launch(dispatchers.io) { cleanupLegacyDbIfNeeded(activeDbName = dbName) }
 
         // Backfill FTS search index for any text messages missing messageText.
-        // On cold start, defer this so it does not starve the single DB connection while
-        // the UI is collecting startup flows. Mid-session switches keep fire-and-forget behavior.
-        val isFirstSwitch = !hasSwitchedOnce
-        hasSwitchedOnce = true
-        managerScope.launch(dispatchers.io) {
-            if (isFirstSwitch) delay(BACKFILL_COLD_START_DELAY_MS)
-            backfillSearchIndexIfNeeded(db)
-        }
+        // On the first real device DB, defer this so it does not starve the single DB connection while
+        // the UI is collecting startup flows. The default DB should not consume the cold-start delay.
+        val shouldDelayBackfill = dbName != DatabaseConstants.DEFAULT_DB_NAME && !hasDelayedFirstDeviceBackfill
+        if (shouldDelayBackfill) hasDelayedFirstDeviceBackfill = true
+        backfillJob?.cancel()
+        backfillJob =
+            managerScope.launch(dispatchers.io) {
+                try {
+                    if (shouldDelayBackfill) delay(BACKFILL_COLD_START_DELAY_MS)
+                    if (_currentDb.value !== db) return@launch
+                    backfillSearchIndexIfNeeded(db)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e) { "Failed to backfill search index for ${anonymizeDbName(dbName)}" }
+                }
+            }
 
         Logger.i { "Switched active DB to ${anonymizeDbName(dbName)} for address ${anonymizeAddress(address)}" }
     }
@@ -222,6 +231,7 @@ open class DatabaseManager(
         }
 
     private companion object {
+        private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
         val DB_TERMS = listOf("pool", "database", "connection", "sqlite")
     }
 
@@ -347,6 +357,8 @@ open class DatabaseManager(
 
     /** Closes all open databases and cancels background work. */
     fun close() {
+        backfillJob?.cancel()
+        backfillJob = null
         managerScope.cancel()
         dbCache.values.forEach { it.close() }
         dbCache.clear()

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -23,6 +23,7 @@ import androidx.room3.DeleteColumn
 import androidx.room3.DeleteTable
 import androidx.room3.RoomDatabase
 import androidx.room3.migration.AutoMigrationSpec
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.database.dao.DeviceHardwareDao
 import org.meshtastic.core.database.dao.DeviceLinkDao
@@ -160,6 +161,7 @@ abstract class MeshtasticDatabase : RoomDatabase() {
          * **JVM/iOS production uses `true`** (the default). Revisit if desktop/iOS field logs show similar
          * pool-exhaustion patterns under cancellation churn.
          */
+        @OptIn(ExperimentalCoroutinesApi::class)
         fun <T : RoomDatabase> RoomDatabase.Builder<T>.configureCommon(
             multiConnection: Boolean = true,
         ): RoomDatabase.Builder<T> = this.fallbackToDestructiveMigration(dropAllTables = false)

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -143,13 +143,14 @@ abstract class MeshtasticDatabase : RoomDatabase() {
          * Configures a [RoomDatabase.Builder] with standard settings for this project.
          *
          * @param multiConnection when `true` (default), opens a multi-reader connection pool (`maxNumOfReaders = 4`,
-         *   `maxNumOfWriters = 1`) so reads can run concurrently. Pass `false` to serialize all reads and writes
-         *   through a single connection (no separate reader pool).
+         *   `maxNumOfWriters = 1`) so reads can run concurrently. Pass `false` to explicitly force
+         *   [setSingleConnectionPool], serializing all reads and writes through one connection.
          *
-         * **Android production passes `false`.** Under coroutine cancellation churn (e.g. DB switches via
-         * `flatMapLatest`), the Room KMP reader-pool permit semaphore can wedge: all reader connections report `Free`
-         * but `permits=0`, so every read acquisition times out indefinitely. Single-connection mode eliminates the
-         * separate reader permit pool. See `DatabaseBuilder.kt` (androidMain).
+         * **Android production passes `false`.** Without the explicit `setSingleConnectionPool()` call, Room defaults
+         * to a 4-reader pool for named databases regardless of whether `setMultipleConnectionPool` was called. Under
+         * coroutine cancellation churn (e.g. DB switches via `flatMapLatest`), the reader-pool permit semaphore can
+         * wedge: all reader connections report `Free` but `permits=0`, so every read acquisition times out
+         * indefinitely. Forcing single-connection eliminates the separate reader permit pool entirely.
          *
          * **In-memory databases MUST pass `false`** for deterministic read-after-write: a pooled reader connection can
          * serve a snapshot older than the latest write on the writer connection, so a read immediately after a write
@@ -162,8 +163,18 @@ abstract class MeshtasticDatabase : RoomDatabase() {
         fun <T : RoomDatabase> RoomDatabase.Builder<T>.configureCommon(
             multiConnection: Boolean = true,
         ): RoomDatabase.Builder<T> = this.fallbackToDestructiveMigration(dropAllTables = false)
-            .apply { if (multiConnection) setMultipleConnectionPool(maxNumOfReaders = 4, maxNumOfWriters = 1) }
-            .setQueryCoroutineContext(ioDispatcher)
+            .apply {
+                if (multiConnection) {
+                    setMultipleConnectionPool(maxNumOfReaders = 4, maxNumOfWriters = 1)
+                } else {
+                    setSingleConnectionPool()
+                }
+            }
+            .setQueryCoroutineContext(
+                // limitedParallelism(1) has the same throughput ceiling as the single-connection pool
+                // (already serialized), so this only blocks the cancellation pileup — not real I/O concurrency.
+                if (multiConnection) ioDispatcher else ioDispatcher.limitedParallelism(1),
+            )
     }
 }
 


### PR DESCRIPTION
On cold start, the FTS backfill can starve the single DB connection while the UI collects startup flows. Defer it 2 s on the first switch so the connection is free for reads.

Also explicitly call setSingleConnectionPool() (instead of just omitting the multi-pool call), because Room KMP defaults to a 4-reader pool for named DBs regardless. Without this, the reader-pool permit semaphore wedges under cancellation churn. Add limitedParallelism(1) on the query dispatcher to cap the cancellation pileup without affecting I/O throughput.
