### PR TITLE
Use InterfaceId for device address prefixes

### DIFF
--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/DeviceTypeTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/DeviceTypeTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** Locks down [DeviceType.name] values used by the cross-platform connect analytics event. */
+class DeviceTypeTest {
+    @Test
+    fun fromAddress_preserves_transport_analytics_names() {
+        assertEquals("BLE", DeviceType.fromAddress("x123")?.name)
+        assertEquals("USB", DeviceType.fromAddress("s/dev/bus/usb/001/002")?.name)
+        assertEquals("USB", DeviceType.fromAddress("m")?.name)
+        assertEquals("TCP", DeviceType.fromAddress("t192.0.2.1")?.name)
+    }
+
+    @Test
+    fun fromAddress_returns_null_for_non_presented_prefixes() {
+        assertNull(DeviceType.fromAddress("r"))
+        assertNull(DeviceType.fromAddress("n"))
+        assertNull(DeviceType.fromAddress(""))
+        assertNull(DeviceType.fromAddress("z"))
+    }
+}

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/Constants.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/Constants.kt
@@ -26,11 +26,5 @@ const val NO_DEVICE_SELECTED: String = "n"
 /** One-char prefix marking a TCP/Network device's `fullAddress`. See [DeviceListEntry.Tcp]. */
 const val TCP_DEVICE_PREFIX: String = "t"
 
-/** One-char prefix / sentinel marking the mock (demo-mode) device's `fullAddress`. See [DeviceListEntry.Mock]. */
-const val MOCK_DEVICE_PREFIX: String = "m"
-
-/** One-char prefix / sentinel marking the capture-replay device's `fullAddress`. See [DeviceListEntry.Replay]. */
-const val REPLAY_DEVICE_PREFIX: String = "r"
-
 /** One-char prefix marking a BLE device's `fullAddress`. See [DeviceListEntry.Ble]. */
 const val BLE_DEVICE_PREFIX: String = "x"

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/model/DeviceListEntry.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/model/DeviceListEntry.kt
@@ -18,6 +18,7 @@ package org.meshtastic.feature.connections.model
 
 import org.meshtastic.core.ble.BleDevice
 import org.meshtastic.core.ble.MeshtasticBleConstants.BLE_NAME_PATTERN
+import org.meshtastic.core.model.InterfaceId
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.util.anonymize
 
