### PR TITLE
Update BLE bonding failure handling and retry messaging

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -119,6 +119,7 @@ bluetooth_feature_discovery_description
 bluetooth_permission
 bold_heading
 bonding_failed_permissions
+bonding_failed_retry
 bottom_nav_settings
 broadcast_interval
 busy_noise_floor

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="bluetooth_permission">Bluetooth</string>
     <string name="bold_heading">Bold Heading</string>
     <string name="bonding_failed_permissions">Pairing failed. Grant nearby device permissions and try again.</string>
+    <string name="bonding_failed_retry">Pairing did not complete. Try pairing again.</string>
     <string name="bottom_nav_settings">Settings</string>
     <string name="broadcast_interval">Broadcast Interval</string>
     <string name="busy_noise_floor">Busy floor</string>

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -342,12 +342,21 @@ class FakeBluetoothRepository :
 
             is BondOutcome.Fail -> throw outcome.error
 
-            BondOutcome.Success -> {
-                val currentState = _state.value
-                if (!currentState.bondedDevices.contains(device)) {
-                    _state.value = currentState.copy(bondedDevices = currentState.bondedDevices + device)
-                }
+            is BondOutcome.FailAfterBond -> {
+                addBondedDevice(device)
+                throw outcome.error
             }
+
+            BondOutcome.Success -> {
+                addBondedDevice(device)
+            }
+        }
+    }
+
+    private fun addBondedDevice(device: BleDevice) {
+        val currentState = _state.value
+        if (!currentState.bondedDevices.contains(device)) {
+            _state.value = currentState.copy(bondedDevices = currentState.bondedDevices + device)
         }
     }
 
@@ -371,6 +380,9 @@ class FakeBluetoothRepository :
         /** bond() throws [error] — models a generic/flaky bonding failure (timeout, dropped broadcast, etc.). */
         data class Fail(val error: Throwable) : BondOutcome
 
+        /** bond() records the device as bonded, then throws [error] — models a lost terminal bond signal. */
+        data class FailAfterBond(val error: Throwable) : BondOutcome
+
         /** bond() throws [error] — models a missing-permission (BLUETOOTH_CONNECT) failure. */
         data class Security(val error: Throwable) : BondOutcome
     }
