### PR TITLE
fix(usb): Add SerialDevicePresence and USB replug recovery

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -84,6 +84,7 @@ import org.meshtastic.core.ui.util.LocalTracerouteMapProvider
 import org.meshtastic.core.ui.util.LocalTracerouteMapScreenProvider
 import org.meshtastic.core.ui.util.showToast
 import org.meshtastic.core.ui.viewmodel.UIViewModel
+import org.meshtastic.feature.connections.NO_DEVICE_SELECTED
 import org.meshtastic.feature.intro.AppIntroductionScreen
 import org.meshtastic.feature.intro.IntroViewModel
 import org.meshtastic.feature.map.MapScreen
@@ -279,7 +280,7 @@ class MainActivity : AppCompatActivity() {
                 // never sees this event. Forward it explicitly so the serialDevices StateFlow
                 // refreshes and the device shows up in the Connect → Serial tab.
                 usbRepository.refreshState()
-                showConnectionsPage()
+                showConnectionsPageIfNoDeviceSelected()
             }
 
             Intent.ACTION_MAIN -> {}
@@ -318,22 +319,10 @@ class MainActivity : AppCompatActivity() {
         return resultPendingIntent!!
     }
 
-    private fun createConnectionsIntent(): PendingIntent {
-        val deepLink = "$DEEP_LINK_BASE_URI/connections"
-        val startActivityIntent =
-            Intent(Intent.ACTION_VIEW, deepLink.toUri(), this, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-            }
+    private fun showConnectionsPageIfNoDeviceSelected() {
+        val selectedAddress = model.currentDeviceAddressFlow.value
+        if (!selectedAddress.isNullOrBlank() && selectedAddress != NO_DEVICE_SELECTED) return
 
-        val resultPendingIntent: PendingIntent? =
-            TaskStackBuilder.create(this).run {
-                addNextIntentWithParentStack(startActivityIntent)
-                getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE)
-            }
-        return resultPendingIntent!!
-    }
-
-    private fun showConnectionsPage() {
-        createConnectionsIntent().send()
+        handleMeshtasticUri("$DEEP_LINK_BASE_URI/connections".toUri())
     }
 }

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
@@ -25,6 +25,7 @@ import org.meshtastic.core.network.repository.SerialConnectionListener
 import org.meshtastic.core.network.repository.UsbRepository
 import org.meshtastic.core.network.transport.HeartbeatSender
 import org.meshtastic.core.repository.RadioTransportCallback
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /** An Android USB/serial [RadioTransport] implementation. */
@@ -38,13 +39,38 @@ class SerialRadioTransport(
 
     private val heartbeatSender = HeartbeatSender(sendToRadio = ::handleSendToRadio, logTag = "Serial[$address]")
 
+    /**
+     * Set while an explicit [close] is tearing down the connection so the reader thread's
+     * [SerialConnectionListener.onDisconnected] callback (invoked synchronously by `port.close()` through the reader's
+     * `onRunError`) does NOT forward a transient [onDeviceDisconnect] up to the orchestrator. The service-layer caller
+     * of `close()` (SharedRadioInterfaceService's stopTransportLocked) owns post-close notification and would otherwise
+     * observe a double emission: a transient DeviceSleep from this callback chain followed by its own intended
+     * disconnect emission.
+     */
+    private val explicitCloseInProgress = AtomicBoolean(false)
+
     override fun start() {
         connect()
     }
 
+    override suspend fun close() {
+        Logger.d { "[$address] Closing serial transport" }
+        explicitCloseInProgress.set(true)
+        try {
+            closeConnection(waitForStopped = true)
+            super.close()
+        } finally {
+            explicitCloseInProgress.set(false)
+        }
+    }
+
     override fun onDeviceDisconnect(waitForStopped: Boolean, isPermanent: Boolean) {
-        connRef.get()?.close(waitForStopped)
+        closeConnection(waitForStopped)
         super.onDeviceDisconnect(waitForStopped, isPermanent)
+    }
+
+    private fun closeConnection(waitForStopped: Boolean) {
+        connRef.getAndSet(null)?.close(waitForStopped)
     }
 
     override fun connect() {
@@ -107,6 +133,13 @@ class SerialRadioTransport(
                                     "Device: $device, " +
                                     "Uptime: ${uptime}ms, " +
                                     "Packets RX: $packetsReceived ($bytesReceived bytes)"
+                            }
+                            // Skip the disconnect callback when the reader-thread termination is the
+                            // direct result of an explicit close() — the caller owns the post-close
+                            // notification. USB unplug / cable error is the only path that should
+                            // forward a transient disconnect here.
+                            if (explicitCloseInProgress.get()) {
+                                return
                             }
                             // USB unplug / cable error is transient — the transport will reconnect when
                             // the device is replugged or the OS re-enumerates the port. Only an explicit

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
@@ -65,12 +65,15 @@ class SerialRadioTransport(
     }
 
     override fun onDeviceDisconnect(waitForStopped: Boolean, isPermanent: Boolean) {
-        closeConnection(waitForStopped)
-        super.onDeviceDisconnect(waitForStopped, isPermanent)
+        if (closeConnection(waitForStopped)) {
+            super.onDeviceDisconnect(waitForStopped, isPermanent)
+        }
     }
 
-    private fun closeConnection(waitForStopped: Boolean) {
-        connRef.getAndSet(null)?.close(waitForStopped)
+    private fun closeConnection(waitForStopped: Boolean): Boolean {
+        val connection = connRef.getAndSet(null) ?: return false
+        connection.close(waitForStopped)
+        return true
     }
 
     override fun connect() {

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/AndroidSerialDevicePresence.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/AndroidSerialDevicePresence.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.coroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
+
+/**
+ * Android implementation of [SerialDevicePresence] backed by [UsbRepository.serialDevices].
+ *
+ * Derives a [Set] of device keys (the map's keys) from the underlying [UsbRepository] flow so consumers do not depend
+ * on the Android-only [android.hardware.usb.UsbDevice] / [com.hoho.android.usbserial.driver.UsbSerialDriver] types.
+ */
+@Single
+class AndroidSerialDevicePresence(
+    usbRepository: UsbRepository,
+    @Named("ProcessLifecycle") processLifecycle: Lifecycle,
+) : SerialDevicePresence {
+    override val deviceKeys =
+        usbRepository.serialDevices
+            .map { it.keys.toSet() }
+            .stateIn(processLifecycle.coroutineScope, SharingStarted.Eagerly, emptySet())
+}

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/StreamTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/StreamTransport.kt
@@ -44,10 +44,10 @@ abstract class StreamTransport(protected val callback: RadioTransportCallback, p
      *
      * @param waitForStopped if true we should wait for the transport to finish - must be false if called from inside
      *   transport callbacks
-     * @param isPermanent true only when the user has explicitly disconnected (e.g. [close] was called). USB unplug, I/O
-     *   errors, and similar conditions are transient — the transport may recover when the device is replugged or the OS
-     *   re-enumerates. Defaults to false so callbacks default to "may come back". The service layer owns explicit close
-     *   notifications so automatic stop/start recovery can close transport resources silently.
+     * @param isPermanent true only when the service layer is signaling a user-initiated terminal disconnect. USB
+     *   unplug, I/O errors, and similar conditions are transient — the transport may recover when the device is
+     *   replugged or the OS re-enumerates. Defaults to false so callbacks default to "may come back". The service layer
+     *   owns explicit close notifications so automatic stop/start recovery can close transport resources silently.
      */
     protected open fun onDeviceDisconnect(waitForStopped: Boolean, isPermanent: Boolean = false) {
         callback.onDisconnect(isPermanent = isPermanent)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/StreamTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/StreamTransport.kt
@@ -36,8 +36,7 @@ abstract class StreamTransport(protected val callback: RadioTransportCallback, p
         StreamFrameCodec(onPacketReceived = { callback.handleFromRadio(it) }, logTag = "StreamTransport")
 
     override suspend fun close() {
-        Logger.d { "Closing stream for good" }
-        onDeviceDisconnect(waitForStopped = true, isPermanent = true)
+        Logger.d { "Closing stream transport" }
     }
 
     /**
@@ -47,8 +46,8 @@ abstract class StreamTransport(protected val callback: RadioTransportCallback, p
      *   transport callbacks
      * @param isPermanent true only when the user has explicitly disconnected (e.g. [close] was called). USB unplug, I/O
      *   errors, and similar conditions are transient — the transport may recover when the device is replugged or the OS
-     *   re-enumerates. Defaults to false so callbacks default to "may come back"; [close] passes true explicitly to
-     *   signal a user-initiated terminal disconnect.
+     *   re-enumerates. Defaults to false so callbacks default to "may come back". The service layer owns explicit close
+     *   notifications so automatic stop/start recovery can close transport resources silently.
      */
     protected open fun onDeviceDisconnect(waitForStopped: Boolean, isPermanent: Boolean = false) {
         callback.onDisconnect(isPermanent = isPermanent)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/SerialDevicePresence.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/SerialDevicePresence.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-abstracted view of currently-connected serial devices.
+ *
+ * Each key is the `rest` portion of an `InterfaceId.SERIAL` address (i.e. the address with its leading `'s'` prefix
+ * stripped) — exactly the keys that [UsbRepository.serialDevices] emits on Android.
+ *
+ * Consumed by transport-recovery code (notably `SharedRadioInterfaceService.initStateListeners`) to detect when a
+ * previously-selected serial device has been unplugged and replugged, so the transport can be brought back without
+ * manual re-selection.
+ *
+ * Platforms without hot-plug observation (e.g. JVM/Desktop jSerialComm) return a perpetually-empty set.
+ */
+interface SerialDevicePresence {
+    /**
+     * The set of currently-connected serial device keys (the `rest` part of an `s$rest` SERIAL address).
+     *
+     * Implementations MUST emit a fresh set whenever the connected-device set changes. Equal sets MUST be deduped by
+     * the underlying [StateFlow] semantics so collectors do not observe redundant emissions.
+     */
+    val deviceKeys: StateFlow<Set<String>>
+}

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/StreamTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/StreamTransportTest.kt
@@ -17,8 +17,10 @@
 package org.meshtastic.core.network.radio
 
 import dev.mokkery.MockMode
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.byte
 import io.kotest.property.arbitrary.byteArray
@@ -83,5 +85,14 @@ class StreamTransportTest {
         assertTrue(fakeStream.sentBytes.isNotEmpty())
         assertTrue(fakeStream.sentBytes[0].contentEquals(StreamFrameCodec.WAKE_BYTES))
         verify { callback.onConnect() }
+    }
+
+    @Test
+    fun `close does not emit disconnect callback`() = runTest {
+        fakeStream = FakeStreamTransport(callback, testScope)
+
+        fakeStream.close()
+
+        verify(mode = VerifyMode.not) { callback.onDisconnect(isPermanent = any(), errorMessage = any()) }
     }
 }

--- a/core/network/src/iosMain/kotlin/org/meshtastic/core/network/repository/IosSerialDevicePresence.kt
+++ b/core/network/src/iosMain/kotlin/org/meshtastic/core/network/repository/IosSerialDevicePresence.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.koin.core.annotation.Single
+
+/**
+ * iOS implementation of [SerialDevicePresence].
+ *
+ * iOS does not currently publish a hot-plug serial device set, so this implementation reports a perpetually-empty set.
+ */
+@Single
+class IosSerialDevicePresence : SerialDevicePresence {
+    override val deviceKeys: StateFlow<Set<String>> = MutableStateFlow<Set<String>>(emptySet()).asStateFlow()
+}

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmSerialDevicePresence.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmSerialDevicePresence.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.koin.core.annotation.Single
+
+/**
+ * JVM/Desktop implementation of [SerialDevicePresence].
+ *
+ * The desktop serial transport (`SerialTransport` backed by jSerialComm) does not currently publish a hot-plug device
+ * set, so this implementation reports a perpetually-empty set. Transport recovery on replug is therefore a no-op on JVM
+ * until/unless jSerialComm enumeration is exposed as a flow.
+ */
+@Single
+class JvmSerialDevicePresence : SerialDevicePresence {
+    // MutableStateFlow implements StateFlow; the property's declared type seals external consumers
+    // to the read-only view without an asStateFlow() wrapper for a value that never changes.
+    override val deviceKeys: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+}

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmSerialDevicePresence.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmSerialDevicePresence.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.network.repository
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import org.koin.core.annotation.Single
 
 /**
@@ -29,7 +30,5 @@ import org.koin.core.annotation.Single
  */
 @Single
 class JvmSerialDevicePresence : SerialDevicePresence {
-    // MutableStateFlow implements StateFlow; the property's declared type seals external consumers
-    // to the read-only view without an asStateFlow() wrapper for a value that never changes.
-    override val deviceKeys: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+    override val deviceKeys: StateFlow<Set<String>> = MutableStateFlow<Set<String>>(emptySet()).asStateFlow()
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -86,22 +86,31 @@ private fun selectedSerialPresence(address: String?, keys: Set<String>): Selecte
 private fun UsbRecoveryTriggerState.next(snapshot: UsbRecoverySnapshot): UsbRecoveryTriggerState {
     val key = snapshot.presence.key
     val present = snapshot.presence.present
-    val armed = armedByAbsence || !this.present
-    val trigger = key == this.key && present && armed && snapshot.state == ConnectionState.DeviceSleep
     return when {
         key == null -> UsbRecoveryTriggerState()
 
-        key != this.key -> UsbRecoveryTriggerState(key = key, present = present)
+        key != this.key ->
+            UsbRecoveryTriggerState(
+                key = key,
+                present = present,
+                armedByAbsence = !present && snapshot.state == ConnectionState.DeviceSleep,
+            )
 
-        !present -> UsbRecoveryTriggerState(key = key)
+        !present ->
+            UsbRecoveryTriggerState(
+                key = key,
+                armedByAbsence = armedByAbsence || this.present || snapshot.state == ConnectionState.DeviceSleep,
+            )
 
-        else ->
+        else -> {
+            val trigger = armedByAbsence && snapshot.state == ConnectionState.DeviceSleep
             UsbRecoveryTriggerState(
                 key = key,
                 present = true,
-                armedByAbsence = armed && !trigger,
+                armedByAbsence = armedByAbsence && !trigger,
                 triggerRecovery = trigger,
             )
+        }
     }
 }
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -65,6 +66,44 @@ import org.meshtastic.core.repository.RadioTransport
 import org.meshtastic.core.repository.RadioTransportFactory
 import org.meshtastic.proto.ToRadio
 import kotlin.concurrent.Volatile
+
+private data class SelectedSerialPresence(val key: String?, val present: Boolean)
+
+private data class UsbRecoverySnapshot(val presence: SelectedSerialPresence, val state: ConnectionState)
+
+private data class UsbRecoveryTriggerState(
+    val key: String? = null,
+    val present: Boolean = false,
+    val armedByAbsence: Boolean = false,
+    val triggerRecovery: Boolean = false,
+)
+
+private fun selectedSerialPresence(address: String?, keys: Set<String>): SelectedSerialPresence {
+    val key = address?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }?.substring(1)
+    return SelectedSerialPresence(key = key, present = key != null && key in keys)
+}
+
+private fun UsbRecoveryTriggerState.next(snapshot: UsbRecoverySnapshot): UsbRecoveryTriggerState {
+    val key = snapshot.presence.key
+    val present = snapshot.presence.present
+    val armed = armedByAbsence || !this.present
+    val trigger = key == this.key && present && armed && snapshot.state == ConnectionState.DeviceSleep
+    return when {
+        key == null -> UsbRecoveryTriggerState()
+
+        key != this.key -> UsbRecoveryTriggerState(key = key, present = present)
+
+        !present -> UsbRecoveryTriggerState(key = key)
+
+        else ->
+            UsbRecoveryTriggerState(
+                key = key,
+                present = true,
+                armedByAbsence = armed && !trigger,
+                triggerRecovery = trigger,
+            )
+    }
+}
 
 /**
  * Shared multiplatform connection orchestrator for Meshtastic radios.
@@ -263,11 +302,10 @@ class SharedRadioInterfaceService(
     // Without this observer the user must manually re-select the device after every replug.
     //
     // We watch the SERIAL device-key set, the currently-selected address, AND the transport
-    // connection state together. The combined boolean — "is the SELECTED serial device present
-    // AND is the transport in zombie DeviceSleep?" — drives the recovery signal:
-    // distinctUntilChanged coalesces same-value re-emissions from UsbRepository and from
-    // incidental state transitions, drop(1) skips the initial cold emission so we never fire on
-    // the startup snapshot, and filter{it} fires only on the absent → present convergence.
+    // connection state together. Recovery is armed only after the SELECTED serial key has been
+    // observed absent and then present again. That "armed by absence" edge is what separates a real
+    // replug from a normal unplug race where onDisconnect(DeviceSleep) arrives before UsbRepository
+    // has removed the still-present key.
     // There is no symmetric stop on absent → absent: the transport's own I/O error path
     // (SerialConnectionListener.onDisconnected → onDeviceDisconnect) handles teardown, mirroring
     // how the network listener only stops on networkAvailable=false rather than trying to detect
@@ -280,23 +318,25 @@ class SharedRadioInterfaceService(
     // and the zombie transport would never recover. With state in the combine, the
     // Connected → DeviceSleep transition while presence is true re-triggers the flow.
     //
-    // Flap/loop safety: each physical replug produces exactly one false → true transition (guaranteed
-    // by distinctUntilChanged), and the recovery branch only fires when connectionRequested AND the
-    // running transport is SERIAL — so an explicit disconnect() (which clears connectionRequested and
-    // nulls runningTransportId via stopTransportLocked) immediately disarms the observer. A device
-    // that flaps N times produces at most N restarts, never an unbounded loop.
+    // Flap/loop safety: each physical replug consumes exactly one armed-by-absence transition, and
+    // the recovery branch only fires when connectionRequested AND the running transport is SERIAL —
+    // so an explicit disconnect() (which clears connectionRequested and nulls runningTransportId via
+    // stopTransportLocked) immediately disarms the observer. A device that flaps N times produces at
+    // most N restarts, never an unbounded loop.
     //
     // Extracted from initStateListeners() so that function stays under detekt's LongMethod cap (60).
     // Pure code motion — all referenced state is class-member scope, launchIn() registers the cold
     // flow on processLifecycle.coroutineScope exactly as before.
     private suspend fun observeUsbRecoveryTriggers() {
-        combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys, _connectionState) { address, keys, state ->
-            val rest = address?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }?.substring(1)
-            rest != null && rest in keys && state == ConnectionState.DeviceSleep
-        }
+        val selectedPresence =
+            combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys, ::selectedSerialPresence)
+                .distinctUntilChanged()
+
+        combine(selectedPresence, _connectionState, ::UsbRecoverySnapshot)
+            .runningFold(UsbRecoveryTriggerState()) { triggerState, snapshot -> triggerState.next(snapshot) }
             .distinctUntilChanged()
             .drop(1)
-            .filter { it }
+            .filter { it.triggerRecovery }
             .onEach {
                 transportMutex.withLock {
                     if (!connectionRequested) return@withLock
@@ -315,13 +355,12 @@ class SharedRadioInterfaceService(
                     // down silently so startTransportLocked() can build a fresh one for the replugged
                     // device. Mirrors the BLE liveness recovery shape: notifyPermanent=false (no
                     // user-facing Disconnected), sendPoliteDisconnect=false (the link is already gone).
-                    // Both stop and start live inside ignoreExceptionSuspend so a transient USB error
-                    // during teardown or bring-up cannot escape onEach and terminate the recovery flow
-                    // via .catch{} (which would disarm all future replug recoveries for this session).
+                    // Keep teardown and bring-up isolated: a transient USB close error must not skip
+                    // the fresh start, and neither error should terminate this long-lived recovery flow.
                     ignoreExceptionSuspend {
                         stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false)
-                        startTransportLocked()
                     }
+                    ignoreExceptionSuspend { startTransportLocked() }
                 }
             }
             .catch { Logger.e(it) { "serialDevicePresence recovery flow crashed" } }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -79,7 +79,7 @@ private data class UsbRecoveryTriggerState(
 )
 
 private fun selectedSerialPresence(address: String?, keys: Set<String>): SelectedSerialPresence {
-    val key = address?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }?.substring(1)
+    val key = address?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }?.drop(1)?.takeIf { it.isNotEmpty() }
     return SelectedSerialPresence(key = key, present = key != null && key in keys)
 }
 
@@ -307,37 +307,17 @@ class SharedRadioInterfaceService(
         }
     }
 
-    // USB-serial recovery: when the selected SERIAL ('s') device is unplugged, the underlying
-    // SerialRadioTransport's onDisconnected fires and emits a transient DeviceSleep, but the
-    // orchestrator does not bring the transport back automatically when the device is replugged.
-    // Without this observer the user must manually re-select the device after every replug.
-    //
-    // We watch the SERIAL device-key set, the currently-selected address, AND the transport
-    // connection state together. Recovery is armed only after the SELECTED serial key has been
-    // observed absent and then present again. That "armed by absence" edge is what separates a real
-    // replug from a normal unplug race where onDisconnect(DeviceSleep) arrives before UsbRepository
-    // has removed the still-present key.
-    // There is no symmetric stop on absent → absent: the transport's own I/O error path
-    // (SerialConnectionListener.onDisconnected → onDeviceDisconnect) handles teardown, mirroring
-    // how the network listener only stops on networkAvailable=false rather than trying to detect
-    // TCP socket death itself.
-    //
-    // Race correctness: including _connectionState in the trigger closes the unplug/replug race
-    // where presence arrives BEFORE the I/O-death callback flips state to DeviceSleep. Without it,
-    // the early-return on Connected/Connecting (below) would swallow the presence emission, the
-    // subsequent state transition would NOT re-emit (distinctUntilChanged swallows true → true),
-    // and the zombie transport would never recover. With state in the combine, the
-    // Connected → DeviceSleep transition while presence is true re-triggers the flow.
-    //
-    // Flap/loop safety: each physical replug consumes exactly one armed-by-absence transition, and
-    // the recovery branch only fires when connectionRequested AND the running transport is SERIAL —
-    // so an explicit disconnect() (which clears connectionRequested and nulls runningTransportId via
-    // stopTransportLocked) immediately disarms the observer. A device that flaps N times produces at
-    // most N restarts, never an unbounded loop.
-    //
-    // Extracted from initStateListeners() so that function stays under detekt's LongMethod cap (60).
-    // Pure code motion — all referenced state is class-member scope, launchIn() registers the cold
-    // flow on processLifecycle.coroutineScope exactly as before.
+    /**
+     * Observes selected-SERIAL-device presence and transport state to auto-restart USB serial after replug.
+     *
+     * Recovery arms only after the selected serial key is observed absent, then fires when that same key is present
+     * while the transport is in [ConnectionState.DeviceSleep]. This prevents normal unplug races from restarting
+     * against stale presence before UsbRepository removes the key.
+     *
+     * Including [_connectionState] closes the race where presence returns before the I/O-death callback flips state to
+     * [ConnectionState.DeviceSleep]. Each physical replug consumes one armed edge, and recovery remains gated by
+     * [connectionRequested] and [runningTransportId] so explicit disconnects cannot resurrect a transport.
+     */
     private fun observeUsbRecoveryTriggers() {
         val selectedPresence =
             combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys, ::selectedSerialPresence)
@@ -364,12 +344,8 @@ class SharedRadioInterfaceService(
                     // Re-check presence under the lock — the combine snapshot may be stale
                     // if the device was unplugged or the selection changed while awaiting
                     // the mutex. Mirrors the race-defense pattern of the state check above.
-                    val currentRest =
-                        _currentDeviceAddressFlow.value
-                            ?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }
-                            ?.substring(1)
                     val currentKeys = serialDevicePresence.deviceKeys.value
-                    if (currentRest == null || currentRest !in currentKeys) {
+                    if (!selectedSerialPresence(_currentDeviceAddressFlow.value, currentKeys).present) {
                         return@withLock
                     }
                     // A previously-started SERIAL transport that died on unplug is still held in

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -34,6 +34,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -53,6 +57,7 @@ import org.meshtastic.core.model.InterfaceId
 import org.meshtastic.core.model.MeshActivity
 import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.network.repository.NetworkRepository
+import org.meshtastic.core.network.repository.SerialDevicePresence
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioPrefs
@@ -74,6 +79,7 @@ class SharedRadioInterfaceService(
     private val dispatchers: CoroutineDispatchers,
     private val bluetoothRepository: BluetoothRepository,
     private val networkRepository: NetworkRepository,
+    private val serialDevicePresence: SerialDevicePresence,
     @Named("ProcessLifecycle") private val processLifecycle: Lifecycle,
     private val radioPrefs: RadioPrefs,
     private val transportFactory: RadioTransportFactory,
@@ -245,8 +251,81 @@ class SharedRadioInterfaceService(
                     }
                     .catch { Logger.e(it) { "networkRepository.networkAvailable flow crashed" } }
                     .launchIn(processLifecycle.coroutineScope)
+
+                observeUsbRecoveryTriggers()
             }
         }
+    }
+
+    // USB-serial recovery: when the selected SERIAL ('s') device is unplugged, the underlying
+    // SerialRadioTransport's onDisconnected fires and emits a transient DeviceSleep, but the
+    // orchestrator does not bring the transport back automatically when the device is replugged.
+    // Without this observer the user must manually re-select the device after every replug.
+    //
+    // We watch the SERIAL device-key set, the currently-selected address, AND the transport
+    // connection state together. The combined boolean — "is the SELECTED serial device present
+    // AND is the transport in zombie DeviceSleep?" — drives the recovery signal:
+    // distinctUntilChanged coalesces same-value re-emissions from UsbRepository and from
+    // incidental state transitions, drop(1) skips the initial cold emission so we never fire on
+    // the startup snapshot, and filter{it} fires only on the absent → present convergence.
+    // There is no symmetric stop on absent → absent: the transport's own I/O error path
+    // (SerialConnectionListener.onDisconnected → onDeviceDisconnect) handles teardown, mirroring
+    // how the network listener only stops on networkAvailable=false rather than trying to detect
+    // TCP socket death itself.
+    //
+    // Race correctness: including _connectionState in the trigger closes the unplug/replug race
+    // where presence arrives BEFORE the I/O-death callback flips state to DeviceSleep. Without it,
+    // the early-return on Connected/Connecting (below) would swallow the presence emission, the
+    // subsequent state transition would NOT re-emit (distinctUntilChanged swallows true → true),
+    // and the zombie transport would never recover. With state in the combine, the
+    // Connected → DeviceSleep transition while presence is true re-triggers the flow.
+    //
+    // Flap/loop safety: each physical replug produces exactly one false → true transition (guaranteed
+    // by distinctUntilChanged), and the recovery branch only fires when connectionRequested AND the
+    // running transport is SERIAL — so an explicit disconnect() (which clears connectionRequested and
+    // nulls runningTransportId via stopTransportLocked) immediately disarms the observer. A device
+    // that flaps N times produces at most N restarts, never an unbounded loop.
+    //
+    // Extracted from initStateListeners() so that function stays under detekt's LongMethod cap (60).
+    // Pure code motion — all referenced state is class-member scope, launchIn() registers the cold
+    // flow on processLifecycle.coroutineScope exactly as before.
+    private suspend fun observeUsbRecoveryTriggers() {
+        combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys, _connectionState) { address, keys, state ->
+            val rest = address?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }?.substring(1)
+            rest != null && rest in keys && state == ConnectionState.DeviceSleep
+        }
+            .distinctUntilChanged()
+            .drop(1)
+            .filter { it }
+            .onEach {
+                transportMutex.withLock {
+                    if (!connectionRequested) return@withLock
+                    if (runningTransportId != InterfaceId.SERIAL) return@withLock
+                    // Race-defense: the combine snapshot may be stale by the time we acquire
+                    // transportMutex — another path (setDeviceAddress, BLE liveness restart) may
+                    // have just brought this transport up to Connected/Connecting. The combine-level
+                    // state filter narrows the trigger; this check guards the emission → mutex
+                    // acquisition window so we never tear down a fresh healthy transport.
+                    val state = _connectionState.value
+                    if (state is ConnectionState.Connected || state is ConnectionState.Connecting) {
+                        return@withLock
+                    }
+                    // A previously-started SERIAL transport that died on unplug is still held in
+                    // radioTransport (the I/O-death path emits DeviceSleep but does not null it). Tear it
+                    // down silently so startTransportLocked() can build a fresh one for the replugged
+                    // device. Mirrors the BLE liveness recovery shape: notifyPermanent=false (no
+                    // user-facing Disconnected), sendPoliteDisconnect=false (the link is already gone).
+                    // Both stop and start live inside ignoreExceptionSuspend so a transient USB error
+                    // during teardown or bring-up cannot escape onEach and terminate the recovery flow
+                    // via .catch{} (which would disarm all future replug recoveries for this session).
+                    ignoreExceptionSuspend {
+                        stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false)
+                        startTransportLocked()
+                    }
+                }
+            }
+            .catch { Logger.e(it) { "serialDevicePresence recovery flow crashed" } }
+            .launchIn(processLifecycle.coroutineScope)
     }
 
     override fun connect() {

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -89,6 +89,8 @@ private fun UsbRecoveryTriggerState.next(snapshot: UsbRecoverySnapshot): UsbReco
     return when {
         key == null -> UsbRecoveryTriggerState()
 
+        snapshot.state == ConnectionState.Disconnected -> UsbRecoveryTriggerState(key = key, present = present)
+
         key != this.key ->
             UsbRecoveryTriggerState(
                 key = key,

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -327,7 +327,7 @@ class SharedRadioInterfaceService(
     // Extracted from initStateListeners() so that function stays under detekt's LongMethod cap (60).
     // Pure code motion — all referenced state is class-member scope, launchIn() registers the cold
     // flow on processLifecycle.coroutineScope exactly as before.
-    private suspend fun observeUsbRecoveryTriggers() {
+    private fun observeUsbRecoveryTriggers() {
         val selectedPresence =
             combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys, ::selectedSerialPresence)
                 .distinctUntilChanged()
@@ -348,6 +348,17 @@ class SharedRadioInterfaceService(
                     // acquisition window so we never tear down a fresh healthy transport.
                     val state = _connectionState.value
                     if (state is ConnectionState.Connected || state is ConnectionState.Connecting) {
+                        return@withLock
+                    }
+                    // Re-check presence under the lock — the combine snapshot may be stale
+                    // if the device was unplugged or the selection changed while awaiting
+                    // the mutex. Mirrors the race-defense pattern of the state check above.
+                    val currentRest =
+                        _currentDeviceAddressFlow.value
+                            ?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }
+                            ?.substring(1)
+                    val currentKeys = serialDevicePresence.deviceKeys.value
+                    if (currentRest == null || currentRest !in currentKeys) {
                         return@withLock
                     }
                     // A previously-started SERIAL transport that died on unplug is still held in

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -1267,8 +1267,8 @@ class SharedRadioInterfaceServiceLivenessTest {
     //         ignoreExceptionSuspend { startTransportLocked() }
     //     } }
     //
-    // The seven tests below drive the controllable [serialDeviceKeys] flow directly to exercise each
-    // branch of that gate contract.
+    // The tests below drive the controllable [serialDeviceKeys] flow directly to exercise each branch of that gate
+    // contract.
 
     /**
      * Happy path: a SERIAL transport left in zombie DeviceSleep (after an unplug I/O death) is recovered automatically
@@ -1536,6 +1536,75 @@ class SharedRadioInterfaceServiceLivenessTest {
             assertFalse(
                 service.connectionState.value == ConnectionState.Connected,
                 "State must remain Disconnected after post-disconnect replug",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: the reducer's armed-by-absence state must not survive an explicit Disconnected state. A user can
+     * unplug while Connected, explicitly disconnect before replugging, then reconnect later. That later normal
+     * transport-level unplug callback arrives while the selected key is still present; it must not consume stale arm
+     * state from the previous connection and restart the fresh transport.
+     */
+    @Test
+    fun `USB recovery arm clears across explicit disconnect before reconnect`() = runTest(testDispatcher) {
+        clock = 0L
+        val selectedKey = "/dev/bus/usb/001/002"
+        serialDeviceKeys.value = setOf(selectedKey)
+        val service = createConnectedService("s$selectedKey")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            val initialTransport = createdTransports.first()
+
+            // Detach while Connected arms the replug edge but must not restart while the transport is healthy.
+            serialDeviceKeys.value = emptySet()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(1, createdTransports.size, "Detach while Connected must NOT restart transport")
+            assertFalse(initialTransport.closeCalled, "Detach while Connected must not close the transport")
+
+            // Explicit disconnect must clear the armed reducer state.
+            service.disconnect()
+            advanceTimeBy(1_000L)
+            val transportCountAfterDisconnect = createdTransports.size
+            assertEquals(ConnectionState.Disconnected, service.connectionState.value, "Precondition: disconnected")
+
+            // Replug while disconnected must not preserve stale arm into the next connection.
+            serialDeviceKeys.value = setOf(selectedKey)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                transportCountAfterDisconnect,
+                createdTransports.size,
+                "Replug while disconnected must NOT restart transport",
+            )
+
+            service.connect()
+            service.onConnect()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            val reconnectedTransport = createdTransports.last()
+            val transportCountAfterReconnect = createdTransports.size
+            assertEquals(ConnectionState.Connected, service.connectionState.value, "Precondition: reconnected")
+
+            service.onDisconnect(isPermanent = false)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                transportCountAfterReconnect,
+                createdTransports.size,
+                "Normal unplug after reconnect must NOT restart from stale armed state",
+            )
+            assertFalse(
+                reconnectedTransport.closeCalled,
+                "Fresh transport must not be closed by stale recovery arm",
             )
         } finally {
             service.disconnect()

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -82,6 +82,9 @@ class SharedRadioInterfaceServiceLivenessTest {
         // Create the lifecycle owner AFTER setMain so Robolectric's main thread is ready.
         // Field initializers run before @BeforeTest, which is too early for Robolectric.
         processLifecycleOwner = TestLifecycleOwner()
+        // USB tests leave serialDeviceKeys non-empty; reset before each test so non-USB
+        // tests start from the documented empty default.
+        serialDeviceKeys.value = emptySet()
     }
 
     @AfterTest

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -1246,30 +1246,25 @@ class SharedRadioInterfaceServiceLivenessTest {
     //
     // The USB-serial recovery observer (see observeUsbRecoveryTriggers) watches the selected SERIAL device's
     // presence via [SerialDevicePresence.deviceKeys] combined with [currentDeviceAddressFlow] and
-    // [_connectionState]. On the absent → present transition for the SELECTED serial device while the
-    // transport is in zombie DeviceSleep, it tears down the zombie transport (left over from the unplug
-    // I/O-death path that emits DeviceSleep without nulling radioTransport) and starts a fresh one —
-    // sparing the user a manual re-select.
+    // [_connectionState]. It arms recovery only after the SELECTED serial key has been observed absent and then
+    // present again; when that armed edge converges with zombie DeviceSleep, it tears down the zombie transport
+    // (left over from the unplug I/O-death path that emits DeviceSleep without nulling radioTransport) and starts a
+    // fresh one — sparing the user a manual re-select.
     //
     // Pipeline (see SharedRadioInterfaceService.observeUsbRecoveryTriggers):
-    //   combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys, _connectionState) { address, keys, state ->
-    //     val rest = address?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }?.substring(1)
-    //     rest != null && rest in keys && state == ConnectionState.DeviceSleep
-    //   }
-    //     .distinctUntilChanged()  // coalesce same-value emissions from UsbRepository
-    //     .drop(1)                  // skip the cold snapshot so a present-at-boot device doesn't fire
-    //     .filter { it }            // fire only on absent → present (false → true)
+    //   selectedPresence = combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys)
+    //   combine(selectedPresence, _connectionState)
+    //     .runningFold(...)         // arms only after selected key goes absent → present
+    //     .filter { triggerRecovery }
     //     .onEach { transportMutex.withLock {
     //         if (!connectionRequested) return@withLock
     //         if (runningTransportId != InterfaceId.SERIAL) return@withLock
     //         if (state is Connected || state is Connecting) return@withLock  // race-defense
-    //         ignoreExceptionSuspend {
-    //             stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false)
-    //             startTransportLocked()
-    //         }
+    //         ignoreExceptionSuspend { stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false) }
+    //         ignoreExceptionSuspend { startTransportLocked() }
     //     } }
     //
-    // The six tests below drive the controllable [serialDeviceKeys] flow directly to exercise each
+    // The seven tests below drive the controllable [serialDeviceKeys] flow directly to exercise each
     // branch of that gate contract.
 
     /**
@@ -1401,6 +1396,55 @@ class SharedRadioInterfaceServiceLivenessTest {
                 createdTransports.first().closeCalled,
                 "Zombie transport must be closed by stopTransportLocked",
             )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: some USB stacks deliver the transport disconnect callback before UsbRepository has emitted the detach
+     * that removes the selected key. A present-at-start key plus DeviceSleep is only "normal unplug in progress", not a
+     * replug, so recovery must stay quiet until the observer sees the selected key go absent and then present again.
+     */
+    @Test
+    fun `USB disconnect before detach emission waits for absent to present replug`() = runTest(testDispatcher) {
+        clock = 0L
+        serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+        val service = createConnectedService("s/dev/bus/usb/001/002")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            val initialTransport = createdTransports.first()
+            assertEquals(ConnectionState.Connected, service.connectionState.value, "Precondition: Connected state")
+
+            // The transport-level disconnect arrives before the deviceKeys detach emission. Because the key was
+            // already present, this must not be treated as an absent → present replug.
+            service.onDisconnect(isPermanent = false)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                1,
+                createdTransports.size,
+                "DeviceSleep with an already-present key must NOT restart transport",
+            )
+            assertFalse(initialTransport.closeCalled, "Unplug callback alone must not close the transport")
+
+            // Now the actual detach/attach sequence is visible: absent first, then present again.
+            serialDeviceKeys.value = emptySet()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(1, createdTransports.size, "Detach emission alone must not restart transport")
+            assertFalse(initialTransport.closeCalled, "Detach emission alone must not close the transport")
+
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(2, createdTransports.size, "Absent → present replug should create one fresh transport")
+            assertTrue(initialTransport.closeCalled, "Zombie transport must be closed by stopTransportLocked")
+            assertEquals(1, initialTransport.closeCount, "Zombie transport closed exactly once")
         } finally {
             service.disconnect()
             advanceTimeBy(1_000L)

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -41,6 +43,7 @@ import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.network.repository.NetworkRepository
+import org.meshtastic.core.network.repository.SerialDevicePresence
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioTransport
 import org.meshtastic.core.repository.RadioTransportFactory
@@ -110,6 +113,19 @@ class SharedRadioInterfaceServiceLivenessTest {
 
     private val bluetoothRepository = FakeBluetoothRepository()
     private val radioPrefs = FakeRadioPrefs()
+
+    /**
+     * Controllable backing flow for [serialDevicePresence]. Defaults to the empty set so liveness/gate-regression tests
+     * (which exercise BLE/TCP paths only) leave the USB recovery observer inert. USB replug tests drive this flow
+     * directly to exercise each branch of the observer's gate contract.
+     */
+    private val serialDeviceKeys = MutableStateFlow<Set<String>>(emptySet())
+
+    /** [SerialDevicePresence] backed by [serialDeviceKeys] so tests can publish device-key sets on demand. */
+    private val serialDevicePresence: SerialDevicePresence =
+        object : SerialDevicePresence {
+            override val deviceKeys: StateFlow<Set<String>> = serialDeviceKeys.asStateFlow()
+        }
 
     private val networkRepository: NetworkRepository = mock(MockMode.autofill)
     private val analytics: PlatformAnalytics = mock(MockMode.autofill)
@@ -232,6 +248,7 @@ class SharedRadioInterfaceServiceLivenessTest {
                 dispatchers = dispatchers,
                 bluetoothRepository = bluetoothRepository,
                 networkRepository = networkRepository,
+                serialDevicePresence = serialDevicePresence,
                 processLifecycle = processLifecycleOwner.lifecycle,
                 radioPrefs = radioPrefs,
                 transportFactory = transportFactory,
@@ -1224,4 +1241,250 @@ class SharedRadioInterfaceServiceLivenessTest {
                 advanceTimeBy(1_000L)
             }
         }
+
+    // ─── USB serial replug observer (observeUsbRecoveryTriggers) ───────────────────────────
+    //
+    // The USB-serial recovery observer (see observeUsbRecoveryTriggers) watches the selected SERIAL device's
+    // presence via [SerialDevicePresence.deviceKeys] combined with [currentDeviceAddressFlow] and
+    // [_connectionState]. On the absent → present transition for the SELECTED serial device while the
+    // transport is in zombie DeviceSleep, it tears down the zombie transport (left over from the unplug
+    // I/O-death path that emits DeviceSleep without nulling radioTransport) and starts a fresh one —
+    // sparing the user a manual re-select.
+    //
+    // Pipeline (see SharedRadioInterfaceService.observeUsbRecoveryTriggers):
+    //   combine(currentDeviceAddressFlow, serialDevicePresence.deviceKeys, _connectionState) { address, keys, state ->
+    //     val rest = address?.takeIf { it.firstOrNull() == InterfaceId.SERIAL.id }?.substring(1)
+    //     rest != null && rest in keys && state == ConnectionState.DeviceSleep
+    //   }
+    //     .distinctUntilChanged()  // coalesce same-value emissions from UsbRepository
+    //     .drop(1)                  // skip the cold snapshot so a present-at-boot device doesn't fire
+    //     .filter { it }            // fire only on absent → present (false → true)
+    //     .onEach { transportMutex.withLock {
+    //         if (!connectionRequested) return@withLock
+    //         if (runningTransportId != InterfaceId.SERIAL) return@withLock
+    //         if (state is Connected || state is Connecting) return@withLock  // race-defense
+    //         ignoreExceptionSuspend {
+    //             stopTransportLocked(notifyPermanent = false, sendPoliteDisconnect = false)
+    //             startTransportLocked()
+    //         }
+    //     } }
+    //
+    // The six tests below drive the controllable [serialDeviceKeys] flow directly to exercise each
+    // branch of that gate contract.
+
+    /**
+     * Happy path: a SERIAL transport left in zombie DeviceSleep (after an unplug I/O death) is recovered automatically
+     * when the same USB device is replugged. The observer must call stopTransportLocked + startTransportLocked exactly
+     * once, producing exactly one fresh transport and closing the zombie.
+     *
+     * The zombie state mirrors what `SerialConnectionListener.onDisconnected → onDeviceDisconnect` leaves behind: a
+     * transient DeviceSleep emission WITHOUT nulling radioTransport (the I/O-death path doesn't run
+     * stopTransportLocked). Only the observer's stop/start cycle reaps the zombie and builds a fresh transport for the
+     * replugged device.
+     */
+    @Test
+    fun `USB replug of selected serial device restarts transport when zombie`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("s/dev/bus/usb/001/002")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            val initialTransport = createdTransports.first()
+
+            // Simulate the unplug I/O-death path: SerialConnectionListener.onDisconnected →
+            // onDeviceDisconnect emits a transient DeviceSleep but does NOT null radioTransport
+            // (the zombie state the observer comment specifies it recovers from).
+            service.onDisconnect(isPermanent = false)
+            assertEquals(ConnectionState.DeviceSleep, service.connectionState.value, "Precondition: zombie state")
+
+            // Replug: serialDevicePresence emits the device's `rest` key (the address minus its 's').
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(2, createdTransports.size, "Replug should create exactly one fresh transport")
+            assertTrue(initialTransport.closeCalled, "Zombie transport must be closed by stopTransportLocked")
+            assertEquals(1, initialTransport.closeCount, "Zombie transport closed exactly once (no double-close)")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Negative counterpart: only the SELECTED device's key triggers recovery. A different USB device being plugged in
+     * must not perturb the selected transport — `rest in keys` evaluates false, the combined flow stays false, and
+     * distinctUntilChanged swallows the redundant false emission.
+     */
+    @Test
+    fun `USB replug of unrelated serial device does not restart transport`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("s/dev/bus/usb/001/002")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+
+            service.onDisconnect(isPermanent = false)
+            assertEquals(ConnectionState.DeviceSleep, service.connectionState.value, "Precondition: zombie state")
+
+            // A different physical device — different `rest` key from the selected address.
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/003")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(1, createdTransports.size, "Unrelated device replug must NOT restart transport")
+            assertFalse(
+                createdTransports.first().closeCalled,
+                "Zombie transport must NOT be closed for an unrelated device",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Healthy-state guard: when the selected device is already Connected (or Connecting), the observer must NOT fire a
+     * restart. This guards the cold-flow false → true transition that happens when the user selects an already-present
+     * USB device — setDeviceAddress has already brought the transport up to Connected, so a "recovery" cycle would be a
+     * redundant teardown of a healthy link.
+     */
+    @Test
+    fun `USB replug does not restart transport when already Connected`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("s/dev/bus/usb/001/002")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            assertEquals(ConnectionState.Connected, service.connectionState.value, "Precondition: Connected state")
+
+            // Device present in the keys — but state is Connected (healthy), not zombie.
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(1, createdTransports.size, "Healthy-state guard must skip restart for Connected state")
+            assertFalse(createdTransports.first().closeCalled, "Healthy transport must NOT be closed")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: the unplug/replug race in which the USB presence signal arrives BEFORE the I/O-death callback has
+     * flipped `_connectionState` to DeviceSleep. The combined trigger now includes `_connectionState` so that the
+     * subsequent Connected → DeviceSleep transition re-emits the flow and fires recovery — without that, the
+     * early-return on Connected swallows the presence emission, the later state transition does not re-emit
+     * (distinctUntilChanged swallows true → true), and the zombie transport never recovers.
+     */
+    @Test
+    fun `USB replug recovers when presence arrives before DeviceSleep`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("s/dev/bus/usb/001/002")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            assertEquals(ConnectionState.Connected, service.connectionState.value, "Precondition: Connected state")
+
+            // Replug signal arrives WHILE state is still Connected — the trigger must NOT fire yet.
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+            assertEquals(1, createdTransports.size, "Presence while Connected must NOT restart transport")
+            assertFalse(createdTransports.first().closeCalled, "Healthy transport must NOT be closed")
+
+            // The I/O-death callback now fires (late) and flips state to DeviceSleep. The combine
+            // re-emits because state is one of its sources; recovery fires after the state catches up.
+            service.onDisconnect(isPermanent = false)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(2, createdTransports.size, "Recovery MUST fire once state catches up to DeviceSleep")
+            assertTrue(
+                createdTransports.first().closeCalled,
+                "Zombie transport must be closed by stopTransportLocked",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: after explicit [SharedRadioInterfaceService.disconnect], the observer MUST be disarmed. disconnect()
+     * clears `connectionRequested` BEFORE stopTransportLocked(), so even if the selected device reappears the
+     * observer's first gate (`!connectionRequested → return@withLock`) fires and no transport is resurrected for a
+     * connection the user tore down. Same shape as the BLE/network post-disconnect recovery regressions above.
+     */
+    @Test
+    fun `USB replug does not restart transport after explicit disconnect`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("s/dev/bus/usb/001/002")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+
+            // Explicit user disconnect: clears connectionRequested gate BEFORE stopTransportLocked(),
+            // nulls radioTransport, and clears runningTransportId. The observer is now disarmed on
+            // multiple gates.
+            service.disconnect()
+            advanceTimeBy(1_000L)
+            val transportCountAfterDisconnect = createdTransports.size
+
+            // Replug the selected device — the observer must observe but not act.
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                transportCountAfterDisconnect,
+                createdTransports.size,
+                "Replug after explicit disconnect must NOT restart transport (connectionRequested gate)",
+            )
+            assertFalse(
+                service.connectionState.value == ConnectionState.Connected,
+                "State must remain Disconnected after post-disconnect replug",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: duplicate same-value emissions of [serialDevicePresence.deviceKeys] must not produce duplicate
+     * restarts. StateFlow semantics dedupe equal set re-publications at the source, and the pipeline's
+     * distinctUntilChanged() coalesces any redundant true → true emissions that slip through, so even a flappy
+     * publisher that re-emits the same set produces exactly ONE stop+start cycle for one physical replug.
+     */
+    @Test
+    fun `USB replug duplicate same-key emissions produce exactly one restart`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("s/dev/bus/usb/001/002")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+
+            service.onDisconnect(isPermanent = false)
+            assertEquals(ConnectionState.DeviceSleep, service.connectionState.value, "Precondition: zombie state")
+
+            // First replug: triggers one restart (false → true transition through the pipeline).
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+            val transportsAfterFirstReplug = createdTransports.size
+
+            // Duplicate same-value emission (e.g. a flappy UsbRepository re-publishing the same set).
+            // StateFlow dedupes equal values at the source; distinctUntilChanged() coalesces any
+            // redundant true → true. No additional restart.
+            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                transportsAfterFirstReplug,
+                createdTransports.size,
+                "Duplicate same-key emission must NOT produce a second restart",
+            )
+            assertEquals(2, createdTransports.size, "Exactly one restart total (1 initial + 1 replug)")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
 }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -1376,13 +1376,25 @@ class SharedRadioInterfaceServiceLivenessTest {
     @Test
     fun `USB replug recovers when presence arrives before DeviceSleep`() = runTest(testDispatcher) {
         clock = 0L
-        val service = createConnectedService("s/dev/bus/usb/001/002")
+        val selectedKey = "/dev/bus/usb/001/002"
+        serialDeviceKeys.value = setOf(selectedKey)
+        val service = createConnectedService("s$selectedKey")
         try {
             assertEquals(1, createdTransports.size, "Initial connect should create one transport")
             assertEquals(ConnectionState.Connected, service.connectionState.value, "Precondition: Connected state")
 
+            // The actual detach is observed first, while state is still Connected.
+            serialDeviceKeys.value = emptySet()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+            assertEquals(1, createdTransports.size, "Detach while Connected must NOT restart transport")
+            assertFalse(
+                createdTransports.first().closeCalled,
+                "Detach while Connected must NOT close the transport",
+            )
+
             // Replug signal arrives WHILE state is still Connected — the trigger must NOT fire yet.
-            serialDeviceKeys.value = setOf("/dev/bus/usb/001/002")
+            serialDeviceKeys.value = setOf(selectedKey)
             testDispatcher.scheduler.runCurrent()
             advanceTimeBy(1_000L)
             assertEquals(1, createdTransports.size, "Presence while Connected must NOT restart transport")
@@ -1399,6 +1411,43 @@ class SharedRadioInterfaceServiceLivenessTest {
                 createdTransports.first().closeCalled,
                 "Zombie transport must be closed by stopTransportLocked",
             )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    /**
+     * Regression: Android serialDevices starts as an empty snapshot before UsbRepository refreshes. That initial empty
+     * → present emission is not a detach/replug edge and must not arm recovery for a later normal unplug callback.
+     */
+    @Test
+    fun `USB initial empty presence does not arm recovery`() = runTest(testDispatcher) {
+        clock = 0L
+        val selectedKey = "/dev/bus/usb/001/002"
+        val service = createConnectedService("s$selectedKey")
+        try {
+            assertEquals(1, createdTransports.size, "Initial connect should create one transport")
+            val initialTransport = createdTransports.first()
+            assertEquals(ConnectionState.Connected, service.connectionState.value, "Precondition: Connected state")
+
+            serialDeviceKeys.value = setOf(selectedKey)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(1, createdTransports.size, "Initial empty → present must NOT restart transport")
+            assertFalse(initialTransport.closeCalled, "Initial presence refresh must not close the transport")
+
+            service.onDisconnect(isPermanent = false)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                1,
+                createdTransports.size,
+                "Later DeviceSleep with initially-present key must NOT restart transport",
+            )
+            assertFalse(initialTransport.closeCalled, "Unplug callback alone must not close the transport")
         } finally {
             service.disconnect()
             advanceTimeBy(1_000L)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request improves resilience in the Meshtastic Android app around USB serial devices by (1) tracking which serial devices are currently connected via a platform abstraction, (2) automatically recovering the currently selected SERIAL transport after an unplug/replug when the transport is stuck in a “zombie” `ConnectionState.DeviceSleep` state, and (3) preventing spurious/duplicate disconnect callbacks during explicit transport shutdown. It also adjusts USB-device-attach navigation so the UI doesn’t switch pages when a device is already selected.

## Key Changes

### Features
- Added `SerialDevicePresence` (common interface) exposing `deviceKeys: StateFlow<Set<String>>`, derived from the “rest” portion of `InterfaceId.SERIAL` addresses.
- Implemented `SerialDevicePresence` per platform:
  - Android: `AndroidSerialDevicePresence` maps `UsbRepository.serialDevices` to a `StateFlow` of serial device keys (eagerly materialized).
  - JVM/Desktop: `JvmSerialDevicePresence` returns an always-empty `deviceKeys` set (no hot-plug updates).
- Updated `SharedRadioInterfaceService` to observe:
  - the selected device address (`currentDeviceAddressFlow`),
  - `SerialDevicePresence.deviceKeys`,
  - and transport `_connectionState`,
  and to perform “absent → present” armed recovery only when the transport snapshot is `ConnectionState.DeviceSleep`.
  - Recovery trigger is de-duplicated and suppresses initial emissions.
  - Under `transportMutex`, it revalidates guards (still requested, still running SERIAL transport, not already `Connected/Connecting`, and the selected key is still present) before restarting.
  - Restart is done as a “silent recovery” (stop zombie transport with `notifyPermanent=false`, `sendPoliteDisconnect=false`, then start immediately), with exceptions logged so the observer doesn’t terminate.

- Updated `MainActivity` USB attach handling:
  - Uses `NO_DEVICE_SELECTED` and `model.currentDeviceAddressFlow` to decide whether to navigate.
  - If a device is already selected, it avoids routing to the connections UI; otherwise it navigates via the `/connections` deep link.

### Fixes
- Hardened explicit shutdown to avoid transient disconnect forwarding:
  - `SerialRadioTransport` adds `explicitCloseInProgress` (`AtomicBoolean`) so `SerialConnectionListener.onDisconnected` suppresses disconnect handling during an explicit `close()`.
  - Added `SerialRadioTransport.close()` that coordinates teardown through a shared `closeConnection(waitForStopped)` helper (including atomically clearing `connRef` before closing the connection) and resets the suppression flag in `finally`.
  - Refactored `onDeviceDisconnect(...)` to route through the same teardown helper and only call `super` when a connection was present and actually closed.

- Adjusted transport close semantics:
  - `StreamTransport.close()` no longer calls `onDeviceDisconnect(...)` (so `close()` does not emit disconnect callbacks).
  - Updated `onDeviceDisconnect` KDoc to clarify that the service layer owns explicit close/disconnect notifications.

### Refactors
- Centralized SERIAL teardown logic in `SerialRadioTransport` via a shared `closeConnection(waitForStopped)` path used by both `close()` and `onDeviceDisconnect(...)`.
- Reworked the USB replug recovery observer in `SharedRadioInterfaceService` into a guarded, de-duplicated, race-tolerant state machine (including timing/order assertions and an explicit disarm condition after manual disconnect).

### Testing
- Extended `SharedRadioInterfaceServiceLivenessTest` with deterministic USB replug recovery scenarios (arming conditions, correct restart gating, unrelated-device non-restarts, “already connected” no-op, race ordering, and duplicate-key de-duplication; plus verifying disarming after `service.disconnect()`).
- Added `StreamTransportTest` assertion that `close()` does not invoke the disconnect callback.

## Breaking Changes / Migration Notes
- `StreamTransport.close()` no longer triggers `onDeviceDisconnect(...)` callbacks, so any behavior relying on transport-emitted disconnect signaling should instead rely on service-layer disconnect/recovery handling.
- `SharedRadioInterfaceService` now depends on `SerialDevicePresence` being provided via DI (implemented by `AndroidSerialDevicePresence` and `JvmSerialDevicePresence` on their respective platforms).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->