@@ -45,7 +46,7 @@ sealed class DeviceListEntry(
         override val node: Node? = null,
     ) : DeviceListEntry(
         name = device.name ?: "unnamed-${device.address}",
-        fullAddress = "x${device.address}",
+        fullAddress = "${InterfaceId.BLUETOOTH.id}${device.address}",
         bonded = bonded,
         node = node,
     ) {
@@ -69,13 +70,13 @@ sealed class DeviceListEntry(
     }
 
     data class Mock(override val name: String, override val node: Node? = null) :
-        DeviceListEntry(name, "m", true, node) {
+        DeviceListEntry(name, InterfaceId.MOCK.id.toString(), true, node) {
         override fun copy(node: Node?): Mock = copy(name = name, node = node)
     }
 
     /** Debug-only virtual device that replays a bundled packet capture on-device (see `ReplayRadioTransport`). */
     data class Replay(override val name: String, override val node: Node? = null) :
-        DeviceListEntry(name, "r", true, node) {
+        DeviceListEntry(name, InterfaceId.REPLAY.id.toString(), true, node) {
         override fun copy(node: Node?): Replay = copy(name = name, node = node)
     }
 }

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -51,6 +51,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.InterfaceId
 import org.meshtastic.core.navigation.Route
 import org.meshtastic.core.navigation.SettingsRoute
 import org.meshtastic.core.resources.Res
@@ -80,9 +81,7 @@ import org.meshtastic.core.ui.util.rememberOpenWifiSettings
 import org.meshtastic.core.ui.util.shouldShowWifiUnavailableBanner
 import org.meshtastic.core.ui.viewmodel.ConnectionStatus
 import org.meshtastic.core.ui.viewmodel.ConnectionsViewModel
-import org.meshtastic.feature.connections.MOCK_DEVICE_PREFIX
 import org.meshtastic.feature.connections.NO_DEVICE_SELECTED
-import org.meshtastic.feature.connections.REPLAY_DEVICE_PREFIX
 import org.meshtastic.feature.connections.ScannerViewModel
 import org.meshtastic.feature.connections.model.DeviceListEntry
 import org.meshtastic.feature.connections.ui.components.ConnectingDeviceInfo
@@ -272,8 +271,8 @@ fun ConnectionsScreen(
                         if (
                             uiState == ConnectionUiState.CONNECTED_WITH_NODE &&
                             regionUnset &&
-                            selectedDevice != MOCK_DEVICE_PREFIX &&
-                            selectedDevice != REPLAY_DEVICE_PREFIX
+                            selectedDevice != InterfaceId.MOCK.id.toString() &&
+                            selectedDevice != InterfaceId.REPLAY.id.toString()
                         ) {
                             Spacer(modifier = Modifier.height(8.dp))
                             Card(modifier = Modifier.fillMaxWidth()) {

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/model/DeviceListEntryTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/model/DeviceListEntryTest.kt
@@ -14,30 +14,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.meshtastic.core.model
+package org.meshtastic.feature.connections.model
 
-/** Represent the different ways a device can connect to the client. */
-enum class DeviceType {
-    BLE,
-    TCP,
-    USB,
-    ;
+import org.meshtastic.core.model.InterfaceId
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
-    companion object {
-        fun fromAddress(address: String): DeviceType? =
-            when (InterfaceId.forIdChar(address.firstOrNull() ?: return null)) {
-                InterfaceId.BLUETOOTH -> BLE
+class DeviceListEntryTest {
+    @Test
+    fun mock_uses_interface_id_prefix() {
+        val entry = DeviceListEntry.Mock(name = "Test")
 
-                InterfaceId.SERIAL,
-                InterfaceId.MOCK, // Mock/demo mode historically presents as USB.
-                -> USB
+        assertEquals(InterfaceId.MOCK.id.toString(), entry.fullAddress)
+    }
 
-                InterfaceId.TCP -> TCP
+    @Test
+    fun replay_uses_interface_id_prefix() {
+        val entry = DeviceListEntry.Replay(name = "Test")
 
-                InterfaceId.NOP,
-                InterfaceId.REPLAY,
-                null,
-                -> null
-            }
+        assertEquals(InterfaceId.REPLAY.id.toString(), entry.fullAddress)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change refactors device connection type handling so the app relies on a canonical `deviceType: DeviceType` discriminator instead of keeping several parallel representations in sync. It also adds `MOCK` and `REPLAY` support to `DeviceType`, updates address parsing and UI logic to use `InterfaceId` values, and adds tests around the new mappings and prefixes. The existing address-prefix characters are preserved, and no data migration is needed.

- Features
  - Added `MOCK` and `REPLAY` variants to `DeviceType`.
  - Updated device address parsing to recognize interface IDs and map them to the right device type.
  - Kept demo-mode telemetry labeling as `"USB"` so analytics behavior stays consistent.

- Refactors
  - Replaced hardcoded address-prefix handling with `InterfaceId`-based values in `DeviceListEntry` and connection UI logic.
  - Removed the old mock/replay prefix constants and introduced a BLE prefix constant for the connection model.

- Fixes
  - Updated the “set your region” warning logic so mock/replay selections are identified through `InterfaceId` values instead of deprecated prefix constants.
  - Added tests covering `DeviceType.fromAddress(...)` behavior and `DeviceListEntry` mock/replay prefixes.

- Migration / breaking changes
  - No migration is required.
  - No address-prefix characters were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->