### PR TITLE
fix(data): persist TAK module config and label in summaries

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigHandlerImpl.kt
@@ -130,5 +130,6 @@ private fun ModuleConfig.summarize(): String = when {
     detection_sensor != null -> "detection_sensor"
     paxcounter != null -> "paxcounter"
     statusmessage != null -> "statusmessage"
+    tak != null -> "tak"
     else -> "unknown"
 }

--- a/core/datastore/src/commonMain/kotlin/org/meshtastic/core/datastore/ModuleConfigDataSource.kt
+++ b/core/datastore/src/commonMain/kotlin/org/meshtastic/core/datastore/ModuleConfigDataSource.kt
@@ -47,6 +47,7 @@ class ModuleConfigDataSource(
     }
 
     /** Updates [LocalModuleConfig] from each [ModuleConfig] oneOf. */
+    @Suppress("CyclomaticComplexMethod")
     suspend fun setLocalModuleConfig(config: ModuleConfig) = moduleConfigStore.updateData { current ->
         when {
             config.mqtt != null -> current.copy(mqtt = config.mqtt)
@@ -77,6 +78,8 @@ class ModuleConfigDataSource(
             config.paxcounter != null -> current.copy(paxcounter = config.paxcounter)
 
             config.statusmessage != null -> current.copy(statusmessage = config.statusmessage)
+
+            config.tak != null -> current.copy(tak = config.tak)
 
             else -> current
         }


### PR DESCRIPTION
Add the tak oneOf branch to ModuleConfigDataSource.setLocalModuleConfig so received TAK configs persist to LocalModuleConfig instead of being silently dropped.

Add the matching tak label to the ModuleConfig.summarize helper in MeshConfigHandlerImpl so handleModuleConfig's debug log reports "tak" instead of "unknown".

Both branches mirror existing per-variant entries in each when block.
