### PR TITLE
Fix Bluetooth bonding timeout handling in AndroidBluetoothRepository

### DIFF
--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -224,7 +224,9 @@ class AndroidBluetoothRepositoryBondTest {
         val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
         val failure = launchBond(repo, mac)
-        advanceTimeBy(30_001L)
+        advanceTimeBy(29_999L)
+        assertFalse(failure.isCompleted, "bond() should still be waiting before the timeout")
+        advanceTimeBy(2L)
 
         assertEquals("Timed out waiting for bonding to complete", failure.await()?.message)
     }

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -124,15 +125,17 @@ class AndroidBluetoothRepositoryBondTest {
 
     @Test
     @Config(sdk = [34], shadows = [ShadowBondingThenBonded::class])
-    fun `createBond false but bond already established resumes immediately`() = runTest(UnconfinedTestDispatcher()) {
-        // Models the real-device race the fix targets: the bond completes between the early bondState check and
-        // the post-createBond re-check. The custom shadow returns BONDING first, then BONDED, with
-        // createBond()==false — driving the BOND_BONDED branch without any broadcast.
+    fun `post receiver registration bond recheck resumes without createBond`() = runTest(UnconfinedTestDispatcher()) {
+        // Models the real-device race where the bond completes between the early bondState check and receiver
+        // registration. The custom shadow returns BONDING first, then BONDED, so the registered receiver is cleaned
+        // up before createBond() is called.
         val mac = "AA:BB:CC:DD:EE:03"
+        ShadowBondingThenBonded.createBondCalls = 0
         val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
-        // Resumes (no broadcast) via the post-createBond BOND_BONDED branch; assert no error surfaced.
+        // Resumes (no broadcast) via the post-registration BOND_BONDED re-check; assert no error surfaced.
         assertNull(launchBond(repo, mac).await(), "bond() should resume when the re-check finds BOND_BONDED")
+        assertEquals(0, ShadowBondingThenBonded.createBondCalls, "createBond() should not run after the re-check")
     }
 
     @Test
@@ -214,6 +217,38 @@ class AndroidBluetoothRepositoryBondTest {
         }
 
     @Test
+    fun `bond times out when no terminal bond broadcast arrives`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:0A"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        RobolectricBleBonding.primeBond(mac, bondState = BluetoothDevice.BOND_BONDING, createBondReturns = false)
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        advanceTimeBy(30_001L)
+
+        assertEquals("Timed out waiting for bonding to complete", failure.await()?.message)
+    }
+
+    @Test
+    fun `bond timeout succeeds when final bond state is bonded`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:0B"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(
+                mac,
+                bondState = BluetoothDevice.BOND_BONDING,
+                createBondReturns = false,
+            )
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        deviceShadow.setBondState(BluetoothDevice.BOND_BONDED)
+        advanceTimeBy(30_001L)
+
+        assertNull(failure.await(), "bond() should accept the final BONDED state after timeout")
+    }
+
+    @Test
     fun `isBonded reflects the adapter bonded devices`() = runTest(UnconfinedTestDispatcher()) {
         val bondedMac = "AA:BB:CC:DD:EE:06"
         val otherMac = "AA:BB:CC:DD:EE:07"
@@ -236,17 +271,25 @@ class AndroidBluetoothRepositoryBondTest {
 
     /**
      * Custom shadow that returns [BluetoothDevice.BOND_BONDING] on the first `getBondState()` read (the early guard)
-     * and [BluetoothDevice.BOND_BONDED] thereafter (the post-`createBond` re-check), with `createBond()` returning
-     * false — reproducing the bond-completed-mid-method race for the BOND_BONDED branch of the fix.
+     * and [BluetoothDevice.BOND_BONDED] thereafter (the post-receiver-registration re-check), reproducing the
+     * bond-completed-mid-method race without a broadcast.
      */
     @Implements(BluetoothDevice::class)
     class ShadowBondingThenBonded : ShadowBluetoothDevice() {
+        companion object {
+            var createBondCalls: Int = 0
+        }
+
         private var bondStateReads = 0
 
         @Implementation
         override fun getBondState(): Int =
             if (bondStateReads++ == 0) BluetoothDevice.BOND_BONDING else BluetoothDevice.BOND_BONDED
 
-        @Implementation override fun createBond(): Boolean = false
+        @Implementation
+        override fun createBond(): Boolean {
+            createBondCalls++
+            return false
+        }
     }
 }

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -130,6 +130,7 @@ class AndroidBluetoothRepositoryBondTest {
         // registration. The custom shadow returns BONDING first, then BONDED, so the registered receiver is cleaned
         // up before createBond() is called.
         val mac = "AA:BB:CC:DD:EE:03"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
         ShadowBondingThenBonded.createBondCalls = 0
         val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
@@ -232,8 +233,30 @@ class AndroidBluetoothRepositoryBondTest {
     }
 
     @Test
-    fun `bond timeout succeeds when final bond state is bonded`() = runTest(UnconfinedTestDispatcher()) {
-        val mac = "AA:BB:CC:DD:EE:0B"
+    fun `bond completes early when bond state becomes bonded without broadcast`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val mac = "AA:BB:CC:DD:EE:0B"
+            RobolectricBleBonding.grantBluetoothConnectPermission()
+            val deviceShadow =
+                RobolectricBleBonding.primeBond(
+                    mac,
+                    bondState = BluetoothDevice.BOND_BONDING,
+                    createBondReturns = false,
+                )
+            val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+            val failure = launchBond(repo, mac)
+            advanceTimeBy(499L)
+            assertFalse(failure.isCompleted, "bond() should still be waiting before the poll interval")
+            deviceShadow.setBondState(BluetoothDevice.BOND_BONDED)
+            advanceTimeBy(2L)
+
+            assertNull(failure.await(), "bond() should accept the polled BONDED state before timeout")
+        }
+
+    @Test
+    fun `bond succeeds when bond state becomes bonded at timeout boundary`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:0C"
         RobolectricBleBonding.grantBluetoothConnectPermission()
         val deviceShadow =
             RobolectricBleBonding.primeBond(
@@ -244,8 +267,10 @@ class AndroidBluetoothRepositoryBondTest {
         val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
         val failure = launchBond(repo, mac)
+        advanceTimeBy(29_999L)
+        assertFalse(failure.isCompleted, "bond() should still be waiting before the timeout")
         deviceShadow.setBondState(BluetoothDevice.BOND_BONDED)
-        advanceTimeBy(30_001L)
+        advanceTimeBy(2L)
 
         assertNull(failure.await(), "bond() should accept the final BONDED state after timeout")
     }

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -149,11 +149,9 @@ class AndroidBluetoothRepository(
                             }
 
                             if (!remoteDevice.createBond()) {
-                                // createBond() returns false when a bond is already in flight (initiated by the OS or
-                                // triggered by a GATT operation hitting a secured characteristic) or already
-                                // established.
-                                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable
-                                // #111),
+                                // createBond() returns false when a bond is already in flight, triggered by a GATT
+                                // operation hitting a secured characteristic, or already established.
+                                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable #111),
                                 // so re-check bondState directly rather than failing the whole flow.
                                 when (remoteDevice.bondState) {
                                     android.bluetooth.BluetoothDevice.BOND_BONDED -> {
@@ -180,6 +178,7 @@ class AndroidBluetoothRepository(
                             completeBond(receiver = receiver, result = Result.failure(e), cont = cont)
                         }
                     }
+                    // Reaching here means the suspended bond wait completed before BOND_TIMEOUT.
                     true
                 } ?: (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED)
 

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -27,19 +27,20 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.di.CoroutineDispatchers
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private val BOND_TIMEOUT = 30.seconds
+private val BOND_STATE_POLL_INTERVAL = 500.milliseconds
 
 /** Android implementation of [BluetoothRepository]. */
 @Single
@@ -94,90 +95,18 @@ class AndroidBluetoothRepository(
         try {
             val bonded =
                 withTimeoutOrNull(BOND_TIMEOUT) {
-                    suspendCancellableCoroutine<Unit> { cont ->
-                        val receiver =
-                            object : android.content.BroadcastReceiver() {
-                                @SuppressLint("MissingPermission")
-                                override fun onReceive(c: Context, intent: android.content.Intent) {
-                                    if (intent.action != android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED) {
-                                        return
-                                    }
-                                    val d =
-                                        androidx.core.content.IntentCompat.getParcelableExtra(
-                                            intent,
-                                            android.bluetooth.BluetoothDevice.EXTRA_DEVICE,
-                                            android.bluetooth.BluetoothDevice::class.java,
-                                        )
-                                    if (d?.address?.equals(macAddress, ignoreCase = true) != true) return
+                    val result = CompletableDeferred<Unit>()
+                    val receiver = createBondReceiver(macAddress, result)
 
-                                    val state =
-                                        intent.getIntExtra(
-                                            android.bluetooth.BluetoothDevice.EXTRA_BOND_STATE,
-                                            android.bluetooth.BluetoothDevice.ERROR,
-                                        )
-                                    val prevState =
-                                        intent.getIntExtra(
-                                            android.bluetooth.BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE,
-                                            android.bluetooth.BluetoothDevice.ERROR,
-                                        )
+                    val filter =
+                        android.content.IntentFilter(android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED)
+                    ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
 
-                                    if (state == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                                        completeBond(receiver = this, result = Result.success(Unit), cont = cont)
-                                    } else if (
-                                        state == android.bluetooth.BluetoothDevice.BOND_NONE &&
-                                        prevState == android.bluetooth.BluetoothDevice.BOND_BONDING
-                                    ) {
-                                        completeBond(
-                                            receiver = this,
-                                            result = Result.failure(Exception("Bonding failed or rejected")),
-                                            cont = cont,
-                                        )
-                                    }
-                                }
-                            }
-
-                        val filter =
-                            android.content.IntentFilter(android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED)
-                        ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
-
-                        cont.invokeOnCancellation { unregisterBondReceiver(receiver) }
-
-                        try {
-                            if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                                completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
-                                return@suspendCancellableCoroutine
-                            }
-
-                            if (!remoteDevice.createBond()) {
-                                // createBond() returns false when a bond is already in flight, triggered by a GATT
-                                // operation hitting a secured characteristic, or already established.
-                                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable
-                                // #111),
-                                // so re-check bondState directly rather than failing the whole flow.
-                                when (remoteDevice.bondState) {
-                                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
-                                        completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
-                                    }
-
-                                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
-                                        // Bond already in progress; leave the receiver registered to resolve it on the
-                                        // terminal BOND_BONDED / BOND_NONE transition instead of treating this as a
-                                        // failure.
-                                        Logger.d { "createBond() returned false but bonding is already in progress" }
-                                    }
-
-                                    else -> {
-                                        completeBond(
-                                            receiver = receiver,
-                                            result = Result.failure(Exception("Failed to initiate bonding")),
-                                            cont = cont,
-                                        )
-                                    }
-                                }
-                            }
-                        } catch (e: Throwable) {
-                            completeBond(receiver = receiver, result = Result.failure(e), cont = cont)
-                        }
+                    try {
+                        startOrObserveBond(remoteDevice, result)
+                        awaitBondResult(remoteDevice, result)
+                    } finally {
+                        unregisterBondReceiver(receiver)
                     }
                     // Reaching here means the suspended bond wait completed before BOND_TIMEOUT.
                     true
@@ -191,14 +120,94 @@ class AndroidBluetoothRepository(
         }
     }
 
-    private fun completeBond(
-        receiver: android.content.BroadcastReceiver,
-        result: Result<Unit>,
-        cont: CancellableContinuation<Unit>,
+    @Suppress("TooGenericExceptionCaught")
+    @SuppressLint("MissingPermission")
+    private fun startOrObserveBond(remoteDevice: android.bluetooth.BluetoothDevice, result: CompletableDeferred<Unit>) {
+        try {
+            if (result.isCompleted) return
+
+            if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                result.complete(Unit)
+            } else if (!remoteDevice.createBond()) {
+                // createBond() returns false when a bond is already in flight, triggered by a GATT
+                // operation hitting a secured characteristic, or already established.
+                // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
+                // re-check bondState directly rather than failing the whole flow.
+                when (remoteDevice.bondState) {
+                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                        result.complete(Unit)
+                    }
+
+                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                        // Bond already in progress; leave the receiver registered to resolve it on
+                        // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
+                        // as a failure.
+                        Logger.d { "createBond() returned false but bonding is already in progress" }
+                    }
+
+                    else -> {
+                        result.completeExceptionally(Exception("Failed to initiate bonding"))
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            result.completeExceptionally(e)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private suspend fun awaitBondResult(
+        remoteDevice: android.bluetooth.BluetoothDevice,
+        result: CompletableDeferred<Unit>,
     ) {
-        unregisterBondReceiver(receiver)
-        if (cont.isActive) {
-            cont.resumeWith(result)
+        while (!result.isCompleted) {
+            val completedFromReceiver =
+                withTimeoutOrNull(BOND_STATE_POLL_INTERVAL) {
+                    result.await()
+                    true
+                } == true
+
+            if (!completedFromReceiver && remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                result.complete(Unit)
+            }
+        }
+        result.await()
+    }
+
+    @Suppress("TooGenericExceptionThrown")
+    private fun createBondReceiver(
+        macAddress: String,
+        result: CompletableDeferred<Unit>,
+    ): android.content.BroadcastReceiver = object : android.content.BroadcastReceiver() {
+        override fun onReceive(c: Context, intent: android.content.Intent) {
+            if (intent.action != android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED) return
+            val d =
+                androidx.core.content.IntentCompat.getParcelableExtra(
+                    intent,
+                    android.bluetooth.BluetoothDevice.EXTRA_DEVICE,
+                    android.bluetooth.BluetoothDevice::class.java,
+                )
+            if (d?.address?.equals(macAddress, ignoreCase = true) != true) return
+
+            val state =
+                intent.getIntExtra(
+                    android.bluetooth.BluetoothDevice.EXTRA_BOND_STATE,
+                    android.bluetooth.BluetoothDevice.ERROR,
+                )
+            val prevState =
+                intent.getIntExtra(
+                    android.bluetooth.BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE,
+                    android.bluetooth.BluetoothDevice.ERROR,
+                )
+
+            if (state == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                result.complete(Unit)
+            } else if (
+                state == android.bluetooth.BluetoothDevice.BOND_NONE &&
+                prevState == android.bluetooth.BluetoothDevice.BOND_BONDING
+            ) {
+                result.completeExceptionally(Exception("Bonding failed or rejected"))
+            }
         }
     }
 

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -27,15 +27,19 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.di.CoroutineDispatchers
-import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.seconds
+
+private val BOND_TIMEOUT = 30.seconds
 
 /** Android implementation of [BluetoothRepository]. */
 @Single
@@ -87,89 +91,116 @@ class AndroidBluetoothRepository(
             return
         }
 
-        suspendCancellableCoroutine<Unit> { cont ->
-            val receiver =
-                object : android.content.BroadcastReceiver() {
-                    @SuppressLint("MissingPermission")
-                    override fun onReceive(c: Context, intent: android.content.Intent) {
-                        if (intent.action == android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED) {
-                            val d =
-                                androidx.core.content.IntentCompat.getParcelableExtra(
-                                    intent,
-                                    android.bluetooth.BluetoothDevice.EXTRA_DEVICE,
-                                    android.bluetooth.BluetoothDevice::class.java,
-                                )
-                            if (d?.address?.equals(macAddress, ignoreCase = true) == true) {
-                                val state =
-                                    intent.getIntExtra(
-                                        android.bluetooth.BluetoothDevice.EXTRA_BOND_STATE,
-                                        android.bluetooth.BluetoothDevice.ERROR,
-                                    )
-                                val prevState =
-                                    intent.getIntExtra(
-                                        android.bluetooth.BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE,
-                                        android.bluetooth.BluetoothDevice.ERROR,
-                                    )
-
-                                if (state == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                                    try {
-                                        context.unregisterReceiver(this)
-                                    } catch (ignored: Exception) {}
-                                    if (cont.isActive) cont.resume(Unit)
-                                } else if (
-                                    state == android.bluetooth.BluetoothDevice.BOND_NONE &&
-                                    prevState == android.bluetooth.BluetoothDevice.BOND_BONDING
-                                ) {
-                                    try {
-                                        context.unregisterReceiver(this)
-                                    } catch (ignored: Exception) {}
-                                    if (cont.isActive) {
-                                        cont.resumeWith(Result.failure(Exception("Bonding failed or rejected")))
+        try {
+            val bonded =
+                withTimeoutOrNull(BOND_TIMEOUT) {
+                    suspendCancellableCoroutine<Unit> { cont ->
+                        val receiver =
+                            object : android.content.BroadcastReceiver() {
+                                @SuppressLint("MissingPermission")
+                                override fun onReceive(c: Context, intent: android.content.Intent) {
+                                    if (intent.action != android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED) {
+                                        return
                                     }
+                                    val d =
+                                        androidx.core.content.IntentCompat.getParcelableExtra(
+                                            intent,
+                                            android.bluetooth.BluetoothDevice.EXTRA_DEVICE,
+                                            android.bluetooth.BluetoothDevice::class.java,
+                                        )
+                                    if (d?.address?.equals(macAddress, ignoreCase = true) != true) return
+
+                                    val state =
+                                        intent.getIntExtra(
+                                            android.bluetooth.BluetoothDevice.EXTRA_BOND_STATE,
+                                            android.bluetooth.BluetoothDevice.ERROR,
+                                        )
+                                    val prevState =
+                                        intent.getIntExtra(
+                                            android.bluetooth.BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE,
+                                            android.bluetooth.BluetoothDevice.ERROR,
+                                        )
+
+                                    if (state == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                                        completeBond(receiver = this, result = Result.success(Unit), cont = cont)
+                                    } else if (
+                                        state == android.bluetooth.BluetoothDevice.BOND_NONE &&
+                                        prevState == android.bluetooth.BluetoothDevice.BOND_BONDING
+                                    ) {
+                                        completeBond(
+                                            receiver = this,
+                                            result = Result.failure(Exception("Bonding failed or rejected")),
+                                            cont = cont,
+                                        )
+                                    }
+                                }
+                            }
+
+                        val filter =
+                            android.content.IntentFilter(android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED)
+                        ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+
+                        cont.invokeOnCancellation { unregisterBondReceiver(receiver) }
+
+                        if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                            completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
+                            return@suspendCancellableCoroutine
+                        }
+
+                        if (!remoteDevice.createBond()) {
+                            // createBond() returns false when a bond is already in flight (initiated by the OS or
+                            // triggered by a GATT operation hitting a secured characteristic) or already established.
+                            // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable #111),
+                            // so re-check bondState directly rather than failing the whole flow.
+                            when (remoteDevice.bondState) {
+                                android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                                    completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
+                                }
+
+                                android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                                    // Bond already in progress; leave the receiver registered to resolve it on the
+                                    // terminal BOND_BONDED / BOND_NONE transition instead of treating this as a
+                                    // failure.
+                                    Logger.d { "createBond() returned false but bonding is already in progress" }
+                                }
+
+                                else -> {
+                                    completeBond(
+                                        receiver = receiver,
+                                        result = Result.failure(Exception("Failed to initiate bonding")),
+                                        cont = cont,
+                                    )
                                 }
                             }
                         }
                     }
-                }
+                    true
+                } ?: (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED)
 
-            val filter = android.content.IntentFilter(android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED)
-            ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
-
-            cont.invokeOnCancellation {
-                try {
-                    context.unregisterReceiver(receiver)
-                } catch (ignored: Exception) {}
+            if (!bonded) {
+                throw Exception("Timed out waiting for bonding to complete")
             }
-
-            if (!remoteDevice.createBond()) {
-                // createBond() returns false when a bond is already in flight (initiated by the OS or
-                // triggered by a GATT operation hitting a secured characteristic) or already established.
-                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable #111),
-                // so re-check bondState directly rather than failing the whole flow.
-                when (remoteDevice.bondState) {
-                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
-                        try {
-                            context.unregisterReceiver(receiver)
-                        } catch (ignored: Exception) {}
-                        if (cont.isActive) cont.resume(Unit)
-                    }
-
-                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
-                        // Bond already in progress; leave the receiver registered to resolve it on the
-                        // terminal BOND_BONDED / BOND_NONE transition instead of treating this as a failure.
-                        Logger.d { "createBond() returned false but bonding is already in progress" }
-                    }
-
-                    else -> {
-                        try {
-                            context.unregisterReceiver(receiver)
-                        } catch (ignored: Exception) {}
-                        if (cont.isActive) cont.resumeWith(Result.failure(Exception("Failed to initiate bonding")))
-                    }
-                }
-            }
+        } finally {
+            updateBluetoothState()
         }
-        updateBluetoothState()
+    }
+
+    private fun completeBond(
+        receiver: android.content.BroadcastReceiver,
+        result: Result<Unit>,
+        cont: CancellableContinuation<Unit>,
+    ) {
+        unregisterBondReceiver(receiver)
+        if (cont.isActive) {
+            cont.resumeWith(result)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun unregisterBondReceiver(receiver: android.content.BroadcastReceiver) {
+        try {
+            context.unregisterReceiver(receiver)
+        } catch (ignored: Exception) {}
     }
 
     internal suspend fun updateBluetoothState() {

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -151,7 +151,8 @@ class AndroidBluetoothRepository(
                             if (!remoteDevice.createBond()) {
                                 // createBond() returns false when a bond is already in flight, triggered by a GATT
                                 // operation hitting a secured characteristic, or already established.
-                                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable #111),
+                                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable
+                                // #111),
                                 // so re-check bondState directly rather than failing the whole flow.
                                 when (remoteDevice.bondState) {
                                     android.bluetooth.BluetoothDevice.BOND_BONDED -> {

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -142,36 +142,42 @@ class AndroidBluetoothRepository(
 
                         cont.invokeOnCancellation { unregisterBondReceiver(receiver) }
 
-                        if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                            completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
-                            return@suspendCancellableCoroutine
-                        }
+                        try {
+                            if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                                completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
+                                return@suspendCancellableCoroutine
+                            }
 
-                        if (!remoteDevice.createBond()) {
-                            // createBond() returns false when a bond is already in flight (initiated by the OS or
-                            // triggered by a GATT operation hitting a secured characteristic) or already established.
-                            // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable #111),
-                            // so re-check bondState directly rather than failing the whole flow.
-                            when (remoteDevice.bondState) {
-                                android.bluetooth.BluetoothDevice.BOND_BONDED -> {
-                                    completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
-                                }
+                            if (!remoteDevice.createBond()) {
+                                // createBond() returns false when a bond is already in flight (initiated by the OS or
+                                // triggered by a GATT operation hitting a secured characteristic) or already
+                                // established.
+                                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable
+                                // #111),
+                                // so re-check bondState directly rather than failing the whole flow.
+                                when (remoteDevice.bondState) {
+                                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                                        completeBond(receiver = receiver, result = Result.success(Unit), cont = cont)
+                                    }
 
-                                android.bluetooth.BluetoothDevice.BOND_BONDING -> {
-                                    // Bond already in progress; leave the receiver registered to resolve it on the
-                                    // terminal BOND_BONDED / BOND_NONE transition instead of treating this as a
-                                    // failure.
-                                    Logger.d { "createBond() returned false but bonding is already in progress" }
-                                }
+                                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                                        // Bond already in progress; leave the receiver registered to resolve it on the
+                                        // terminal BOND_BONDED / BOND_NONE transition instead of treating this as a
+                                        // failure.
+                                        Logger.d { "createBond() returned false but bonding is already in progress" }
+                                    }
 
-                                else -> {
-                                    completeBond(
-                                        receiver = receiver,
-                                        result = Result.failure(Exception("Failed to initiate bonding")),
-                                        cont = cont,
-                                    )
+                                    else -> {
+                                        completeBond(
+                                            receiver = receiver,
+                                            result = Result.failure(Exception("Failed to initiate bonding")),
+                                            cont = cont,
+                                        )
+                                    }
                                 }
                             }
+                        } catch (e: Throwable) {
+                            completeBond(receiver = receiver, result = Result.failure(e), cont = cont)
                         }
                     }
                     true


### PR DESCRIPTION


## Summary by Sourcery

Add a timeout and improved state handling to Android Bluetooth bonding and extend tests to cover bonding edge cases and timeouts.

Bug Fixes:
- Prevent indefinite waiting during Bluetooth bonding by enforcing a 30-second timeout and validating final bond state after timeout.
- Ensure bond completion and failure paths always clean up the broadcast receiver and correctly resume the bonding coroutine, including when bonding races occur around receiver registration.

Enhancements:
- Refactor bonding flow into reusable helpers for completing and unregistering the bond receiver, improving robustness against exceptions and cancellation.

Tests:
- Expand Android Bluetooth bonding host tests to cover bond timeout behavior, acceptance of final bonded state after timeout, and races where bonding completes between receiver registration and createBond().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This update makes the Android BLE bonding flow in `AndroidBluetoothRepository.bond()` deterministic and bounded. It enforces a 30-second bonding timeout, coordinates success/failure via both broadcast observation and bond-state polling, and re-checks the final bond state on timeout to handle late/near-miss transitions. It also hardens the broadcast receiver lifecycle so the bonding coroutine reliably completes and cleans up without leaking receivers or missing resumes during race conditions.

### Fixes
- Add a fixed 30s bonding timeout (`BOND_TIMEOUT`) to `AndroidBluetoothRepository.bond()`, failing with `"Timed out waiting for bonding to complete"` when no terminal condition is reached.
- After timeout, re-check the current bond state:
  - Treat `BOND_BONDED` as success even if no “terminal” broadcast was received.
  - When `createBond()` returns `false`, interpret the existing bond state explicitly:
    - Success only for `BOND_BONDED`
    - Continue waiting only for `BOND_BONDING`
    - Fail for other states.
- Ensure `updateBluetoothState()` runs on success, failure, and timeout by wrapping the bonding operation in an outer `finally`.
- Improve bonding broadcast receiver handling:
  - Complete the wait when the receiver observes `ACTION_BOND_STATE_CHANGED` for the target device with `BOND_BONDED` (and complete exceptionally when it reaches `BOND_NONE` after bonding started).
  - Always unregister the receiver in a `finally` block to prevent leaks and reduce cancellation/race issues.
- Match bond-state change broadcasts more precisely (uses the target device address from intent extras, case-insensitive).
- Add bond-state polling during the wait so success can be detected even if broadcasts are missed.

### Features
- Refactor the bonding wait into a structured coroutine flow using a `CompletableDeferred`, resolved by receiver events and/or polling, governed by `withTimeoutOrNull`.

### Refactors
- Replace the prior `suspendCancellableCoroutine`/manual resume approach with deferred-based coordination to make completion and cleanup paths consistent.
- Extract helper logic for “complete bonding” and “unregister receiver” so success/failure/cancellation handling is centralized and predictable.

### Tests
- Update and expand Robolectric host tests (`AndroidBluetoothRepositoryBondTest`) to cover:
  - Timeout failure when no terminal bond state is reached.
  - Success when bond state transitions to `BOND_BONDED` during the polling window without broadcasts.
  - Success when `BOND_BONDED` occurs exactly at the timeout boundary.
  - Race behavior around receiver registration: the shadow now reports `BOND_BONDING` on the first `getBondState()` read and `BOND_BONDED` thereafter, and the test asserts `createBond()` is not invoked after the post-registration re-check succeeds.
- Extend the Robolectric shadow (`ShadowBondingThenBonded`) with a `createBondCalls` counter to support the race assertion.

### Breaking changes / migration
- None expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->