### PR TITLE
Refactor BLE device discovery to require fresh scanning

### DIFF
--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -54,10 +54,12 @@ import org.meshtastic.core.ble.retryBleOperation
 import org.meshtastic.core.ble.toMeshtasticRadioProfile
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.RadioNotConnectedException
+import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.network.transport.HeartbeatSender
 import org.meshtastic.core.repository.RadioTransport
 import org.meshtastic.core.repository.RadioTransportCallback
 import kotlin.concurrent.Volatile
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -77,6 +79,18 @@ private val CONNECTION_TIMEOUT = 15.seconds
 private val HEARTBEAT_DRAIN_DELAY = 200.milliseconds
 
 private val TARGETED_SCAN_TIMEOUT = 2.seconds
+
+/**
+ * Bounded scan duration used by both discovery paths in [findDevice]:
+ * - Bonded escalation: after the 2s [TARGETED_SCAN_TIMEOUT] misses the low-duty advertisement window, this is the
+ *   single bounded retry before declaring the bonded device unreachable.
+ * - Non-bonded retry: each of the [SCAN_RETRY_COUNT] attempts uses this duration.
+ *
+ * 5s covers multiple advertising intervals for typical BLE power-save slots (~1–2s each) while keeping the total bonded
+ * scan window bounded (~7s scan, ~10s total attempt including the existing reconnect settle delay) so
+ * [BleReconnectPolicy] iterates on its normal schedule instead of parking on [CONNECTION_TIMEOUT] (15s) via an
+ * `autoConnect=true` hang on a stale handle.
+ */
 private val SCAN_TIMEOUT = 5.seconds
 private val GATT_CLEANUP_TIMEOUT = 5.seconds
 
