### PR TITLE
Add restartTransport() for WiFi handshake stall recovery

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -249,8 +249,15 @@ class MeshConnectionManagerImpl(
                         // now arrive from app-level Disconnected, bypass the redundant-Connecting guard, and re-enter
                         // handleConnected to restart the handshake cleanly.
                         scope.handledLaunch {
-                            onConnectionChanged(ConnectionState.Disconnected)
-                            radioInterfaceService.restartTransport()
+                            // Fresh Connecting re-check: this sibling runs asynchronously, so app
+                            // state may have advanced out of Connecting between the stall firing and
+                            // execution (e.g. config arrived just in time, or another transition
+                            // landed). Skip the teardown when the handshake has since completed —
+                            // otherwise we would tear down a healthy, fully-connected link.
+                            if (serviceRepository.connectionState.value is ConnectionState.Connecting) {
+                                onConnectionChanged(ConnectionState.Disconnected)
+                                radioInterfaceService.restartTransport()
+                            }
                         }
                         // Return without calling onConnectionChanged here. The sibling job owns both transitions.
                     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -232,8 +232,8 @@ class MeshConnectionManagerImpl(
                         // CRITICAL ordering: onConnectionChanged() below cancels `handshakeTimeout`,
                         // which IS the coroutine running this code — any work chained AFTER the state
                         // flip is not guaranteed to run. Launch the transport restart as a sibling
-                        // Job on the long-lived ServiceScope (SupervisorJob, survives
-                        // handshakeTimeout cancellation) BEFORE the state transition so the WiFi/TCP
+                        // Job on the long-lived ServiceScope (cancelling handshakeTimeout does not
+                        // cascade to siblings) BEFORE the state transition so the WiFi/TCP
                         // split-brain (transport Connected + connectionRequested=true + radioTransport
                         // non-null, which setDeviceAddress's fast-path then blocks against) is broken
                         // even after this coroutine is torn down. restartTransport() is silent

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -229,21 +229,28 @@ class MeshConnectionManagerImpl(
                     action()
                     delay(HANDSHAKE_RETRY_TIMEOUT)
                     if (serviceRepository.connectionState.value is ConnectionState.Connecting) {
-                        // CRITICAL ordering: onConnectionChanged() below cancels `handshakeTimeout`,
-                        // which IS the coroutine running this code — any work chained AFTER the state
-                        // flip is not guaranteed to run. Launch the transport restart as a sibling
-                        // Job on the long-lived ServiceScope (cancelling handshakeTimeout does not
-                        // cascade to siblings) BEFORE the state transition so the WiFi/TCP
-                        // split-brain (transport Connected + connectionRequested=true + radioTransport
-                        // non-null, which setDeviceAddress's fast-path then blocks against) is broken
-                        // even after this coroutine is torn down. restartTransport() is silent
-                        // recovery: it preserves the selected address and the connectionRequested
-                        // gate, re-validates the device address before bringing the transport back
-                        // up, and reuses the isRestarting CAS so it cannot stack with a concurrent
-                        // BLE liveness restart.
                         Logger.e { "Handshake still stalled after retry, requesting forced transport restart" }
-                        scope.handledLaunch { radioInterfaceService.restartTransport() }
-                        onConnectionChanged(ConnectionState.Disconnected)
+                        // Launch a sibling recovery job that performs BOTH the app-level Disconnected transition
+                        // AND the transport restart, in deterministic order. We MUST NOT call onConnectionChanged
+                        // from this handshakeTimeout coroutine after launching the sibling: onConnectionChanged
+                        // cancels handshakeTimeout (the very job running this code), and any work chained after
+                        // the launch is not guaranteed to run. We MUST ALSO NOT leave the explicit Disconnected
+                        // call in this coroutine after the sibling launch — otherwise the sibling's restart
+                        // emissions (DeviceSleep, then Connected) can arrive while the app-level state is still
+                        // Connecting, causing onConnectionChanged's redundant-Connected-while-Connecting guard to
+                        // ignore the fresh Connected emission. That leaves the app Disconnected while transport is
+                        // Connected — the same split-brain this restart path is meant to break.
+                        //
+                        // Inside the sibling: (1) flip app state to Disconnected first — this cancels handshakeTimeout
+                        // (the OUTER timeout job, not this sibling, so the sibling keeps running). (2) THEN call
+                        // restartTransport(), whose emissions (DeviceSleep → Connected) now arrive from app-level
+                        // Disconnected, bypass the redundant-Connecting guard, and re-enter handleConnected to
+                        // restart the handshake cleanly.
+                        scope.handledLaunch {
+                            onConnectionChanged(ConnectionState.Disconnected)
+                            radioInterfaceService.restartTransport()
+                        }
+                        // Return without calling onConnectionChanged here. The sibling job owns both transitions.
                     }
                 }
             }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -229,7 +229,20 @@ class MeshConnectionManagerImpl(
                     action()
                     delay(HANDSHAKE_RETRY_TIMEOUT)
                     if (serviceRepository.connectionState.value is ConnectionState.Connecting) {
-                        Logger.e { "Handshake still stalled after retry, forcing reconnect" }
+                        // CRITICAL ordering: onConnectionChanged() below cancels `handshakeTimeout`,
+                        // which IS the coroutine running this code — any work chained AFTER the state
+                        // flip is not guaranteed to run. Launch the transport restart as a sibling
+                        // Job on the long-lived ServiceScope (SupervisorJob, survives
+                        // handshakeTimeout cancellation) BEFORE the state transition so the WiFi/TCP
+                        // split-brain (transport Connected + connectionRequested=true + radioTransport
+                        // non-null, which setDeviceAddress's fast-path then blocks against) is broken
+                        // even after this coroutine is torn down. restartTransport() is silent
+                        // recovery: it preserves the selected address and the connectionRequested
+                        // gate, re-validates the device address before bringing the transport back
+                        // up, and reuses the isRestarting CAS so it cannot stack with a concurrent
+                        // BLE liveness restart.
+                        Logger.e { "Handshake still stalled after retry, requesting forced transport restart" }
+                        scope.handledLaunch { radioInterfaceService.restartTransport() }
                         onConnectionChanged(ConnectionState.Disconnected)
                     }
                 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -241,11 +241,13 @@ class MeshConnectionManagerImpl(
                         // ignore the fresh Connected emission. That leaves the app Disconnected while transport is
                         // Connected — the same split-brain this restart path is meant to break.
                         //
-                        // Inside the sibling: (1) flip app state to Disconnected first — this cancels handshakeTimeout
-                        // (the OUTER timeout job, not this sibling, so the sibling keeps running). (2) THEN call
-                        // restartTransport(), whose emissions (DeviceSleep → Connected) now arrive from app-level
-                        // Disconnected, bypass the redundant-Connecting guard, and re-enter handleConnected to
-                        // restart the handshake cleanly.
+                        // Inside the sibling: (1) flip app state to Disconnected first. By the time the sibling runs,
+                        // handshakeTimeout has already completed naturally (it launched the sibling and returned), so
+                        // the cancellation onConnectionChanged would attempt is a no-op on an already-completed job —
+                        // and because the sibling is parented to `scope`, not to handshakeTimeout, it survives
+                        // independently. (2) THEN call restartTransport(), whose emissions (DeviceSleep → Connected)
+                        // now arrive from app-level Disconnected, bypass the redundant-Connecting guard, and re-enter
+                        // handleConnected to restart the handshake cleanly.
                         scope.handledLaunch {
                             onConnectionChanged(ConnectionState.Disconnected)
                             radioInterfaceService.restartTransport()

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
@@ -451,8 +451,10 @@ class MeshConnectionManagerImplTest {
 
             // Advance past HANDSHAKE_TIMEOUT_STAGE1 (30s) + HANDSHAKE_RETRY_TIMEOUT (15s) WITHOUT
             // any config arrival. The stall-retry-exceeded branch must fire: the production code
-            // launches restartTransport() on the long-lived ServiceScope BEFORE flipping state to
-            // Disconnected (to dodge the handshakeTimeout self-cancel in onConnectionChanged).
+            // runs BOTH transitions inside one sibling recovery job — onConnectionChanged(Disconnected)
+            // FIRST, then restartTransport() — so the fresh Connected emission from restartTransport
+            // arrives with app-level state already Disconnected and is not ignored by the
+            // redundant-Connecting guard in onConnectionChanged.
             advanceTimeBy(46_000L)
             advanceUntilIdle()
 
@@ -467,22 +469,25 @@ class MeshConnectionManagerImplTest {
     @Test
     fun `Handshake stall recovery orders app disconnect before transport restart emissions`() =
         runTest(testDispatcher) {
-            // Stub restartTransport() to synchronously emit the transport-level restart sequence.
-            // Under the FIXED sibling ordering, the recovery runs onConnectionChanged(Disconnected)
-            // BEFORE restartTransport(): the fresh Connected emission arrives when app-level state
-            // is Disconnected (not Connecting), bypasses the redundant-Connecting guard in
-            // onConnectionChanged, and re-enters handleConnected → state goes back to Connecting.
-            // Under the BROKEN (old) ordering — restartTransport() BEFORE Disconnected — the fresh
-            // Connected arrives while app state is still Connecting → ignored by the redundant-
-            // Connected guard → the subsequent explicit Disconnected lands → final state would be
-            // Disconnected while transport is Connected (split-brain). This assertion is what
-            // distinguishes the two orderings.
-            everySuspend { radioInterfaceService.restartTransport() } calls
-                {
-                    radioConnectionState.value = ConnectionState.DeviceSleep
-                    radioConnectionState.value = ConnectionState.Connected
-                }
-
+            // This test locks in the ordering invariant of the stall-retry-exceeded recovery
+            // sibling: onConnectionChanged(Disconnected) runs FIRST, then restartTransport().
+            // We deliberately do NOT stub restartTransport() — the default mock no-op leaves it
+            // as a pure boundary call so the sibling's two phases can be observed independently.
+            //
+            // After the stall fires and the sibling completes, we MANUALLY replay the
+            // transport-level emissions that the real restartTransport() would produce:
+            //   - DeviceSleep (onDisconnect(isPermanent=false) on the old transport)
+            //   - Connected   (the new transport's onConnect callback)
+            // Under the FIXED ordering, the fresh Connected arrives with app state already
+            // Disconnected, bypasses the redundant-Connecting guard in onConnectionChanged,
+            // and re-enters handleConnected → state returns to Connecting.
+            // Under the BROKEN (old) ordering — restartTransport() BEFORE Disconnected — the
+            // fresh Connected would arrive while app state was still Connecting, the redundant-
+            // Connecting guard would drop it, and the state would never return to Connecting.
+            //
+            // Restructured to be deterministic on JVM CI: rather than relying on a stubbed
+            // restartTransport() lambda whose StateFlow side-effect emissions race with the
+            // flow collector under Mokkery, the test body itself drives the emissions in order.
             manager = createManager(backgroundScope)
             // Disconnected -> Connected: handleConnected() sets Connecting, sends pre-handshake
             // heartbeat, and (after PRE_HANDSHAKE_SETTLE_MS=100ms) calls startConfigOnly() which
@@ -499,26 +504,38 @@ class MeshConnectionManagerImplTest {
             )
 
             // Advance past HANDSHAKE_TIMEOUT_STAGE1 (30s) + HANDSHAKE_RETRY_TIMEOUT (15s) WITHOUT
-            // any config arrival. The stall-retry-exceeded branch fires the recovery sibling,
-            // which (under the fix) runs onConnectionChanged(Disconnected) FIRST and then
-            // restartTransport(). With UnconfinedTestDispatcher the sibling body executes inline;
-            // the stub's DeviceSleep → Connected emissions re-enter handleConnected and set state
-            // back to Connecting.
-            //
-            // Deliberately NOT calling advanceUntilIdle() after this advanceTimeBy: the
-            // post-restart handleConnected re-arms a fresh Stage 1 stall guard, and
-            // advanceUntilIdle would advance virtual time past it (and every subsequent re-arm),
-            // looping the recovery and obscuring the single-shot ordering this test locks in.
-            // advanceTimeBy(46_000L) fires exactly one stall-retry cycle.
+            // any config arrival. The stall-retry-exceeded branch fires the recovery sibling:
+            // onConnectionChanged(Disconnected) FIRST, then restartTransport() (default mock
+            // no-op, so nothing re-arms a stall guard and advanceUntilIdle is safe here).
             advanceTimeBy(46_000L)
+            advanceUntilIdle()
 
             verifySuspend(exactly(1)) { radioInterfaceService.restartTransport() }
             assertEquals(
+                ConnectionState.Disconnected,
+                serviceRepository.connectionState.value,
+                "Sibling must run onConnectionChanged(Disconnected) BEFORE restartTransport() — " +
+                    "proves the app-level Disconnected transition landed",
+            )
+
+            // Manually replay the transport-level restart signals that the real restartTransport()
+            // would emit. DeviceSleep corresponds to onDisconnect(isPermanent=false) on the old
+            // transport; Connected corresponds to the new transport's onConnect callback. With
+            // UnconfinedTestDispatcher each emission is collected synchronously inline, so no
+            // advanceUntilIdle() is needed between them — and none is safe AFTER the Connected
+            // emission, because handleConnected re-arms a fresh Stage 1 stall guard and
+            // advanceUntilIdle would advance virtual time past it (and every subsequent re-arm),
+            // looping the recovery and obscuring the single-shot ordering this test locks in.
+            radioConnectionState.value = ConnectionState.DeviceSleep
+            radioConnectionState.value = ConnectionState.Connected
+
+            assertEquals(
                 ConnectionState.Connecting,
                 serviceRepository.connectionState.value,
-                "Final state should be Connecting (NOT Disconnected): the post-restart fresh " +
-                    "Connected emission re-enters handleConnected because the app-level Disconnected " +
-                    "transition runs BEFORE restartTransport's DeviceSleep → Connected emissions",
+                "Fresh Connected emission must re-enter handleConnected (NOT be ignored by the " +
+                    "redundant-Connecting guard) because the app-level Disconnected transition " +
+                    "already ran BEFORE restartTransport's transport cycle — this is the ordering " +
+                    "invariant under test",
             )
         }
 

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
@@ -465,6 +465,64 @@ class MeshConnectionManagerImplTest {
         }
 
     @Test
+    fun `Handshake stall recovery orders app disconnect before transport restart emissions`() =
+        runTest(testDispatcher) {
+            // Stub restartTransport() to synchronously emit the transport-level restart sequence.
+            // Under the FIXED sibling ordering, the recovery runs onConnectionChanged(Disconnected)
+            // BEFORE restartTransport(): the fresh Connected emission arrives when app-level state
+            // is Disconnected (not Connecting), bypasses the redundant-Connecting guard in
+            // onConnectionChanged, and re-enters handleConnected → state goes back to Connecting.
+            // Under the BROKEN (old) ordering — restartTransport() BEFORE Disconnected — the fresh
+            // Connected arrives while app state is still Connecting → ignored by the redundant-
+            // Connected guard → the subsequent explicit Disconnected lands → final state would be
+            // Disconnected while transport is Connected (split-brain). This assertion is what
+            // distinguishes the two orderings.
+            everySuspend { radioInterfaceService.restartTransport() } calls
+                {
+                    radioConnectionState.value = ConnectionState.DeviceSleep
+                    radioConnectionState.value = ConnectionState.Connected
+                }
+
+            manager = createManager(backgroundScope)
+            // Disconnected -> Connected: handleConnected() sets Connecting, sends pre-handshake
+            // heartbeat, and (after PRE_HANDSHAKE_SETTLE_MS=100ms) calls startConfigOnly() which
+            // arms the Stage 1 stall guard (HANDSHAKE_TIMEOUT_STAGE1 = 30s).
+            radioConnectionState.value = ConnectionState.Connected
+            advanceTimeBy(200)
+            advanceUntilIdle()
+
+            // Pre-condition: Stage 1 is in flight.
+            assertEquals(
+                ConnectionState.Connecting,
+                serviceRepository.connectionState.value,
+                "Manager should be Connecting after radio Connected",
+            )
+
+            // Advance past HANDSHAKE_TIMEOUT_STAGE1 (30s) + HANDSHAKE_RETRY_TIMEOUT (15s) WITHOUT
+            // any config arrival. The stall-retry-exceeded branch fires the recovery sibling,
+            // which (under the fix) runs onConnectionChanged(Disconnected) FIRST and then
+            // restartTransport(). With UnconfinedTestDispatcher the sibling body executes inline;
+            // the stub's DeviceSleep → Connected emissions re-enter handleConnected and set state
+            // back to Connecting.
+            //
+            // Deliberately NOT calling advanceUntilIdle() after this advanceTimeBy: the
+            // post-restart handleConnected re-arms a fresh Stage 1 stall guard, and
+            // advanceUntilIdle would advance virtual time past it (and every subsequent re-arm),
+            // looping the recovery and obscuring the single-shot ordering this test locks in.
+            // advanceTimeBy(46_000L) fires exactly one stall-retry cycle.
+            advanceTimeBy(46_000L)
+
+            verifySuspend(exactly(1)) { radioInterfaceService.restartTransport() }
+            assertEquals(
+                ConnectionState.Connecting,
+                serviceRepository.connectionState.value,
+                "Final state should be Connecting (NOT Disconnected): the post-restart fresh " +
+                    "Connected emission re-enters handleConnected because the app-level Disconnected " +
+                    "transition runs BEFORE restartTransport's DeviceSleep → Connected emissions",
+            )
+        }
+
+    @Test
     fun `Stage 2 node-info stall after retry timeout triggers transport restart`() = runTest(testDispatcher) {
         manager = createManager(backgroundScope)
         radioConnectionState.value = ConnectionState.Connected

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
@@ -24,6 +24,7 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -425,5 +426,102 @@ class MeshConnectionManagerImplTest {
                 "Connected should cancel the sleep timeout; final state should be Connecting",
             )
         }
+    }
+
+    @Test
+    fun `Stage 1 config stall after retry timeout triggers transport restart and ends Disconnected`() =
+        runTest(testDispatcher) {
+            manager = createManager(backgroundScope)
+            // Disconnected -> Connected: handleConnected() sets Connecting, sends pre-handshake
+            // heartbeat, and (after PRE_HANDSHAKE_SETTLE_MS=100ms) calls startConfigOnly() which
+            // arms the Stage 1 stall guard (HANDSHAKE_TIMEOUT_STAGE1 = 30s).
+            radioConnectionState.value = ConnectionState.Connected
+            advanceTimeBy(200)
+            advanceUntilIdle()
+
+            // Pre-condition: Stage 1 is in flight — manager is Connecting and a ToRadio has been sent
+            // (heartbeat + want_config_id). Use at-least-one here so the test isn't brittle on the
+            // exact packet count.
+            assertEquals(
+                ConnectionState.Connecting,
+                serviceRepository.connectionState.value,
+                "Manager should be Connecting after radio Connected",
+            )
+            verify { packetHandler.sendToRadio(any<org.meshtastic.proto.ToRadio>()) }
+
+            // Advance past HANDSHAKE_TIMEOUT_STAGE1 (30s) + HANDSHAKE_RETRY_TIMEOUT (15s) WITHOUT
+            // any config arrival. The stall-retry-exceeded branch must fire: the production code
+            // launches restartTransport() on the long-lived ServiceScope BEFORE flipping state to
+            // Disconnected (to dodge the handshakeTimeout self-cancel in onConnectionChanged).
+            advanceTimeBy(46_000L)
+            advanceUntilIdle()
+
+            verifySuspend(exactly(1)) { radioInterfaceService.restartTransport() }
+            assertEquals(
+                ConnectionState.Disconnected,
+                serviceRepository.connectionState.value,
+                "Stage 1 stall should end in Disconnected after restart is requested",
+            )
+        }
+
+    @Test
+    fun `Stage 2 node-info stall after retry timeout triggers transport restart`() = runTest(testDispatcher) {
+        manager = createManager(backgroundScope)
+        radioConnectionState.value = ConnectionState.Connected
+        // Pre-handshake settle completes; Stage 1 stall guard armed.
+        advanceTimeBy(200)
+        advanceUntilIdle()
+
+        // Drive the connection into Stage 2. In production this is done by the config-flow
+        // manager once Stage 1 config arrives; here we invoke it directly. startNodeInfoOnly()
+        // cancels the Stage 1 stall guard and arms Stage 2 (HANDSHAKE_TIMEOUT_STAGE2 = 60s).
+        manager.startNodeInfoOnly()
+        advanceUntilIdle()
+
+        assertEquals(
+            ConnectionState.Connecting,
+            serviceRepository.connectionState.value,
+            "Manager should still be Connecting entering Stage 2",
+        )
+
+        // Advance past HANDSHAKE_TIMEOUT_STAGE2 (60s) + HANDSHAKE_RETRY_TIMEOUT (15s) WITHOUT
+        // invoking onNodeDbReady(). The stall-retry-exceeded branch must fire.
+        advanceTimeBy(76_000L)
+        advanceUntilIdle()
+
+        verifySuspend(exactly(1)) { radioInterfaceService.restartTransport() }
+        assertEquals(
+            ConnectionState.Disconnected,
+            serviceRepository.connectionState.value,
+            "Stage 2 stall should end in Disconnected after restart is requested",
+        )
+    }
+
+    @Test
+    fun `Handshake completing before stall timeout does not trigger transport restart`() = runTest(testDispatcher) {
+        // Stubs required by onNodeDbReady() (full handshake completion path).
+        everySuspend { commandSender.requestTelemetry(any(), any(), any()) } returns Unit
+        every { nodeManager.myNodeNum } returns MutableStateFlow(123)
+        every { mqttManager.startProxy(any(), any()) } returns Unit
+        everySuspend { historyManager.requestHistoryReplay(any(), any(), any(), any()) } returns Unit
+        every { nodeManager.getMyNodeInfo() } returns null
+
+        manager = createManager(backgroundScope)
+        radioConnectionState.value = ConnectionState.Connected
+        // Pre-handshake settle completes; Stage 1 stall guard armed.
+        advanceTimeBy(200)
+        advanceUntilIdle()
+
+        // Simulate the full handshake completing (config arrives + NodeDB becomes ready).
+        // onNodeDbReady() cancels handshakeTimeout, so the stall-retry-exceeded branch can
+        // never run even if virtual time later crosses the stage windows.
+        manager.onNodeDbReady()
+        advanceUntilIdle()
+
+        // Advance well past BOTH stage windows + retry (Stage 1: 30s+15s, Stage 2: 60s+15s).
+        advanceTimeBy(120_000L)
+        advanceUntilIdle()
+
+        verifySuspend(exactly(0)) { radioInterfaceService.restartTransport() }
     }
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -120,7 +120,9 @@ interface RadioInterfaceService : RadioTransportCallback {
      * - Does **NOT** bypass selected-device validation; the replacement transport is built from the same bonded address
      *   via the normal start path.
      * - Emits ordinary transport-level transitions through the existing [RadioTransportCallback] surface, so observers
-     *   see the same Connecting/Connected lifecycle as a fresh [connect].
+     *   see the transient [ConnectionState.DeviceSleep] state followed by [ConnectionState.Connected] when the
+     *   replacement transport connects. (No [ConnectionState.Connecting] is emitted at the transport layer — that is an
+     *   app-level state set by [MeshConnectionManager], not a transport callback.)
      *
      * Suspends until the teardown/restart cycle completes.
      */

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -101,6 +101,31 @@ interface RadioInterfaceService : RadioTransportCallback {
      */
     suspend fun disconnect()
 
+    /**
+     * Silent recovery for WiFi/TCP handshake stalls: tears down the active transport and re-establishes it in place,
+     * without touching the connection-request gate or the selected device address.
+     *
+     * Invoked by [MeshConnectionManager][org.meshtastic.core.repository.MeshConnectionManager] when the app-level mesh
+     * handshake has stalled past its retry window. The transport itself may still be physically
+     * [ConnectionState.Connected] (e.g. a TCP socket whose radio firmware has stopped responding to `want_config_id`),
+     * so flipping app-level state to [ConnectionState.Disconnected] alone leaves a split-brain: transport Connected +
+     * `connectionRequested=true` + a live `RadioTransport` handle, which then blocks same-node reconnect via
+     * [setDeviceAddress]'s fast-path. This method breaks that deadlock by cycling the transport in place.
+     *
+     * Contract:
+     * - Preserves the selected device address (does not modify [currentDeviceAddressFlow]).
+     * - Preserves the `connectionRequested` gate; **MUST NOT** clear it. Safe to call concurrently with an explicit
+     *   [disconnect] — the internal gate check makes it a no-op in that case.
+     * - Safe to call when no transport is running — implementations must no-op.
+     * - Does **NOT** bypass selected-device validation; the replacement transport is built from the same bonded address
+     *   via the normal start path.
+     * - Emits ordinary transport-level transitions through the existing [RadioTransportCallback] surface, so observers
+     *   see the same Connecting/Connected lifecycle as a fresh [connect].
+     *
+     * Suspends until the teardown/restart cycle completes.
+     */
+    suspend fun restartTransport()
+
     /** Returns the current device address. */
     fun getDeviceAddress(): String?
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -291,7 +291,8 @@ class SharedRadioInterfaceService(
                 // WITHOUT clearing connectionRequested avoids the split-brain where setDeviceAddress's
                 // fast-path would otherwise block same-node reconnect. The caller (MeshConnectionManager)
                 // is responsible for the app-level Disconnected flip; this method only cycles the
-                // transport and emits the normal Connecting/Connected transitions via callbacks.
+                // transport and emits the transport-level DeviceSleep -> Connected transitions via
+                // callbacks (no Connecting — that is an app-level state, not a transport emission).
                 if (!connectionRequested) {
                     Logger.d { "restartTransport: skipped-not-requested" }
                     return@withLock
@@ -332,9 +333,10 @@ class SharedRadioInterfaceService(
                     Logger.d { "restartTransport: aborted, disconnect requested during stop" }
                     return@withLock
                 }
-                // startTransportLocked() re-validates the selected address (no-op if null) and
-                // emits Connecting -> Connected through the transport callbacks as a normal
-                // fresh connect would.
+                // startTransportLocked() re-validates the selected address (no-op if null) and emits
+                // Connected through the transport callbacks (via the new transport's onConnect) once
+                // the fresh transport comes up — there is no Connecting emission at the transport
+                // layer (that is an app-level state owned by MeshConnectionManager).
                 startTransportLocked()
                 Logger.i { "restartTransport: completed" }
             }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -271,40 +271,45 @@ class SharedRadioInterfaceService(
     }
 
     override suspend fun restartTransport() {
-        transportMutex.withLock {
-            // Silent recovery for app-level handshake stalls. The transport may still be physically
-            // up (TCP socket alive, firmware unresponsive to want_config_id), so cycling it in place
-            // WITHOUT clearing connectionRequested avoids the split-brain where setDeviceAddress's
-            // fast-path would otherwise block same-node reconnect. The caller (MeshConnectionManager)
-            // is responsible for the app-level Disconnected flip; this method only cycles the
-            // transport and emits the normal Connecting/Connected transitions via callbacks.
-            if (!connectionRequested) {
-                Logger.d { "restartTransport: skipped-not-requested" }
-                return@withLock
-            }
-            if (getBondedDeviceAddress() == null) {
-                Logger.d { "restartTransport: skipped-no-address" }
-                return@withLock
-            }
-            // Honor the documented "safe no-op when no transport running" contract: environmental
-            // stops (network unavailable, BLE disabled) intentionally preserve
-            // connectionRequested=true so the recovery listeners above can re-bring-up the
-            // transport later. A stale restart job running after such a stop must NOT bypass that
-            // recovery path by creating a transport directly via startTransportLocked().
-            if (radioTransport == null) {
-                Logger.d { "restartTransport: skipped-no-transport" }
-                return@withLock
-            }
-            // Reuse the liveness CAS so a concurrent BLE zombie-recovery restart cannot stack with
-            // this handshake-induced restart — the loser observes isRestarting == true and defers
-            // to the in-flight cycle. startTransportLocked() is idempotent w.r.t. an existing
-            // transport, but the CAS also prevents a double stop/stop race on the teardown side.
-            if (!isRestarting.compareAndSet(expect = false, update = true)) {
-                Logger.d { "restartTransport: skipped, concurrent restart in progress" }
-                return@withLock
-            }
-            Logger.w { "restartTransport: restarting transport for ${getDeviceAddress()?.anonymize}" }
-            try {
+        // CAS BEFORE the mutex, mirroring checkLiveness()'s coordination structure: both
+        // restart paths CAS synchronously, one wins, one loses immediately. Performing the
+        // CAS inside transportMutex.withLock races checkLiveness's outer
+        // `finally { isRestarting = false }` (which runs AFTER mutex release): a queued
+        // restartTransport that resumes from mutex.wait can observe isRestarting == false,
+        // win the CAS, and produce an extra transport cycle (3 instead of 2) under the JVM's
+        // real dispatcher. The loser here observes isRestarting == true and defers to the
+        // in-flight cycle. startTransportLocked() is idempotent w.r.t. an existing transport,
+        // but the CAS also prevents a double stop/stop race on the teardown side.
+        if (!isRestarting.compareAndSet(expect = false, update = true)) {
+            Logger.d { "restartTransport: skipped, concurrent restart in progress" }
+            return
+        }
+        try {
+            transportMutex.withLock {
+                // Silent recovery for app-level handshake stalls. The transport may still be physically
+                // up (TCP socket alive, firmware unresponsive to want_config_id), so cycling it in place
+                // WITHOUT clearing connectionRequested avoids the split-brain where setDeviceAddress's
+                // fast-path would otherwise block same-node reconnect. The caller (MeshConnectionManager)
+                // is responsible for the app-level Disconnected flip; this method only cycles the
+                // transport and emits the normal Connecting/Connected transitions via callbacks.
+                if (!connectionRequested) {
+                    Logger.d { "restartTransport: skipped-not-requested" }
+                    return@withLock
+                }
+                if (getBondedDeviceAddress() == null) {
+                    Logger.d { "restartTransport: skipped-no-address" }
+                    return@withLock
+                }
+                // Honor the documented "safe no-op when no transport running" contract: environmental
+                // stops (network unavailable, BLE disabled) intentionally preserve
+                // connectionRequested=true so the recovery listeners above can re-bring-up the
+                // transport later. A stale restart job running after such a stop must NOT bypass that
+                // recovery path by creating a transport directly via startTransportLocked().
+                if (radioTransport == null) {
+                    Logger.d { "restartTransport: skipped-no-transport" }
+                    return@withLock
+                }
+                Logger.w { "restartTransport: restarting transport for ${getDeviceAddress()?.anonymize}" }
                 // Mirror BLE liveness silent recovery: emit the transport-level Connected ->
                 // DeviceSleep transition BEFORE the stop/start cycle. MeshConnectionManager
                 // observes connectionState and re-triggers handleConnected() when the fresh
@@ -332,9 +337,9 @@ class SharedRadioInterfaceService(
                 // fresh connect would.
                 startTransportLocked()
                 Logger.i { "restartTransport: completed" }
-            } finally {
-                isRestarting.value = false
             }
+        } finally {
+            isRestarting.value = false
         }
     }
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -296,14 +296,24 @@ class SharedRadioInterfaceService(
             }
             Logger.w { "restartTransport: restarting transport for ${getDeviceAddress()?.anonymize}" }
             try {
-                // Mirror BLE liveness silent recovery: notifyPermanent=false (no user-facing
-                // Disconnected modal — the app-level state machine drives that separately) and
-                // sendPoliteDisconnect=false (firmware is unresponsive, writing a goodbye frame
-                // into a dead link only delays teardown).
+                // Mirror BLE liveness silent recovery: emit the transport-level Connected ->
+                // DeviceSleep transition BEFORE the stop/start cycle. MeshConnectionManager
+                // observes connectionState and re-triggers handleConnected() when the fresh
+                // transport's onConnect() fires — but StateFlow is idempotent on same-value,
+                // so without this DeviceSleep emission the subsequent Connected signal would be
+                // a no-op (Connected -> Connected) and the manager would stay stuck on its
+                // app-level Disconnected state. checkLiveness() relies on the same ordering:
+                // it calls onDisconnect(isPermanent = false) before launching its restart
+                // coroutine. This is silent (transient DeviceSleep, not permanent Disconnected).
+                onDisconnect(isPermanent = false)
+                // notifyPermanent=false below (no user-facing Disconnected modal — the app-level
+                // state machine drives that separately) and sendPoliteDisconnect=false (firmware
+                // is unresponsive, writing a goodbye frame into a dead link only delays teardown).
                 ignoreExceptionSuspend { stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false) }
-                // Race window: an explicit disconnect() may have arrived between the gate check
-                // above and the stop. Re-check before restarting so we do not resurrect a
-                // transport the user has torn down. This mirrors the BLE liveness recovery gate.
+                // Defense-in-depth mirroring the liveness recovery gate; today all
+                // connectionRequested mutators (connect/disconnect/setDeviceAddress) hold
+                // transportMutex so this re-check is unreachable, but it guards against future
+                // refactors that mutate the gate without serialization.
                 if (!connectionRequested) {
                     Logger.d { "restartTransport: aborted, disconnect requested during stop" }
                     return@withLock

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -286,6 +286,15 @@ class SharedRadioInterfaceService(
                 Logger.d { "restartTransport: skipped-no-address" }
                 return@withLock
             }
+            // Honor the documented "safe no-op when no transport running" contract: environmental
+            // stops (network unavailable, BLE disabled) intentionally preserve
+            // connectionRequested=true so the recovery listeners above can re-bring-up the
+            // transport later. A stale restart job running after such a stop must NOT bypass that
+            // recovery path by creating a transport directly via startTransportLocked().
+            if (radioTransport == null) {
+                Logger.d { "restartTransport: skipped-no-transport" }
+                return@withLock
+            }
             // Reuse the liveness CAS so a concurrent BLE zombie-recovery restart cannot stack with
             // this handshake-induced restart — the loser observes isRestarting == true and defers
             // to the in-flight cycle. startTransportLocked() is idempotent w.r.t. an existing

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -270,6 +270,55 @@ class SharedRadioInterfaceService(
         }
     }
 
+    override suspend fun restartTransport() {
+        transportMutex.withLock {
+            // Silent recovery for app-level handshake stalls. The transport may still be physically
+            // up (TCP socket alive, firmware unresponsive to want_config_id), so cycling it in place
+            // WITHOUT clearing connectionRequested avoids the split-brain where setDeviceAddress's
+            // fast-path would otherwise block same-node reconnect. The caller (MeshConnectionManager)
+            // is responsible for the app-level Disconnected flip; this method only cycles the
+            // transport and emits the normal Connecting/Connected transitions via callbacks.
+            if (!connectionRequested) {
+                Logger.d { "restartTransport: skipped-not-requested" }
+                return@withLock
+            }
+            if (getBondedDeviceAddress() == null) {
+                Logger.d { "restartTransport: skipped-no-address" }
+                return@withLock
+            }
+            // Reuse the liveness CAS so a concurrent BLE zombie-recovery restart cannot stack with
+            // this handshake-induced restart — the loser observes isRestarting == true and defers
+            // to the in-flight cycle. startTransportLocked() is idempotent w.r.t. an existing
+            // transport, but the CAS also prevents a double stop/stop race on the teardown side.
+            if (!isRestarting.compareAndSet(expect = false, update = true)) {
+                Logger.d { "restartTransport: skipped, concurrent restart in progress" }
+                return@withLock
+            }
+            Logger.w { "restartTransport: restarting transport for ${getDeviceAddress()?.anonymize}" }
+            try {
+                // Mirror BLE liveness silent recovery: notifyPermanent=false (no user-facing
+                // Disconnected modal — the app-level state machine drives that separately) and
+                // sendPoliteDisconnect=false (firmware is unresponsive, writing a goodbye frame
+                // into a dead link only delays teardown).
+                ignoreExceptionSuspend { stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false) }
+                // Race window: an explicit disconnect() may have arrived between the gate check
+                // above and the stop. Re-check before restarting so we do not resurrect a
+                // transport the user has torn down. This mirrors the BLE liveness recovery gate.
+                if (!connectionRequested) {
+                    Logger.d { "restartTransport: aborted, disconnect requested during stop" }
+                    return@withLock
+                }
+                // startTransportLocked() re-validates the selected address (no-op if null) and
+                // emits Connecting -> Connected through the transport callbacks as a normal
+                // fresh connect would.
+                startTransportLocked()
+                Logger.i { "restartTransport: completed" }
+            } finally {
+                isRestarting.value = false
+            }
+        }
+    }
+
     override fun isMockTransport(): Boolean = transportFactory.isMockTransport()
 
     override fun toInterfaceAddress(interfaceId: InterfaceId, rest: String): String =

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -1115,4 +1115,93 @@ class SharedRadioInterfaceServiceLivenessTest {
             advanceTimeBy(1_000L)
         }
     }
+
+    /**
+     * Regression for the `radioTransport == null` gate added to [SharedRadioInterfaceService.restartTransport] (the
+     * third early-return, before the `isRestarting` CAS and the `onDisconnect(isPermanent = false)` call).
+     *
+     * Scenario: a TCP transport has been torn down by an environmental stop (`networkAvailable = false`) but
+     * `connectionRequested` is intentionally preserved so the network recovery listener can re-bring-up the transport
+     * when connectivity returns. A stale handshake-stall restart fired in that window MUST be a no-op:
+     * - It MUST NOT create a fresh transport via `startTransportLocked()` (that would bypass the recovery listener,
+     *   which owns the re-bring-up).
+     * - It MUST NOT emit `DeviceSleep` via `onDisconnect(isPermanent = false)` (the gate returns before that call), so
+     *   the recovery path's later transitions stay meaningful.
+     *
+     * Counter-assertion: the recovery listener itself MUST still function after the gate fires — toggling
+     * `networkAvailable` back to `true` MUST create the second transport, proving the gate did not break the documented
+     * re-bring-up path.
+     */
+    @Test
+    fun `restartTransport is a no-op when transport is environmentally stopped but connection remains requested`() =
+        runTest(testDispatcher) {
+            clock = 0L
+            val networkAvailability = MutableStateFlow<Boolean>(true)
+            val service = createConnectedService("t192.168.1.100", networkAvailability = networkAvailability)
+            try {
+                assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+                val initialTransport = createdTransports.first()
+
+                // Subscribe BEFORE the environmental stop so we capture every state transition through
+                // the stop, the gated restartTransport, and the recovery. _connectionState is a StateFlow
+                // (replays current value to late collectors), so the launch's first emission is Connected.
+                val stateEmissions = mutableListOf<ConnectionState>()
+                val collectJob = backgroundScope.launch { service.connectionState.collect { stateEmissions.add(it) } }
+                testDispatcher.scheduler.runCurrent()
+
+                // Environmental stop: network drops while a TCP transport is running. The network
+                // listener (see initStateListeners) calls stopTransportLocked() with defaults
+                // (notifyPermanent=true → onDisconnect(isPermanent=true) → Disconnected). The transport
+                // is closed and radioTransport becomes null, but connectionRequested STAYS true so the
+                // recovery listener can re-bring-up later.
+                networkAvailability.value = false
+                testDispatcher.scheduler.runCurrent()
+                // Drain the polite-disconnect frame (POLITE_DISCONNECT_DRAIN_MS = 500ms).
+                advanceTimeBy(1_000L)
+
+                assertTrue(initialTransport.closeCalled, "Environmental stop must close the running TCP transport")
+                assertEquals(
+                    1,
+                    createdTransports.size,
+                    "Environmental stop must not create a new transport (only teardown)",
+                )
+
+                // Stale handshake-stall restart fired in the window where radioTransport == null but
+                // connectionRequested is still true. The new gate must short-circuit BEFORE the
+                // isRestarting CAS and BEFORE the onDisconnect(isPermanent=false) DeviceSleep emission.
+                service.restartTransport()
+                testDispatcher.scheduler.runCurrent()
+                advanceTimeBy(1_000L)
+
+                assertEquals(
+                    1,
+                    createdTransports.size,
+                    "restartTransport must be a no-op when radioTransport == null (gate fired)",
+                )
+                assertFalse(
+                    ConnectionState.DeviceSleep in stateEmissions,
+                    "Gated restartTransport must NOT emit DeviceSleep " +
+                        "(returned before onDisconnect(isPermanent=false)); emitted: $stateEmissions",
+                )
+
+                // Environmental recovery: networkAvailable flips back to true. connectionRequested is
+                // still true (neither the environmental stop nor the gated restart cleared it), so the
+                // recovery listener MUST call startTransportLocked() and create the second transport.
+                // This proves the new gate did not break the documented re-bring-up path.
+                networkAvailability.value = true
+                testDispatcher.scheduler.runCurrent()
+                advanceTimeBy(1_000L)
+
+                collectJob.cancel()
+
+                assertEquals(
+                    2,
+                    createdTransports.size,
+                    "Network recovery must re-bring-up the transport after the gated no-op restart (gate still set)",
+                )
+            } finally {
+                service.disconnect()
+                advanceTimeBy(1_000L)
+            }
+        }
 }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -791,10 +791,11 @@ class SharedRadioInterfaceServiceLivenessTest {
     // [SharedRadioInterfaceService.restartTransport] is the app-level handshake-stall recovery
     // path. It mirrors BLE liveness silent recovery: stopTransportLocked(notifyPermanent=false,
     // sendPoliteDisconnect=false) then startTransportLocked(), all under transportMutex. The gate
-    // contract has three legs that MUST hold for the cycle to fire:
+    // contract has four early-return gates (in order) that MUST hold for the cycle to fire:
     //   1. connectionRequested == true  (cleared by disconnect() / setDeviceAddress(null)/("n"))
     //   2. getBondedDeviceAddress() != null  (re-validates the selected address)
-    //   3. isRestarting.compareAndSet(false, true) succeeds  (reuses the liveness CAS)
+    //   3. radioTransport != null  (defends against a stale restart after an environmental stop)
+    //   4. isRestarting.compareAndSet(false, true) succeeds  (reuses the liveness CAS)
     // The cycle must also be address-preserving and silent (no permanent Disconnected, no
     // user-facing error). The tests below lock each leg of that contract.
 
@@ -1025,12 +1026,16 @@ class SharedRadioInterfaceServiceLivenessTest {
      * observes `isRestarting == true` and defers to the in-flight cycle, preventing a double stop/start race on the
      * transport.
      *
+     * restartTransport performs the isRestarting CAS synchronously BEFORE acquiring transportMutex (mirroring
+     * checkLiveness). Under this pattern, a concurrent liveness restart and a handshake-induced restart serialize on
+     * the CAS first — the loser returns immediately without touching the mutex. This is deterministic on all
+     * dispatchers, not just UnconfinedTestDispatcher.
+     *
      * Deterministic in-flight overlap: a [GatedFakeRadioTransport] suspends the liveness restart genuinely inside
-     * stopTransportLocked → close() (awaiting closeGate). Under UnconfinedTestDispatcher, when the liveness coroutine's
-     * `transportMutex.withLock {}` exits and calls `unlock()`, the queued restartTransport coroutine is resumed inline
-     * BEFORE the liveness coroutine's outer `finally { isRestarting.value = false }` runs — so restartTransport's CAS
-     * observes `isRestarting == true` and returns without another cycle. A stacking bug (CAS ignored, or finally
-     * ordering inverted) would produce 3 transports.
+     * stopTransportLocked → close() (awaiting closeGate). While the liveness coroutine holds `isRestarting == true`
+     * inside its restart cycle, a concurrent `restartTransport()` call CAS-fails on `isRestarting` and returns
+     * immediately without ever acquiring `transportMutex`. A stacking bug (CAS ignored, or CAS performed inside the
+     * mutex) would produce 3 transports.
      */
     @Test
     fun `restartTransport coordinates with in-flight liveness restart via isRestarting`() = runTest(testDispatcher) {
@@ -1058,14 +1063,16 @@ class SharedRadioInterfaceServiceLivenessTest {
             clock = 65_000L
             service.checkLiveness()
 
-            // Issue restartTransport() while the liveness restart is suspended. It will
-            // suspend waiting for transportMutex; the body cannot run until liveness releases.
+            // Issue restartTransport() while the liveness restart is in-flight. Under the refactored
+            // CAS-before-mutex pattern, restartTransport's CAS fails immediately (isRestarting is already
+            // true from checkLiveness's synchronous CAS). It returns without acquiring the mutex.
             val restartJob = backgroundScope.launch { service.restartTransport() }
             testDispatcher.scheduler.runCurrent()
 
             try {
                 // Pre-release: liveness still in-flight (close() suspended on closeGate),
-                // restartTransport still queued on mutex. No fresh transport, no stacking.
+                // but restartTransport already returned via CAS-fail on isRestarting (it never
+                // touched transportMutex). No fresh transport from restartTransport, no stacking.
                 assertEquals(
                     1,
                     gatedTransports.size,
@@ -1077,9 +1084,10 @@ class SharedRadioInterfaceServiceLivenessTest {
                     initialTransport.closeCompletedCount,
                     "Liveness restart close() must still be suspended (gate not yet released)",
                 )
-                assertFalse(
+                assertTrue(
                     restartJob.isCompleted,
-                    "restartTransport should be queued on transportMutex, not completed",
+                    "restartTransport should CAS-fail immediately when liveness already holds isRestarting, " +
+                        "not queue on transportMutex",
                 )
             } finally {
                 // Release the gate unconditionally so the suspended liveness restart can
@@ -1088,11 +1096,8 @@ class SharedRadioInterfaceServiceLivenessTest {
                 closeGate.complete(Unit)
             }
 
-            // Resume the liveness restart: close() returns, startTransportLocked creates the
-            // single fresh transport, mutex is released and restartTransport resumes inline.
-            // Under UnconfinedTestDispatcher the inline resume runs BEFORE the liveness
-            // coroutine's outer finally resets isRestarting, so restartTransport's CAS fails
-            // and it returns without another cycle.
+            // Release the gate: liveness restart completes (close + startTransport).
+            // restartTransport already returned via CAS-fail, so no second cycle. Exactly 2 transports.
             testDispatcher.scheduler.runCurrent()
             advanceTimeBy(1_000L)
             restartJob.join()

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -785,4 +785,325 @@ class SharedRadioInterfaceServiceLivenessTest {
                 advanceTimeBy(1_000L)
             }
         }
+
+    // ─── restartTransport gate contract ─────────────────────────────────────────────────────
+    //
+    // [SharedRadioInterfaceService.restartTransport] is the app-level handshake-stall recovery
+    // path. It mirrors BLE liveness silent recovery: stopTransportLocked(notifyPermanent=false,
+    // sendPoliteDisconnect=false) then startTransportLocked(), all under transportMutex. The gate
+    // contract has three legs that MUST hold for the cycle to fire:
+    //   1. connectionRequested == true  (cleared by disconnect() / setDeviceAddress(null)/("n"))
+    //   2. getBondedDeviceAddress() != null  (re-validates the selected address)
+    //   3. isRestarting.compareAndSet(false, true) succeeds  (reuses the liveness CAS)
+    // The cycle must also be address-preserving and silent (no permanent Disconnected, no
+    // user-facing error). The tests below lock each leg of that contract.
+
+    /**
+     * Happy path: [SharedRadioInterfaceService.restartTransport] after a normal [connect] with a selected address stops
+     * the running transport and creates a fresh one. Mirrors the BLE liveness "timeout closes old transport and creates
+     * fresh one" assertion shape.
+     */
+    @Test
+    fun `restartTransport after connect closes old transport and creates fresh one`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            val initialTransport = createdTransports.first()
+
+            service.restartTransport()
+            // sendPoliteDisconnect = false → no 500ms drain inside the cycle. Under
+            // UnconfinedTestDispatcher the whole stop/start runs inline; runCurrent is
+            // belt-and-suspenders. The trailing disconnect() covers its own polite delay.
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(2, createdTransports.size, "restartTransport should create exactly one fresh transport")
+            assertTrue(initialTransport.closeCalled, "Old transport must be closed by restartTransport")
+            assertEquals(1, initialTransport.closeCount, "Old transport closed exactly once (no double-close)")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: [SharedRadioInterfaceService.restartTransport] MUST be a no-op after an explicit
+     * [SharedRadioInterfaceService.disconnect]. disconnect() clears `connectionRequested` BEFORE stopTransportLocked(),
+     * and restartTransport() consults that gate as its first check. Without the gate, a racing handshake-induced
+     * restart would silently resurrect a transport the user tore down.
+     */
+    @Test
+    fun `restartTransport is a no-op after explicit disconnect`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+
+            service.disconnect()
+            advanceTimeBy(1_000L)
+            val transportCountAfterDisconnect = createdTransports.size
+
+            service.restartTransport()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(
+                transportCountAfterDisconnect,
+                createdTransports.size,
+                "restartTransport must not create a transport after disconnect (connectionRequested gate)",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: [SharedRadioInterfaceService.restartTransport] MUST be a no-op after
+     * [SharedRadioInterfaceService.setDeviceAddress] with `null`. The deselect clears `connectionRequested` AND leaves
+     * getBondedDeviceAddress() == null (invalid address); either gate alone is sufficient to skip the restart, but both
+     * must hold to defend against a stale listener emission re-arming the transport.
+     */
+    @Test
+    fun `restartTransport is a no-op after setDeviceAddress null`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+
+            service.setDeviceAddress(null)
+            advanceTimeBy(1_000L)
+            val transportCountAfterDeselect = createdTransports.size
+
+            service.restartTransport()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(
+                transportCountAfterDeselect,
+                createdTransports.size,
+                "restartTransport must not create a transport after setDeviceAddress(null)",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Counterpart to the null-deselect test: `"n"` is the UI sentinel for "no device" and is sanitized to `null` inside
+     * [SharedRadioInterfaceService.setDeviceAddress]. The same gate must skip restartTransport for both forms.
+     */
+    @Test
+    fun `restartTransport is a no-op after setDeviceAddress n`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+
+            service.setDeviceAddress("n")
+            advanceTimeBy(1_000L)
+            val transportCountAfterDeselect = createdTransports.size
+
+            service.restartTransport()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(
+                transportCountAfterDeselect,
+                createdTransports.size,
+                "restartTransport must not create a transport after setDeviceAddress(\"n\")",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: [SharedRadioInterfaceService.restartTransport] cycles the transport in place WITHOUT writing a new
+     * devAddr or clearing currentDeviceAddressFlow. The caller (MeshConnectionManager) is the sole owner of address
+     * changes; restartTransport must never silently re-bind to a different device or evict the selection.
+     */
+    @Test
+    fun `restartTransport preserves selected device address`() = runTest(testDispatcher) {
+        clock = 0L
+        val address = "xAA:BB:CC:DD:EE:FF"
+        val service = createConnectedService(address)
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            val addrBefore = service.getDeviceAddress()
+            val prefsAddrBefore = radioPrefs.devAddr.value
+
+            service.restartTransport()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(
+                addrBefore,
+                service.getDeviceAddress(),
+                "getDeviceAddress must not change across restartTransport",
+            )
+            assertEquals(address, service.getDeviceAddress(), "Selected device address preserved")
+            assertEquals(
+                prefsAddrBefore,
+                radioPrefs.devAddr.value,
+                "radioPrefs.devAddr must not be rewritten by restartTransport",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: [SharedRadioInterfaceService.restartTransport] mirrors BLE liveness silent recovery —
+     * `notifyPermanent=false` so no user-facing Disconnected state is emitted. The caller drives app-level state
+     * transitions separately; surfacing a permanent disconnect for a self-healing cycle would pop a confusing modal for
+     * a transient condition.
+     */
+    @Test
+    fun `restartTransport does not emit permanent Disconnected`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        try {
+            val stateEmissions = mutableListOf<ConnectionState>()
+            val collectJob = backgroundScope.launch { service.connectionState.collect { stateEmissions.add(it) } }
+
+            service.restartTransport()
+            testDispatcher.scheduler.runCurrent()
+
+            collectJob.cancel()
+
+            assertFalse(
+                ConnectionState.Disconnected in stateEmissions,
+                "restartTransport must not emit permanent Disconnected state (emitted: $stateEmissions)",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: [SharedRadioInterfaceService.restartTransport] must not emit a user-facing connection error.
+     * _connectionError is a no-replay SharedFlow, so the collector must subscribe BEFORE the restart; under
+     * UnconfinedTestDispatcher the launch runs eagerly up to its first suspension (awaiting SharedFlow emission). A
+     * silent-recovery cycle surfacing an error modal is the same UX bug as a liveness recovery surfacing one.
+     */
+    @Test
+    fun `restartTransport does not emit user-facing connection error`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        try {
+            val errors = mutableListOf<String>()
+            val collectJob = backgroundScope.launch { service.connectionError.collect { errors.add(it) } }
+
+            service.restartTransport()
+            testDispatcher.scheduler.runCurrent()
+
+            collectJob.cancel()
+
+            assertTrue(
+                errors.isEmpty(),
+                "restartTransport must not emit user-facing connection error (got: $errors)",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: [SharedRadioInterfaceService.restartTransport] reuses the BLE liveness `isRestarting` CAS so a
+     * concurrent liveness silent-recovery cycle and a handshake-induced restart cannot stack. The loser of the CAS
+     * observes `isRestarting == true` and defers to the in-flight cycle, preventing a double stop/start race on the
+     * transport.
+     *
+     * Deterministic in-flight overlap: a [GatedFakeRadioTransport] suspends the liveness restart genuinely inside
+     * stopTransportLocked → close() (awaiting closeGate). Under UnconfinedTestDispatcher, when the liveness coroutine's
+     * `transportMutex.withLock {}` exits and calls `unlock()`, the queued restartTransport coroutine is resumed inline
+     * BEFORE the liveness coroutine's outer `finally { isRestarting.value = false }` runs — so restartTransport's CAS
+     * observes `isRestarting == true` and returns without another cycle. A stacking bug (CAS ignored, or finally
+     * ordering inverted) would produce 3 transports.
+     */
+    @Test
+    fun `restartTransport coordinates with in-flight liveness restart via isRestarting`() = runTest(testDispatcher) {
+        val gatedTransports = mutableListOf<GatedFakeRadioTransport>()
+        val closeGate = CompletableDeferred<Unit>()
+        // Publish the gate to activeCloseGate so tearDown can release it even if an assertion
+        // throws before we reach the inner try/finally — otherwise disconnect() below would
+        // hang forever on the gated close().
+        activeCloseGate = closeGate
+        val transportProvider: () -> RadioTransport = {
+            GatedFakeRadioTransport(closeGate).also { gatedTransports.add(it) }
+        }
+
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF", transportProvider)
+        try {
+            assertEquals(1, gatedTransports.size, "Initial connect should create one transport")
+            val initialTransport = gatedTransports.first()
+
+            // Past the 60s threshold → first checkLiveness CAS-sets isRestarting=true and
+            // launches a restart coroutine whose close() suspends on closeGate. Under
+            // UnconfinedTestDispatcher the launched coroutine runs eagerly up to the
+            // suspension point: by the time checkLiveness() returns, mutex is held and
+            // isRestarting == true.
+            clock = 65_000L
+            service.checkLiveness()
+
+            // Issue restartTransport() while the liveness restart is suspended. It will
+            // suspend waiting for transportMutex; the body cannot run until liveness releases.
+            val restartJob = backgroundScope.launch { service.restartTransport() }
+            testDispatcher.scheduler.runCurrent()
+
+            try {
+                // Pre-release: liveness still in-flight (close() suspended on closeGate),
+                // restartTransport still queued on mutex. No fresh transport, no stacking.
+                assertEquals(
+                    1,
+                    gatedTransports.size,
+                    "No fresh transport created while liveness restart is in-flight",
+                )
+                assertTrue(initialTransport.closeCalled, "Liveness restart must have entered close()")
+                assertEquals(
+                    0,
+                    initialTransport.closeCompletedCount,
+                    "Liveness restart close() must still be suspended (gate not yet released)",
+                )
+                assertFalse(
+                    restartJob.isCompleted,
+                    "restartTransport should be queued on transportMutex, not completed",
+                )
+            } finally {
+                // Release the gate unconditionally so the suspended liveness restart can
+                // complete. tearDown also releases activeCloseGate, but completing here is
+                // required for the post-finally assertions to observe the resumed cycle.
+                closeGate.complete(Unit)
+            }
+
+            // Resume the liveness restart: close() returns, startTransportLocked creates the
+            // single fresh transport, mutex is released and restartTransport resumes inline.
+            // Under UnconfinedTestDispatcher the inline resume runs BEFORE the liveness
+            // coroutine's outer finally resets isRestarting, so restartTransport's CAS fails
+            // and it returns without another cycle.
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+            restartJob.join()
+
+            // Exactly 2 transports: 1 initial + 1 from liveness restart. restartTransport
+            // was a no-op via the isRestarting CAS. A stacking bug would produce 3.
+            assertEquals(
+                2,
+                gatedTransports.size,
+                "restartTransport must not stack another cycle on an in-flight liveness restart",
+            )
+            assertEquals(1, initialTransport.closeCount, "Initial transport closed exactly once")
+            assertEquals(
+                1,
+                initialTransport.closeCompletedCount,
+                "Initial transport close completed exactly once after gate release",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
 }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -1186,8 +1186,9 @@ class SharedRadioInterfaceServiceLivenessTest {
                 )
 
                 // Stale handshake-stall restart fired in the window where radioTransport == null but
-                // connectionRequested is still true. The new gate must short-circuit BEFORE the
-                // isRestarting CAS and BEFORE the onDisconnect(isPermanent=false) DeviceSleep emission.
+                // connectionRequested is still true. The new gate must short-circuit AFTER the
+                // isRestarting CAS (inside transportMutex) but BEFORE the onDisconnect(isPermanent=false) DeviceSleep
+                // emission.
                 service.restartTransport()
                 testDispatcher.scheduler.runCurrent()
                 advanceTimeBy(1_000L)

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -953,10 +953,13 @@ class SharedRadioInterfaceServiceLivenessTest {
     }
 
     /**
-     * Regression: [SharedRadioInterfaceService.restartTransport] mirrors BLE liveness silent recovery —
-     * `notifyPermanent=false` so no user-facing Disconnected state is emitted. The caller drives app-level state
-     * transitions separately; surfacing a permanent disconnect for a self-healing cycle would pop a confusing modal for
-     * a transient condition.
+     * Regression: [SharedRadioInterfaceService.restartTransport] mirrors BLE liveness silent recovery. It MUST emit a
+     * transient DeviceSleep (via onDisconnect(isPermanent = false)) BEFORE the stop/start cycle so the subsequent
+     * onConnect() produces a real Connected transition (StateFlow is idempotent on same-value — without the DeviceSleep
+     * flip, Connected -> Connected is a no-op and MeshConnectionManager stays stuck on its app-level Disconnected
+     * state). It MUST NOT emit a permanent user-facing Disconnected state — the caller drives app-level state
+     * transitions separately, and surfacing a permanent disconnect for a self-healing cycle would pop a confusing modal
+     * for a transient condition.
      */
     @Test
     fun `restartTransport does not emit permanent Disconnected`() = runTest(testDispatcher) {
@@ -971,6 +974,12 @@ class SharedRadioInterfaceServiceLivenessTest {
 
             collectJob.cancel()
 
+            // The DeviceSleep emission is the intended transport-level transition that lets
+            // MeshConnectionManager observe a real Connected transition on the fresh transport.
+            assertTrue(
+                ConnectionState.DeviceSleep in stateEmissions,
+                "restartTransport must emit transient DeviceSleep so the post-restart onConnect() re-triggers handleConnected() (emitted: $stateEmissions)",
+            )
             assertFalse(
                 ConnectionState.Disconnected in stateEmissions,
                 "restartTransport must not emit permanent Disconnected state (emitted: $stateEmissions)",

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -790,12 +790,17 @@ class SharedRadioInterfaceServiceLivenessTest {
     //
     // [SharedRadioInterfaceService.restartTransport] is the app-level handshake-stall recovery
     // path. It mirrors BLE liveness silent recovery: stopTransportLocked(notifyPermanent=false,
-    // sendPoliteDisconnect=false) then startTransportLocked(), all under transportMutex. The gate
-    // contract has four early-return gates that MUST all hold for the cycle to fire:
-    //   1. connectionRequested == true  (cleared by disconnect() / setDeviceAddress(null)/("n"))
-    //   2. getBondedDeviceAddress() != null  (re-validates the selected address)
-    //   3. radioTransport != null  (defends against a stale restart after an environmental stop)
-    //   4. isRestarting.compareAndSet(false, true) succeeds  (reuses the liveness CAS)
+    // sendPoliteDisconnect=false) then startTransportLocked(). The isRestarting CAS runs
+    // synchronously BEFORE transportMutex (mirroring checkLiveness), then the remaining gates run
+    // inside the mutex. The gate contract has four early-return gates that MUST all hold for the
+    // cycle to fire, evaluated in this exact order:
+    //   1. isRestarting.compareAndSet(false, true) succeeds  (reuses the liveness CAS; synchronous,
+    //      BEFORE acquiring transportMutex — both restart paths serialize on this CAS first)
+    //   2. connectionRequested == true  (cleared by disconnect() / setDeviceAddress(null)/("n");
+    //      checked inside transportMutex)
+    //   3. getBondedDeviceAddress() != null  (re-validates the selected address; inside transportMutex)
+    //   4. radioTransport != null  (defends against a stale restart after an environmental stop;
+    //      inside transportMutex)
     // The cycle must also be address-preserving and silent (no permanent Disconnected, no
     // user-facing error). The tests below lock each leg of that contract.
 
@@ -812,6 +817,10 @@ class SharedRadioInterfaceServiceLivenessTest {
             assertEquals(1, createdTransports.size, "Initial connect should create one transport")
             val initialTransport = createdTransports.first()
 
+            // Lock the sendPoliteDisconnect=false contract: clear any bytes recorded during the
+            // initial connect so sentData reflects only writes performed during restartTransport.
+            initialTransport.sentData.clear()
+
             service.restartTransport()
             // sendPoliteDisconnect = false → no 500ms drain inside the cycle. Under
             // UnconfinedTestDispatcher the whole stop/start runs inline; runCurrent is
@@ -821,6 +830,10 @@ class SharedRadioInterfaceServiceLivenessTest {
             assertEquals(2, createdTransports.size, "restartTransport should create exactly one fresh transport")
             assertTrue(initialTransport.closeCalled, "Old transport must be closed by restartTransport")
             assertEquals(1, initialTransport.closeCount, "Old transport closed exactly once (no double-close)")
+            assertTrue(
+                initialTransport.sentData.isEmpty(),
+                "restartTransport must NOT write any bytes to the old transport (sendPoliteDisconnect=false)",
+            )
         } finally {
             service.disconnect()
             advanceTimeBy(1_000L)
@@ -1123,7 +1136,8 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     /**
      * Regression for the `radioTransport == null` gate added to [SharedRadioInterfaceService.restartTransport] (the
-     * third early-return, before the `isRestarting` CAS and the `onDisconnect(isPermanent = false)` call).
+     * mutex-protected early-return, checked after the `isRestarting` CAS but before the `onDisconnect(isPermanent =
+     * false)` call).
      *
      * Scenario: a TCP transport has been torn down by an environmental stop (`networkAvailable = false`) but
      * `connectionRequested` is intentionally preserved so the network recovery listener can re-bring-up the transport

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -791,7 +791,7 @@ class SharedRadioInterfaceServiceLivenessTest {
     // [SharedRadioInterfaceService.restartTransport] is the app-level handshake-stall recovery
     // path. It mirrors BLE liveness silent recovery: stopTransportLocked(notifyPermanent=false,
     // sendPoliteDisconnect=false) then startTransportLocked(), all under transportMutex. The gate
-    // contract has four early-return gates (in order) that MUST hold for the cycle to fire:
+    // contract has four early-return gates that MUST all hold for the cycle to fire:
     //   1. connectionRequested == true  (cleared by disconnect() / setDeviceAddress(null)/("n"))
     //   2. getBondedDeviceAddress() != null  (re-validates the selected address)
     //   3. radioTransport != null  (defends against a stale restart after an environmental stop)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -64,6 +64,8 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
 
     val sentToRadio = mutableListOf<ByteArray>()
     var connectCalled = false
+    var restartTransportCalled: Boolean = false
+        private set
 
     override fun isMockTransport(): Boolean = true
 
@@ -77,6 +79,10 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
 
     override suspend fun disconnect() {
         connectCalled = false
+    }
+
+    override suspend fun restartTransport() {
+        restartTransportCalled = true
     }
 
     override fun getDeviceAddress(): String? = _currentDeviceAddressFlow.value

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -90,6 +90,10 @@ class NoopRadioInterfaceService : RadioInterfaceService {
         logWarn("NoopRadioInterfaceService.disconnect()")
     }
 
+    override suspend fun restartTransport() {
+        logWarn("NoopRadioInterfaceService.restartTransport()")
+    }
+
     override fun getDeviceAddress(): String? = null
 
     override fun setDeviceAddress(deviceAddr: String?): Boolean = false


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR addresses a WiFi/TCP mesh handshake stall where the transport can stay physically connected while the firmware stops responding. It introduces a `restartTransport()` recovery mechanism that silently cycles the active transport and ensures the ordering of app-level disconnect vs. transport-level restart work prevents “split-brain” connection state transitions.

## Key Changes

### Features
- Added `suspend fun restartTransport()` to `RadioInterfaceService`, with documented contract for silent recovery:
  - Restarts/replaces the active transport while preserving the selected device address and the connection-request gate
  - Safe no-op when no transport is running (including during/alongside disconnect)
  - Uses the normal start path validation for the bonded/bonded device address
  - Waits for the restart cycle to complete via transport lifecycle callbacks
- Implemented `restartTransport()` in `SharedRadioInterfaceService`:
  - Uses an `isRestarting` CAS guard plus `transportMutex` to prevent overlapping restart executions
  - Emits only a transient non-permanent disconnect (`onDisconnect(isPermanent = false)`)
  - Stops the current transport without polite disconnect signaling/permanent disconnect marking
  - Re-checks `connectionRequested` before restarting to avoid reconnecting after an explicit disconnect
- Updated stubs/fakes to support the new API:
  - `FakeRadioInterfaceService` records whether `restartTransport()` was called
  - `NoopRadioInterfaceService` provides a no-op implementation (logs a warning)

### Fixes
- Updated handshake stall recovery in `MeshConnectionManagerImpl`:
  - Changed the “handshake still stalled after retry” path to start recovery as a sibling job under the long-lived `ServiceScope`
  - Avoids calling `onConnectionChanged(Disconnected)` directly inside the `handshakeTimeout` coroutine, preventing cancellation/ordering issues
  - Ensures app-level `Disconnected` transition occurs before transport restart emissions

### Refactors / Test Infrastructure
- Extended `MeshConnectionManagerImplTest` with virtual-time tests validating:
  - Stage 1 and Stage 2 handshake stall-after-retry triggers restart and ends in `ConnectionState.Disconnected`
  - Ordering invariant: app disconnect transition happens before any restart-driven transport emissions
  - No restart if handshake completes before the stall timeout
- Added/expanded liveness contract tests in `SharedRadioInterfaceServiceLivenessTest` for restart behavior:
  - Correct close/recreate semantics and “old transport not used during restart”
  - No-op after explicit `disconnect()` or device deselection (`setDeviceAddress(null)` / `"n"`)
  - Selected device address preserved (does not rewrite `radioPrefs.devAddr`)
  - Only transient disconnect is emitted (never permanent `ConnectionState.Disconnected`)
  - No user-facing connection errors during restart
  - Concurrency correctness with coordination during in-flight liveness restarts
  - No-op when the transport is environmentally stopped (e.g., `networkAvailable=false`) while `connectionRequested` remains true

## Breaking / Migration Notes
- `RadioInterfaceService` gained a new public method, so all implementations must add an override of `restartTransport()` (this PR updates `SharedRadioInterfaceService`, `FakeRadioInterfaceService`, and `NoopRadioInterfaceService` accordingly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->