@@ -379,4 +391,9 @@ class FakeBluetoothRepository :
 /** Make the next [FakeBluetoothRepository.bond] call throw a generic [error] (the flaky/interrupted-bonding path). */
 fun FakeBluetoothRepository.failBondWith(error: Throwable = Exception("bond failed")) {
     bondOutcome = FakeBluetoothRepository.BondOutcome.Fail(error)
+}
+
+/** Make the next [FakeBluetoothRepository.bond] call record the device as bonded and then throw [error]. */
+fun FakeBluetoothRepository.failBondAfterRecording(error: Throwable = Exception("bond failed after pairing")) {
+    bondOutcome = FakeBluetoothRepository.BondOutcome.FailAfterBond(error)
 }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -337,20 +337,23 @@ class FakeBluetoothRepository :
 
     override suspend fun bond(device: BleDevice) {
         bondCalls += device
-        when (val outcome = bondOutcome) {
-            is BondOutcome.Security -> throw outcome.error
+        val error =
+            when (val outcome = bondOutcome) {
+                is BondOutcome.Security -> outcome.error
 
-            is BondOutcome.Fail -> throw outcome.error
+                is BondOutcome.Fail -> outcome.error
 
-            is BondOutcome.FailAfterBond -> {
-                addBondedDevice(device)
-                throw outcome.error
+                is BondOutcome.FailAfterBond -> {
+                    addBondedDevice(device)
+                    outcome.error
+                }
+
+                BondOutcome.Success -> {
+                    addBondedDevice(device)
+                    null
+                }
             }
-
-            BondOutcome.Success -> {
-                addBondedDevice(device)
-            }
-        }
+        error?.let { throw it }
     }
 
     private fun addBondedDevice(device: BleDevice) {

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -23,8 +23,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.jetbrains.compose.resources.getString
 import org.junit.runner.RunWith
 import org.meshtastic.core.network.repository.UsbRepository
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.bonding_failed_retry
 import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.core.testing.failBondAfterRecording
 import org.meshtastic.core.testing.failBondWith
@@ -130,7 +133,7 @@ class AndroidScannerViewModelBondingTest {
 
         assertEquals(1, harness.bluetoothRepository.bondCalls.size)
         assertNull(harness.radioController.lastSetDeviceAddress)
-        assertNotNull(harness.serviceRepository.errorMessage.value)
+        assertEquals(getString(Res.string.bonding_failed_retry), harness.serviceRepository.errorMessage.value)
     }
 
     @Test

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -41,10 +41,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Coverage for the #5849 fix in [AndroidScannerViewModel.requestBonding]: the transport is armed
- * (`changeDeviceAddress`) on every bonding outcome EXCEPT a permissions [SecurityException], so an interrupted bond no
- * longer strands the device. Driven through the public [ScannerViewModel.onSelected] entry point (which routes an
- * unbonded BLE entry to `requestBonding`).
+ * Coverage for [AndroidScannerViewModel.requestBonding]: only a successful bond arms the transport. Bond failures
+ * surface a warning and wait for an explicit retry so the Android pairing flow does not immediately re-enter through
+ * transport-side bonding.
  *
  * Robolectric is used only because the class under test lives in `androidMain`; the bonding outcomes themselves are
  * injected via [org.meshtastic.core.testing.FakeBluetoothRepository], keeping each assertion deterministic. The real
@@ -58,11 +57,12 @@ class AndroidScannerViewModelBondingTest {
     private val mac = "AA:BB:CC:DD:EE:FF"
     private val expectedFullAddress = "x$mac"
 
-    private val harness = ScannerViewModelHarness()
+    private lateinit var harness: ScannerViewModelHarness
     private lateinit var viewModel: AndroidScannerViewModel
 
     @BeforeTest
     fun setUp() {
+        harness = ScannerViewModelHarness()
         Dispatchers.setMain(harness.testDispatcher)
         viewModel =
             AndroidScannerViewModel(
@@ -119,17 +119,17 @@ class AndroidScannerViewModelBondingTest {
     }
 
     @Test
-    fun `generic bond failure still arms the transport`() = runTest(harness.testDispatcher) {
-        // The interrupted-bonding case the fix targets: bond() throws a non-permission error, but we must still
-        // arm the transport so its reconnect loop can converge instead of leaving the device inert.
+    fun `generic bond failure does not arm the transport and surfaces an error`() = runTest(harness.testDispatcher) {
+        // A failed pairing attempt should wait for another user action instead of immediately arming the transport,
+        // which would call transport-side bond() and risk a duplicate PIN dialog or Android createBond() throttle.
         harness.bluetoothRepository.failBondWith(Exception("Failed to initiate bonding"))
 
         viewModel.onSelected(ScannerViewModelHarness.unbondedBleEntry(mac))
         testScheduler.advanceUntilIdle()
 
         assertEquals(1, harness.bluetoothRepository.bondCalls.size)
-        assertEquals(expectedFullAddress, harness.radioController.lastSetDeviceAddress)
-        assertNull(harness.serviceRepository.errorMessage.value)
+        assertNull(harness.radioController.lastSetDeviceAddress)
+        assertNotNull(harness.serviceRepository.errorMessage.value)
     }
 
     @Test

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.feature.connections
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
@@ -159,6 +160,23 @@ class AndroidScannerViewModelBondingTest {
         assertEquals(1, harness.bluetoothRepository.bondCalls.size)
         assertNull(harness.radioController.lastSetDeviceAddress)
         assertNotNull(harness.serviceRepository.errorMessage.value)
+    }
+
+    @Test
+    fun `CancellationException from bond propagates without arming transport`() = runTest(harness.testDispatcher) {
+        // CE must propagate — not be swallowed into an error message or transport arming.
+        // Discriminator: if the CE catch were removed, CE would fall through to catch(Exception),
+        // set an error message, and return false — errorMessage would be non-null, failing this test.
+        harness.bluetoothRepository.failBondWith(CancellationException("cancelled"))
+
+        viewModel.onSelected(ScannerViewModelHarness.unbondedBleEntry(mac))
+        testScheduler.advanceUntilIdle()
+
+        assertNull(harness.radioController.lastSetDeviceAddress, "transport must not be armed")
+        assertNull(
+            harness.serviceRepository.errorMessage.value,
+            "CE must propagate, not be caught as generic failure",
+        )
     }
 
     @Test

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.meshtastic.core.network.repository.UsbRepository
 import org.meshtastic.core.testing.FakeBleDevice
+import org.meshtastic.core.testing.failBondAfterRecording
 import org.meshtastic.core.testing.failBondWith
 import org.meshtastic.core.testing.failBondWithSecurityException
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -130,6 +131,18 @@ class AndroidScannerViewModelBondingTest {
         assertEquals(1, harness.bluetoothRepository.bondCalls.size)
         assertNull(harness.radioController.lastSetDeviceAddress)
         assertNotNull(harness.serviceRepository.errorMessage.value)
+    }
+
+    @Test
+    fun `bond failure after Android records bond still arms the transport`() = runTest(harness.testDispatcher) {
+        harness.bluetoothRepository.failBondAfterRecording(Exception("Timed out waiting for bonding to complete"))
+
+        viewModel.onSelected(ScannerViewModelHarness.unbondedBleEntry(mac))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(1, harness.bluetoothRepository.bondCalls.size)
+        assertEquals(expectedFullAddress, harness.radioController.lastSetDeviceAddress)
+        assertNull(harness.serviceRepository.errorMessage.value)
     }
 
     @Test

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
@@ -91,15 +91,23 @@ class AndroidScannerViewModel(
                 } catch (ex: CancellationException) {
                     throw ex
                 } catch (ex: Exception) {
-                    Logger.w(ex) {
-                        "Bonding did not complete cleanly for ${entry.device.address.anonymize}; " +
-                            "waiting for an explicit retry"
+                    if (bluetoothRepository.isBonded(entry.device.address)) {
+                        Logger.w(ex) {
+                            "Bonding did not complete cleanly for ${entry.device.address.anonymize}, " +
+                                "but Android now reports it bonded; selecting device"
+                        }
+                        true
+                    } else {
+                        Logger.w(ex) {
+                            "Bonding did not complete cleanly for ${entry.device.address.anonymize}; " +
+                                "waiting for an explicit retry"
+                        }
+                        serviceRepository.setErrorMessage(
+                            text = getString(Res.string.bonding_failed_retry),
+                            severity = Severity.Warn,
+                        )
+                        false
                     }
-                    serviceRepository.setErrorMessage(
-                        text = getString(Res.string.bonding_failed_retry),
-                        severity = Severity.Warn,
-                    )
-                    false
                 }
             if (armTransport) {
                 changeDeviceAddress(entry.fullAddress)

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
@@ -19,6 +19,7 @@ package org.meshtastic.feature.connections
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -36,6 +37,7 @@ import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.repository.UiPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.bonding_failed_permissions
+import org.meshtastic.core.resources.bonding_failed_retry
 import org.meshtastic.core.resources.usb_permission_denied
 import org.meshtastic.feature.connections.model.AndroidUsbDeviceData
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -86,17 +88,18 @@ class AndroidScannerViewModel(
                         severity = Severity.Warn,
                     )
                     false
+                } catch (ex: CancellationException) {
+                    throw ex
                 } catch (ex: Exception) {
-                    // Bonding is flaky and can fail for many reasons: user cancel/timeout, an unreliable
-                    // ACTION_BOND_STATE_CHANGED broadcast, or an OS/GATT-initiated bond already in flight
-                    // (see Kable #111). Don't treat any of these as terminal — arm the transport anyway so
-                    // its persistent reconnect loop (which bonds on demand and retries with backoff) can
-                    // converge, instead of leaving the device inert until the user re-selects it.
                     Logger.w(ex) {
                         "Bonding did not complete cleanly for ${entry.device.address.anonymize}; " +
-                            "arming transport to retry"
+                            "waiting for an explicit retry"
                     }
-                    true
+                    serviceRepository.setErrorMessage(
+                        text = getString(Res.string.bonding_failed_retry),
+                        severity = Severity.Warn,
+                    )
+                    false
                 }
             if (armTransport) {
                 changeDeviceAddress(entry.fullAddress)


### PR DESCRIPTION
## Summary by Sourcery

Adjust BLE bonding handling so only successful or already-recorded bonds arm the transport, while failed pairings show a retry warning and wait for explicit user action.

Bug Fixes:
- Prevent transport from arming and immediately re-triggering bonding when Android pairing fails without actually recording the device as bonded.
- Ensure that bonds which succeed at the OS level but surface as failures still proceed to select the device and arm the transport.

Enhancements:
- Model a new bond failure-after-bonding scenario in the fake Bluetooth repository and share bonded-device update logic.
- Expand bonding tests to cover both non-armed generic failures with user-facing errors and failures that occur after Android records the bond.

Documentation:
- Add a user-visible string explaining that pairing did not complete and prompting the user to retry.

Tests:
- Update and extend AndroidScannerViewModel bonding tests to cover new failure-handling behavior and the after-bond failure case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the Bluetooth bonding flow so the app only arms the transport after pairing completes successfully. When bonding fails, it surfaces a user-visible “try pairing again” warning and avoids automatically re-entering Android’s pairing flow. The bonding ViewModel logic and tests were updated to reflect these new semantics, including handling cases where the device appears bonded in Android but the bonding call still fails.

- Features
  - Added a new localized string key/resource for bonding retry messaging: `bonding_failed_retry` (“Pairing did not complete. Try pairing again.”).

- Fixes
  - Updated `AndroidScannerViewModel.requestBonding` so:
    - Successful bonding is required before arming the transport.
    - `SecurityException` continues to use the existing permission-focused warning and prevents arming.
    - `CancellationException` is preserved by rethrowing (cancels the coroutine).
    - For other bonding failures:
      - If `bluetoothRepository.isBonded(...)` indicates the device is already bonded, bonding is treated as successful and the transport can be armed.
      - Otherwise, the ViewModel sets `bonding_failed_retry`, returns `false`, and does not arm the transport (so the reconnect flow doesn’t proceed automatically).
  - Updated `AndroidScannerViewModelBondingTest` to verify:
    - A non-permission bond failure does **not** arm the transport and emits an error message.
    - A bond failure that happens after Android records the bond can still arm the transport without expecting the error message.

- Refactors / test support
  - Extended `FakeBle` (`FakeBluetoothRepository`) with a new bonding outcome `BondOutcome.FailAfterBond` (records as bonded, then throws) and added `failBondAfterRecording(...)` to drive the new test scenario.
  - Adjusted test harness setup (moved `harness` to `lateinit var` created in `setUp()`) and updated test naming/KDoc to match the new bonding behavior.

- Migration / breaking changes
  - If bonding fails (and the device is not already recorded as bonded), users may need to manually retry pairing rather than relying on an automatic re-entry into the Android pairing/bonding flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->