@@ -222,56 +236,71 @@ class BleRadioTransport(
             bluetoothRepository.state.value.bondedDevices.firstOrNull { it.address.equals(address, ignoreCase = true) }
 
         if (bondedDevice != null) {
-            Logger.i { "[$address] Bonded device found; attempting short targeted scan for fresh advertisement" }
-            findTargetedDevice()?.let {
-                Logger.i { "[$address] Fresh advertisement found; using scanned device" }
+            // Fast path: 2s targeted scan catches active advertising.
+            Logger.i {
+                "[${address.anonymize()}] Bonded device found; attempting short targeted scan for fresh advertisement"
+            }
+            scanForFreshDevice(TARGETED_SCAN_TIMEOUT)?.let {
+                Logger.i { "[${address.anonymize()}] Fresh advertisement found; using scanned device" }
                 return it
             }
-            Logger.i { "[$address] Targeted scan timed out; falling back to bonded address" }
-            return bondedDevice
-        }
 
-        Logger.i { "[$address] Device not found in bonded list, scanning" }
-
-        repeat(SCAN_RETRY_COUNT) { attempt ->
-            try {
-                val d =
-                    withTimeoutOrNull(SCAN_TIMEOUT) {
-                        // Pass both service UUID and address so the scanner can apply the most
-                        // efficient platform filter. Android uses address (OS-level HW filter),
-                        // while CoreBluetooth (macOS) needs the service UUID because it caches
-                        // peripheral identifiers and may not re-report by address alone.
-                        scanner.scan(timeout = SCAN_TIMEOUT, serviceUuid = SERVICE_UUID, address = address).first {
-                            it.address.equals(address, ignoreCase = true)
-                        }
-                    }
-                if (d != null) return d
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.v(e) { "[$address] Scan attempt failed or timed out" }
+            // Escalation: radio may be in a low-duty advertising slot. Try one bounded SCAN_TIMEOUT scan.
+            Logger.i { "[${address.anonymize()}] Targeted scan missed; escalating to bounded scan before giving up" }
+            scanForFreshDevice(SCAN_TIMEOUT)?.let {
+                Logger.i { "[${address.anonymize()}] Fresh advertisement found during escalated scan" }
+                return it
             }
 
+            // Never fall back to the stale bonded handle — that path forces autoConnect=true and hangs for
+            // CONNECTION_TIMEOUT (15s) before throwing. Bounded scan window (~7s scan, ~10s total attempt
+            // including the existing reconnect settle delay) lets the reconnect policy iterate on its
+            // normal schedule instead of parking on the autoConnect hang.
+            Logger.w { "[${address.anonymize()}] No fresh advertisement within $SCAN_TIMEOUT; reporting unreachable" }
+            throw RadioNotConnectedException("Bonded device is not advertising")
+        }
+
+        // Non-bonded path: preserve existing retry behavior (SCAN_RETRY_COUNT attempts at SCAN_TIMEOUT).
+        Logger.i { "[${address.anonymize()}] Device not found in bonded list, scanning" }
+        repeat(SCAN_RETRY_COUNT) { attempt ->
+            scanForFreshDevice(SCAN_TIMEOUT)?.let {
+                return it
+            }
             if (attempt < SCAN_RETRY_COUNT - 1) {
                 delay(SCAN_RETRY_DELAY)
             }
         }
-
         throw RadioNotConnectedException("Device not found at address $address")
     }
 
-    private suspend fun findTargetedDevice(): BleDevice? = try {
-        withTimeoutOrNull(TARGETED_SCAN_TIMEOUT) {
-            // Pass both service UUID and address so the scanner can apply the most
-            // efficient platform filter while still keeping CoreBluetooth service-scoped.
-            scanner.scan(timeout = TARGETED_SCAN_TIMEOUT, serviceUuid = SERVICE_UUID, address = address).first {
+    /**
+     * Performs a single BLE scan attempt for the selected [address] and returns the first matching [BleDevice], or null
+     * if the scan times out or fails.
+     *
+     * One scan attempt only — no retry, no backoff. Both bonded and non-bonded paths in [findDevice] share this
+     * primitive so retry policy stays centralized:
+     * - Bonded: escalated from [TARGETED_SCAN_TIMEOUT] to [SCAN_TIMEOUT] before [findDevice] declares the device
+     *   unreachable.
+     * - Non-bonded: [SCAN_RETRY_COUNT] attempts at [SCAN_TIMEOUT] with [SCAN_RETRY_DELAY] between attempts.
+     *
+     * The outer [withTimeoutOrNull] is binding: the scanner receives [timeout] as a hint, but this coroutine resumes on
+     * its own schedule regardless of when (or whether) the scanner honors it.
+     *
+     * [CancellationException] is rethrown — coroutine cancellation must never be swallowed.
+     */
+    private suspend fun scanForFreshDevice(timeout: Duration): BleDevice? = try {
+        withTimeoutOrNull(timeout) {
+            // Pass both service UUID and address so the scanner can apply the most efficient platform filter.
+            // Android uses address (OS-level HW filter), while CoreBluetooth (macOS) needs the service UUID because
+            // it caches peripheral identifiers and may not re-report by address alone.
+            scanner.scan(timeout = timeout, serviceUuid = SERVICE_UUID, address = address).first {
                 it.address.equals(address, ignoreCase = true)
             }
         }
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        Logger.v(e) { "[$address] Targeted scan failed; falling back to bonded address" }
+        Logger.v(e) { "[${address.anonymize()}] Scan failed (timeout=$timeout)" }
         null
     }
 

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -27,16 +27,20 @@ import dev.mokkery.mock
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.ble.BleConnection
 import org.meshtastic.core.ble.BleConnectionFactory
 import org.meshtastic.core.ble.BleConnectionState
 import org.meshtastic.core.ble.BleDevice
+import org.meshtastic.core.ble.BleScanner
 import org.meshtastic.core.ble.BleService
 import org.meshtastic.core.ble.BleWriteType
 import org.meshtastic.core.ble.DisconnectReason
@@ -1025,6 +1029,132 @@ class BleRadioTransportReconnectCrashTest {
             bleTransport.close()
         }
     }
+
+    // ─── Bonded fresh-advertisement discovery ─────────────────────────────────────────────────────
+
+    /**
+     * Regression: bonded auto-reconnect must NOT reuse the stale bonded handle when the targeted scan misses the
+     * advertising window. The escalation path (TARGETED_SCAN_TIMEOUT → SCAN_TIMEOUT) must surface a freshly-scanned
+     * device.
+     *
+     * Sequenced scanner: call 0 (2s targeted) returns empty; call 1 (5s escalated) emits a fresh `FakeBleDevice` for
+     * the bonded address. The transport must connect using the fresh scanned device, never the stale bonded handle.
+     */
+    @Test
+    fun `bonded device missed by targeted scan is found by escalated scan`() = runTest {
+        val bondedDevice = FakeBleDevice(address = address, name = "Bonded Handle")
+        bluetoothRepository.bond(bondedDevice)
+
+        val freshDevice = FakeBleDevice(address = address, name = "Fresh Scan Result")
+        val sequencedScanner =
+            SequencedBleScanner().apply {
+                responses += { flow { awaitCancellation() } } // call 0: targeted scan misses (runs until 2s timeout)
+                responses += { flow { emit(freshDevice) } } // call 1: escalated scan emits fresh device
+            }
+
+        // Profile setup needs FROMNUM/FROMRADIO so the transport reaches a stable Connected state
+        // rather than tearing down before we can inspect which device was connected.
+        connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
+        connection.service.addCharacteristic(FROMRADIO_CHARACTERISTIC)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = sequencedScanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        try {
+            bleTransport.start()
+
+            // 2s targeted scan + immediate escalated emit + connect/handshake settle.
+            advanceTimeBy(8_000L)
+
+            assertTrue(
+                sequencedScanner.callCount >= 2,
+                "Expected at least 2 scan calls (targeted + escalated); got ${sequencedScanner.callCount}",
+            )
+            assertEquals(
+                2_000L,
+                sequencedScanner.calls[0].timeout.inWholeMilliseconds,
+                "First scan must be targeted (2s)",
+            )
+            assertEquals(
+                5_000L,
+                sequencedScanner.calls[1].timeout.inWholeMilliseconds,
+                "Second scan must be escalated (5s)",
+            )
+            assertEquals(SERVICE_UUID, sequencedScanner.calls[0].serviceUuid, "First scan must include service UUID")
+            assertEquals(address, sequencedScanner.calls[0].address, "First scan must target selected address")
+            assertEquals(SERVICE_UUID, sequencedScanner.calls[1].serviceUuid, "Second scan must include service UUID")
+            assertEquals(address, sequencedScanner.calls[1].address, "Second scan must target selected address")
+            assertEquals(1, connection.connectAndAwaitCalls, "Must connect exactly once with the fresh scanned device")
+            assertTrue(
+                connection.device === freshDevice,
+                "Must use the fresh scanned device, not the stale bonded handle " +
+                    "(got: ${connection.device?.name}, expected: ${freshDevice.name})",
+            )
+
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    /**
+     * Critical regression: when the bonded device is not advertising at all, [findDevice] must throw
+     * [RadioNotConnectedException] after the bounded scan window (~7s scan, ~10s total attempt including the existing
+     * reconnect settle delay) and must not fall back to the stale bonded handle.
+     *
+     * Before the fix, the stale handle forced `autoConnect=true` and hung for [CONNECTION_TIMEOUT] (15s) before the
+     * reconnect loop could iterate. This test proves `connectAndAwait` is never invoked against the stale handle.
+     */
+    @Test
+    fun `bonded device never advertising results in zero connect calls`() = runTest {
+        val bondedDevice = FakeBleDevice(address = address, name = "Bonded Handle")
+        bluetoothRepository.bond(bondedDevice)
+
+        val sequencedScanner =
+            SequencedBleScanner().apply {
+                responses += { flow { awaitCancellation() } } // call 0: targeted scan misses (runs until 2s timeout)
+                responses += { flow { awaitCancellation() } } // call 1: escalated scan misses (runs until 5s timeout)
+            }
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = sequencedScanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        try {
+            bleTransport.start()
+
+            // 2s targeted + 5s escalated + reconnect backoff + settle delay before second iteration.
+            // With awaitCancellation(), scans now suspend for their full timeout durations, so we
+            // must cover the full reconnect iteration window (settle + targeted + escalated + backoff).
+            advanceTimeBy(20_000L)
+
+            // Proves the stale bonded handle was not used: no connectAndAwait call.
+            assertEquals(
+                0,
+                connection.connectAndAwaitCalls,
+                "Must never call connectAndAwait when no fresh advertisement was found",
+            )
+            assertTrue(
+                sequencedScanner.callCount >= 2,
+                "Expected at least 2 scan calls (targeted + escalated); got ${sequencedScanner.callCount}",
+            )
+
+            bleTransport.close()
+        } finally {
+            bleTransport.close()
+        }
+    }
 }
 
 // ─── Test doubles ────────────────────────────────────────────────────────────────────────────────
@@ -1117,4 +1247,34 @@ private class NeverConnectedStateBleConnection : BleConnection {
     ): T = CoroutineScope(currentCoroutineContext()).setup(service)
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = null
+}
+
+/**
+ * A [BleScanner] test double that records each [scan] call's arguments and delegates to a per-call [Flow] supplier.
+ *
+ * Unlike [FakeBleScanner] (which is replay-based and re-emits all previously-emitted devices on every call), this
+ * scanner lets a test model "first scan misses, second scan finds" by configuring [responses] index-by-index. Calls
+ * beyond the configured list return a never-completing flow (models a scan that runs until cancelled).
+ */
+private class SequencedBleScanner : BleScanner {
+    data class Call(val timeout: Duration, val serviceUuid: kotlin.uuid.Uuid?, val address: String?)
+
+    private val _calls = mutableListOf<Call>()
+    val calls: List<Call>
+        get() = _calls.toList()
+
+    val callCount: Int
+        get() = _calls.size
+
+    /**
+     * Per-call [Flow] suppliers, indexed by call order. Call 0 returns [responses][0], call 1 returns [responses][1],
+     * etc. Calls beyond the list size return a never-completing flow (suspends until cancelled).
+     */
+    val responses = mutableListOf<() -> Flow<BleDevice>>()
+
+    override fun scan(timeout: Duration, serviceUuid: kotlin.uuid.Uuid?, address: String?): Flow<BleDevice> {
+        val index = _calls.size
+        _calls += Call(timeout, serviceUuid, address)
+        return if (index < responses.size) responses[index]() else flow { awaitCancellation() }
+    }
 }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -209,7 +209,7 @@ class BleRadioTransportTest {
     }
 
     @Test
-    fun `findDevice falls back to bonded device when targeted scan finds nothing`() = runTest {
+    fun `findDevice does not fall back to bonded device when scan finds nothing`() = runTest {
         val bondedDevice = FakeBleDevice(address = address, name = "Bonded Device")
         bluetoothRepository.bond(bondedDevice)
 
@@ -224,11 +224,12 @@ class BleRadioTransportTest {
             )
         bleTransport.start()
         try {
-            advanceTimeBy(5_500)
+            // 3s settle + 2s targeted + 5s escalated scan = 10s before RadioNotConnectedException.
+            // The bonded device is never advertising, so findDevice must escalate and throw
+            // rather than returning the stale bonded handle.
+            advanceTimeBy(11_000)
 
-            assertEquals(SERVICE_UUID, scanner.lastScanServiceUuid)
-            assertEquals(address, scanner.lastScanAddress)
-            assertEquals("Bonded Device", connection.device?.name)
+            assertEquals(0, connection.connectAndAwaitCalls, "Must not connect when bonded device is not advertising")
         } finally {
             bleTransport.close()
         }

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -38,6 +38,7 @@ import org.meshtastic.core.ble.MeshtasticBleConstants
 import org.meshtastic.core.datastore.RecentAddressesDataSource
 import org.meshtastic.core.datastore.model.RecentAddress
 import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.network.repository.NetworkRepository
 import org.meshtastic.core.repository.RadioController
@@ -157,6 +158,13 @@ open class ScannerViewModel(
     init {
         _showMockTransport.value = radioInterfaceService.isMockTransport()
         serviceRepository.connectionProgress.onEach { _connectionProgressText.value = it }.launchIn(viewModelScope)
+        serviceRepository.connectionState
+            .onEach { state ->
+                if (state is ConnectionState.Connected) {
+                    stopAllScans()
+                }
+            }
+            .launchIn(viewModelScope)
         Logger.d { "ScannerViewModel created" }
     }
 
@@ -289,6 +297,19 @@ open class ScannerViewModel(
                     if (scanGeneration.value == generation) _isBleScanning.value = false
                 }
             }
+    }
+
+    /**
+     * Starts BLE scanning for screen-entry auto-scan only when no device is already selected. Manual scan toggles call
+     * [startBleScan] directly so users can still discover/switch devices while connected.
+     *
+     * This controls only Connections-screen discovery. Selected-device reconnect still performs its fresh-advertisement
+     * scan in `BleRadioTransport.findDevice` before connecting.
+     */
+    fun startBleAutoScan() {
+        val selectedAddress = selectedAddressFlow.value
+        if (selectedAddress != null && selectedAddress != NO_DEVICE_SELECTED) return
+        startBleScan()
     }
 
     /**

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -146,15 +146,16 @@ fun ConnectionsScreen(
     val openBluetoothSettings = rememberOpenBluetoothSettings()
     val openWifiSettings = rememberOpenWifiSettings()
 
-    // Auto-start BLE scan when the screen is visible (lifecycle ≥ STARTED) and the user has previously opted in.
-    // LifecycleStartEffect stops scanning on ON_STOP (app backgrounded) and restarts on ON_START — preventing
-    // continuous background BLE radio usage that drains the battery.
+    // Auto-start BLE discovery when the screen is visible (lifecycle ≥ STARTED) and the user has previously opted in.
+    // ScannerViewModel skips screen-entry discovery when a selected device can reconnect through the transport's
+    // fresh-advertisement scan. LifecycleStartEffect stops scanning on ON_STOP (app backgrounded) and restarts on
+    // ON_START — preventing continuous background BLE radio usage that drains the battery.
     // Keyed on Unit so the effect fires only on lifecycle events, not on preference writes. The toggle handler
     // starts/stops scans directly; this effect handles screen-entry auto-start only. Keying on the pref caused
     // Compose to dispose the running scan (calling stopBleScan) and immediately re-run (calling startBleScan)
     // every time the pref was written, which cycled scans until Android's BluetoothLeScanner rate-limited.
     LifecycleStartEffect(Unit) {
-        if (scanModel.bleAutoScan.value && !scanModel.isBleScanning.value) scanModel.startBleScan()
+        if (scanModel.bleAutoScan.value && !scanModel.isBleScanning.value) scanModel.startBleAutoScan()
         onStopOrDispose { scanModel.stopBleScan() }
     }
 

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -294,7 +294,7 @@ class ScannerViewModelTest {
         assertEquals(true, viewModel.isNetworkScanning.value)
     }
 
-    // ── Scanning allowed in any connection state ────────────────────────────────────────────
+    // Manual scan control.
 
     @Test
     fun `startBleScan succeeds while Connected`() = runTest {
@@ -337,12 +337,41 @@ class ScannerViewModelTest {
     }
 
     @Test
-    fun `connectionState transition does not cancel active scan`() = runTest {
+    fun `connectionState transition to Connected cancels active ble scan`() = runTest {
         viewModel.startBleScan()
         assertEquals(true, viewModel.isBleScanning.value)
 
         serviceRepository.setConnectionState(ConnectionState.Connected)
         testScheduler.advanceUntilIdle()
+
+        assertEquals(false, viewModel.isBleScanning.value)
+    }
+
+    @Test
+    fun `connectionState transition to Connected cancels active network scan`() = runTest {
+        viewModel.startNetworkScan()
+        assertEquals(true, viewModel.isNetworkScanning.value)
+
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(false, viewModel.isNetworkScanning.value)
+    }
+
+    @Test
+    fun `startBleAutoScan skips when device already selected`() = runTest {
+        harness.currentDeviceAddressFlow.value = "x01:02:03:04:05:06"
+
+        viewModel.startBleAutoScan()
+
+        assertEquals(false, viewModel.isBleScanning.value)
+    }
+
+    @Test
+    fun `startBleAutoScan starts when no device selected`() = runTest {
+        harness.currentDeviceAddressFlow.value = null
+
+        viewModel.startBleAutoScan()
 
         assertEquals(true, viewModel.isBleScanning.value)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a BLE reconnection issue in the Meshtastic Android application where bonded devices that were missed by the 2-second targeted scan would fall back to stale bonded device handles, forcing the connection into `autoConnect=true` mode and causing reliable 15-second hangs. The fix escalates from the targeted scan to a bounded 5-second scan before throwing an exception, ensuring a fresh advertisement is always obtained. This extends the total reconnection attempt to approximately 10 seconds, allowing the reconnect policy to iterate on its normal schedule instead of blocking on lengthy timeouts.

## Changes

**Fixes**
- Modified `findDevice()` in `BleRadioTransport` to escalate from targeted scan (2 seconds) to bounded scan (5 seconds) when bonded devices are initially missed, rather than falling back to stale bonded device handles
- Bonded reconnect now throws `RadioNotConnectedException` with a descriptive error message if no fresh advertisement is found within the bounded window, instead of silently returning a stale handle

**Refactoring**
- Extracted new private helper `scanForFreshDevice(timeout)` that performs a single scan attempt using both `SERVICE_UUID` and device address, centralizing "fresh advertisement" scanning logic
- Rewrote bonded and non-bonded code paths in `findDevice()` to share the common `scanForFreshDevice()` primitive while preserving retry policy logic
- Non-bonded behavior remains unchanged with existing `SCAN_RETRY_COUNT` attempts, `SCAN_TIMEOUT` duration, and `SCAN_RETRY_DELAY` between retries

**Tests**
- Added two new regression tests in `BleRadioTransportReconnectCrashTest` validating bonded device reconnection scenarios:
  - Verifies escalation to longer scan window when bonded device is missed by targeted scan, confirming connection uses freshly discovered device
  - Verifies that devices with no advertising result in bounded failures without falling back to stale bonded handles
- Introduced `SequencedBleScanner` test double to record scan call arguments and control per-call responses for precise scenario testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->