### PR TITLE
fix(ble): Stop transport connect after failed bonding

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+early_access: true
+reviews:
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
+  auto_review:
+    enabled: false
+    drafts: false
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,7 +15,6 @@ concurrency:
 jobs:
   # 1. CHANGE DETECTION: Prevents unnecessary builds
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -54,7 +54,6 @@ jobs:
 
   # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
   verify-check-changes-filter:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ build-scan-*.scan
 # craft pipeline scratch workpad (per-task working notes, not source)
 /workpad.md
 /workpad.*.md
+.omo/*

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -119,6 +119,7 @@ bluetooth_feature_discovery_description
 bluetooth_permission
 bold_heading
 bonding_failed_permissions
+bonding_failed_retry
 bottom_nav_settings
 broadcast_interval
 busy_noise_floor

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RadioNotConnectedException.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RadioNotConnectedException.kt
@@ -17,4 +17,5 @@
 package org.meshtastic.core.model
 
 /** Exception thrown when an operation is attempted while not connected to a mesh radio. */
-open class RadioNotConnectedException(message: String = "Not connected to radio") : Exception(message)
+open class RadioNotConnectedException(message: String = "Not connected to radio", cause: Throwable? = null) :
+    Exception(message, cause)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -358,21 +358,7 @@ class BleRadioTransport(
 
         val device = findDevice()
 
-        // Bond before connecting: firmware may require an encrypted link,
-        // and without a bond Android fails with status 5 or 133.
-        // No-op on Desktop/JVM where the OS handles pairing automatically.
-        if (!bluetoothRepository.isBonded(address)) {
-            Logger.i { "[$address] Device not bonded, initiating bonding" }
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                bluetoothRepository.bond(device)
-                Logger.i { "[$address] Bonding successful" }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.w(e) { "[$address] Bonding failed, attempting connection anyway" }
-            }
-        }
+        bondDeviceBeforeConnect(device)
 
         val state = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
 
@@ -468,6 +454,30 @@ class BleRadioTransport(
         }
 
         return BleReconnectPolicy.Outcome.Disconnected(wasStable = wasStable, wasIntentional = wasIntentional)
+    }
+
+    private suspend fun bondDeviceBeforeConnect(device: BleDevice) {
+        if (bluetoothRepository.isBonded(address)) return
+
+        // Bond before connecting: firmware may require an encrypted link, and without a bond Android fails with
+        // status 5 or 133. Non-Android targets use repository-specific no-op behavior.
+        Logger.i { "[$address] Device not bonded, initiating bonding" }
+        try {
+            bluetoothRepository.bond(device)
+            Logger.i { "[$address] Bonding successful" }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // bond() failed. Android may still have recorded the bond, in which case we can safely continue into GATT
+            // setup. If the device is still not bonded, continuing would fail later with a cryptic status (5/133), so
+            // stop now and let BleReconnectPolicy own the retry/backoff.
+            if (bluetoothRepository.isBonded(address)) {
+                Logger.w(e) { "[$address] Bonding reported failure but device is bonded; continuing" }
+            } else {
+                Logger.w(e) { "[$address] Bonding failed and device is still not bonded; stopping connection attempt" }
+                throw RadioNotConnectedException("Bonding failed and device is still not bonded", e)
+            }
+        }
     }
 
     private suspend fun onConnected() {

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -23,6 +23,7 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
@@ -37,6 +38,8 @@ import org.meshtastic.core.testing.FakeBleConnectionFactory
 import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.core.testing.FakeBleScanner
 import org.meshtastic.core.testing.FakeBluetoothRepository
+import org.meshtastic.core.testing.failBondAfterRecording
+import org.meshtastic.core.testing.failBondWith
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -259,6 +262,129 @@ class BleRadioTransportTest {
             assertNotNull(scanner.lastScanServiceUuid, "scan must include serviceUuid")
             assertEquals(SERVICE_UUID, scanner.lastScanServiceUuid)
             assertEquals(address, scanner.lastScanAddress)
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    // --- Transport-side bond failure handling ---
+
+    @Test
+    fun `bond succeeds then connectAndAwait is called`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            advanceTimeBy(3_001)
+            assertEquals(1, bluetoothRepository.bondCalls.size, "bond() must be called before connecting")
+            assertEquals(1, connection.connectAndAwaitCalls, "connectAndAwait must be called after successful bond")
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
+    fun `bond throws but device is bonded then connectAndAwait is still called`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+        bluetoothRepository.failBondAfterRecording(Exception("bond flaked"))
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            advanceTimeBy(3_001)
+            assertEquals(1, bluetoothRepository.bondCalls.size, "bond() must be attempted before connecting")
+            assertEquals(
+                1,
+                connection.connectAndAwaitCalls,
+                "connectAndAwait must be called when bond flaked but device is bonded",
+            )
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
+    fun `bond throws and device not bonded then connectAndAwait is not called`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+        bluetoothRepository.failBondWith(Exception("bond rejected"))
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            // Advance past one failed bond attempt and retry backoff, but before the next bond attempt.
+            advanceTimeBy(10_001)
+            assertEquals(
+                0,
+                connection.connectAndAwaitCalls,
+                "connectAndAwait must not be called when bond failed and device is not bonded",
+            )
+            assertEquals(1, bluetoothRepository.bondCalls.size, "bond() must have been attempted once")
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    /**
+     * When [bluetoothRepository.bond] throws a [CancellationException], it must propagate as coroutine cancellation —
+     * NOT be swallowed into a generic [BleReconnectPolicy.Outcome.Failed].
+     *
+     * Discriminator: with the `catch (CancellationException) { throw e }` guard present, the job is cancelled and bond
+     * is called exactly once. If the guard were removed, the CE would be caught by `catch (Exception)`, converted to
+     * `RadioNotConnectedException`, become `Outcome.Failed`, and the policy would retry — making `bondCalls.size > 1`.
+     */
+    @Test
+    fun `CancellationException from bond cancels the connection job without retrying`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+        bluetoothRepository.bondOutcome =
+            FakeBluetoothRepository.BondOutcome.Fail(CancellationException("simulated cancel"))
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            advanceTimeBy(12_000)
+            assertEquals(
+                1,
+                bluetoothRepository.bondCalls.size,
+                "bond() must be called exactly once — cancellation, not retry",
+            )
+            assertEquals(0, connection.connectAndAwaitCalls, "connectAndAwait must not be called after cancellation")
         } finally {
             bleTransport.close()
         }

--- a/core/resources/src/commonMain/composeResources/values-et/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-et/strings.xml
@@ -245,6 +245,7 @@
     <string name="config_display_wake_on_tap_or_motion_summary">Vajalik, et teie seadmes oleks kiirendusmõõtur.</string>
     <string name="config_lora_frequency_slot_summary">Teie sõlme töösagedus arvutatakse piirkonna, modemi eelseadistuse ja selle välja põhjal. Kui see on 0, arvutatakse pesa automaatselt primaarse kanali nime põhjal ja see muutub vaikimisi avalikust pesast. Muutke see tagasi avalikuks vaikepesaks, kui privaatsed primaarsed ja avalikud sekundaarsed kanalid on konfigureeritud.</string>
     <string name="config_lora_hop_limit_summary">Määrab hüpete maksimaalse arvu, vaikimisi on see 3. Hüpete suurendamine suurendab ka ülekoormust ja seda tuleks kasutada ettevaatlikult. 0 hüppega leviedastussõnumid ei saa ACK-sid.</string>
+    <string name="config_lora_modem_preset_licensed_summary">Selle piirkonna eelseadistused on ainult litsentseeritud (amatöörraadio) operaatoritele. Nende valimiseks lubage kasutaja konfis litsentseeritud amatöörraadio (amatöör).</string>
     <string name="config_lora_modem_preset_summary">Saadaval olevad modemi eelseadistused, vaikesäte on Long Fast.</string>
     <string name="config_lora_region_summary">Raadio kasutama hakkamise piirkond.</string>
     <string name="config_network_eth_enabled_summary">Etherneti lubamine keelab sinihamba ühenduse rakendusega. TCP-sõlmede ühendused pole Apple'i seadmetes saadaval.</string>
@@ -465,6 +466,7 @@
     <string name="doc_keywords_desktop">desktop,linux,macos,windows,serial</string>
     <string name="doc_keywords_discovery">avastamine,topoloogia,võrk,skaneerimine,naaber</string>
     <string name="doc_keywords_firmware">püsivara,värskendus,ota,välkmälu,versioon,taastamine</string>
+    <string name="doc_keywords_help">abi,dokumentatsioon,dokumendid,chirpy,assistent,otsing,võrguühenduseta</string>
     <string name="doc_keywords_map">kaart,teekonnapunkt,gps,asukoht,marker</string>
     <string name="doc_keywords_measurement">vormindaja,mõõdik,arv,lokaat,temperatuur,teisendus,api</string>
     <string name="doc_keywords_messages">sõnum,kanal,krüpteerimine,otseülekanne,kiirvestlus</string>
@@ -479,6 +481,7 @@
     <string name="doc_keywords_telemetry">telemeetria,andur,temperatuur,niiskus,rõhk,võimsus</string>
     <string name="doc_keywords_translate">tõlkimine,rahvahulk,lokaliseerimine,keel,i18n,panusta</string>
     <string name="doc_keywords_units">ühikud,lokaal,meetriline,imperial,temperatuur,vahemaa</string>
+    <string name="doc_keywords_widget">vidin,avakuva,kohalik statistika,vaade,aku,kasutus</string>
     <string name="doc_search_placeholder">Otsi dokumentatsiooni…</string>
     <string name="doc_section_developer">Arendaja juhis</string>
     <string name="doc_section_user">Kasutaja juhis</string>
@@ -488,6 +491,7 @@
     <string name="doc_title_desktop">Töölauarakendus</string>
     <string name="doc_title_discovery">Avastamine</string>
     <string name="doc_title_firmware">Püsivara värskendused</string>
+    <string name="doc_title_help">Abi &amp; Rakendusesisesed dokumendid</string>
     <string name="doc_title_map">Kaart &amp; Teekonnapunktid</string>
     <string name="doc_title_measurement">Mõõtmine &amp; vormindamine</string>
     <string name="doc_title_messages">Sõnumid &amp; Kanalid</string>
@@ -502,6 +506,7 @@
     <string name="doc_title_telemetry">Telemeetria &amp; Sensorid</string>
     <string name="doc_title_translate">Tõlgi rakendus</string>
     <string name="doc_title_units">Ühikud &amp; Asukoht</string>
+    <string name="doc_title_widget">Avakuva vidin</string>
     <string name="done">Valmis</string>
     <string name="dont_show_again_for_device">Ära selle seadme puhul enam kuva</string>
     <string name="double_tap_as_button_press">Topeltpuudutus nupuna</string>
@@ -534,6 +539,7 @@
     <string name="environment_metrics_use_fahrenheit">Keskkonnamõõdikud kasutavad Fahrenheiti</string>
     <string name="error">Viga</string>
     <string name="error_duty_cycle">Töötsükli limiit on saavutatud. Sõnumite saatmine ei ole hetkel võimalik. Proovi hiljem uuesti.</string>
+    <string name="error_recovery_exhausted">Pärast korduvaid katseid ei õnnestunud stabiilset ühendust luua. Uuesti proovimiseks vali palun sõlm.</string>
     <string name="establish_session">Ühenda &amp; ja halda</string>
     <string name="establishing_session">Kaugühenduse loomine…</string>
     <string name="ethernet_config">Etherneti valikud</string>
@@ -623,6 +629,7 @@
     <string name="firmware_update_retry">Proovi uuesti</string>
     <string name="firmware_update_save_dfu_file">Palun salvesta .uf2-fail oma seadme DFU-kettale.</string>
     <string name="firmware_update_select_file">Vali kohalik fail</string>
+    <string name="firmware_update_slow_bootloader_hint">Seadme alglaaduri värskendused on aeglased. OTAFIX alglaaduri flash võimaldab palju kiiremaid BLE värskendusi.</string>
     <string name="firmware_update_source_local">Allikas: kohalik fail</string>
     <string name="firmware_update_stable">Stabiilne</string>
     <string name="firmware_update_starting_dfu">DFU käivitamine...</string>
@@ -634,6 +641,7 @@
     <string name="firmware_update_unknown_error">Tundmatu viga</string>
     <string name="firmware_update_unknown_hardware">Tundmatu riistvaramudel: %1$d</string>
     <string name="firmware_update_unknown_release">Tundmatu väljalase</string>
+    <string name="firmware_update_unsupported_transport">Selle seadme püsivara värskendus ei toetata üle selle ühenduse. Värskendamiseks loo ühendus muul viisil (nt sinihamba ​​kaudu).</string>
     <string name="firmware_update_uploading">Laen püsivara...</string>
     <string name="firmware_update_usb_bootloader_warning">%1$s on tavaliselt varustatud alglaaduriga, mis ei toeta OTA värskendusi. Enne OTA värskendamist pead võib-olla USB kaudu OTA-toega alglaaduri käivitama.</string>
     <string name="firmware_update_usb_failed">USB-värskendus ebaõnnestus</string>
@@ -785,7 +793,35 @@
     <string name="location_disabled">Juurdepääs asukohale on välja lülitatud, ei saa asukohta teistele jagada.</string>
     <string name="location_sharing">Asukoha jagamine</string>
     <!-- LOCKDOWN -->
+    <string name="lockdown_backoff">Proovi uuesti %1$d sekundi pärast.</string>
+    <string name="lockdown_boots_remaining">Käivitusi alles</string>
+    <string name="lockdown_confirm_passphrase">Kinnita salasõna</string>
+    <string name="lockdown_disable">Keela lukustus</string>
+    <string name="lockdown_disable_message">Lukustuse väljalülitamiseks sisesta salasõna. Seade dekrüpteerib oma salvestusruumi ja taaskäivitub.</string>
+    <string name="lockdown_enable">Luba lukustus</string>
     <string name="lockdown_enable_ack">Saan aru</string>
+    <string name="lockdown_enable_warning">Tähelepanu: lukustuse lubamine lukustab silumispordi (SWD) toetatud riistvara. Lukustuse saab igal ajal salasõnaga välja lülitada ja seadme täielik kustutamine taastab vajadusel kõik.</string>
+    <string name="lockdown_enter_passphrase">Sisesta salasõna</string>
+    <string name="lockdown_hide_passphrase">Peida</string>
+    <string name="lockdown_hours_until_expiry">Tunde kuni kehtivusaja lõpuni</string>
+    <string name="lockdown_incorrect_passphrase">Vale salasõna.</string>
+    <string name="lockdown_lock_now">Lukusta nüüd</string>
+    <string name="lockdown_lock_reason">Põhjus: %1$s</string>
+    <string name="lockdown_mode">Lukustusrežiim</string>
+    <string name="lockdown_mode_setting_up">Seadistamine…</string>
+    <string name="lockdown_mode_summary_locked">Aktiivne – sisesta selle ühenduse avamiseks salasõna.</string>
+    <string name="lockdown_mode_summary_off">Krüpteeri seadme salvestusruum ja nõua iga ühenduse jaoks salasõna.</string>
+    <string name="lockdown_mode_summary_unlocked">Aktiivne – salvestusruum on krüpteeritud, see ühendus on autentitud.</string>
+    <string name="lockdown_passphrase">Salasõna</string>
+    <string name="lockdown_passphrases_do_not_match">Salasõna ei ühti</string>
+    <string name="lockdown_session_boots_remaining">Seanss: %1$d taaskäivitust jäänud</string>
+    <string name="lockdown_session_expires">Aegub %1$s</string>
+    <string name="lockdown_session_minutes">Seansi limiit (minutid)</string>
+    <string name="lockdown_session_minutes_help">Käivitusaja piirang. 0 = piiramatu.</string>
+    <string name="lockdown_session_no_time_limit">Ajapiirangut pole</string>
+    <string name="lockdown_set_passphrase">Määra salasõna</string>
+    <string name="lockdown_show_passphrase">Kuva</string>
+    <string name="lockdown_submit">Kinnita</string>
     <string name="locked">Lukustatud</string>
     <!-- LOG -->
     <string name="log_retention_days">MeshLogi säilitusperiood</string>
@@ -950,6 +986,8 @@
     <string name="no_network_devices_seen">Võrgu seadmeid ei tuvastatud</string>
     <string name="no_pax_metrics_logs">Pax mõõdikut pole saadaval.</string>
     <string name="no_usb_devices_found">USB seadmeid ei leitud</string>
+    <string name="no_usb_devices_hint">Jadapordi kasutamiseks ühenda seade USB-andmesidekaabli abil.</string>
+    <string name="no_usb_devices_seen">USB seadmeid ei tuvastatud</string>
     <!-- NODE -->
     <string name="node_count_template">(%1$d võrgus / %2$d näidatud / %3$d kokku)</string>
     <string name="node_filter_exclude_infrastructure">Välista infrastruktuur</string>

--- a/core/resources/src/commonMain/composeResources/values-fi/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-fi/strings.xml
@@ -466,6 +466,7 @@
     <string name="doc_keywords_desktop">desktop, linux, macOS, windows, sarjaportti</string>
     <string name="doc_keywords_discovery">haku, verkon topologia, verkko, skannaus, naapuri</string>
     <string name="doc_keywords_firmware">laiteohjelmisto, päivitys, ota, ohjelmoi, versio, palautus</string>
+    <string name="doc_keywords_help">ohje, dokumentaatio, dokumentit, chirpy, avustaja, haku, offline</string>
     <string name="doc_keywords_map">kartta, reittipiste, gps, sijainti, sijainti, merkki</string>
     <string name="doc_keywords_measurement">formatter, metriikka, numero, alueasetus, lämpötila, muunnos, api</string>
     <string name="doc_keywords_messages">message, kanava, salaus, suora, yleislähetys, pikakeskustelu</string>
@@ -480,6 +481,7 @@
     <string name="doc_keywords_telemetry">telemetria, anturi, lämpötila, kosteus, ilmanpaine, virta</string>
     <string name="doc_keywords_translate">käännös, crowdin, lokalisointi, kieli, i18n, osallistu</string>
     <string name="doc_keywords_units">yksiköt, alueasetus, metriikka, imperiaalinen, lämpötila, etäisyys</string>
+    <string name="doc_keywords_widget">widget, aloitusnäyttö, paikalliset tilastot, yhdellä silmäyksellä, akku, käyttöaste</string>
     <string name="doc_search_placeholder">Hae documentaatiosta…</string>
     <string name="doc_section_developer">Kehittäjän opas</string>
     <string name="doc_section_user">Käyttöopas</string>
@@ -489,6 +491,7 @@
     <string name="doc_title_desktop">Työpöytäsovellus</string>
     <string name="doc_title_discovery">Haku</string>
     <string name="doc_title_firmware">Laiteohjelmiston päivitykset</string>
+    <string name="doc_title_help">Ohjeet &amp; sovelluksen sisäinen dokumentaatio</string>
     <string name="doc_title_map">Kartta &amp; reittipisteet</string>
     <string name="doc_title_measurement">Mittayksikkö &amp; muotoilu</string>
     <string name="doc_title_messages">Viestit &amp; kanavat</string>
@@ -503,6 +506,7 @@
     <string name="doc_title_telemetry">Telemetria &amp; anturit</string>
     <string name="doc_title_translate">Käännä sovellus</string>
     <string name="doc_title_units">Yksiköt &amp; paikallisasetukset</string>
+    <string name="doc_title_widget">Aloitusnäytön Widget</string>
     <string name="done">Valmis</string>
     <string name="dont_show_again_for_device">Älä näytä enää tälle laitteelle</string>
     <string name="double_tap_as_button_press">Kaksoisnapautus painikkeena</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="bluetooth_permission">Bluetooth</string>
     <string name="bold_heading">Bold Heading</string>
     <string name="bonding_failed_permissions">Pairing failed. Grant nearby device permissions and try again.</string>
+    <string name="bonding_failed_retry">Pairing did not complete. Try pairing again.</string>
     <string name="bottom_nav_settings">Settings</string>
     <string name="broadcast_interval">Broadcast Interval</string>
     <string name="busy_noise_floor">Busy floor</string>

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -337,17 +337,29 @@ class FakeBluetoothRepository :
 
     override suspend fun bond(device: BleDevice) {
         bondCalls += device
-        when (val outcome = bondOutcome) {
-            is BondOutcome.Security -> throw outcome.error
+        val error =
+            when (val outcome = bondOutcome) {
+                is BondOutcome.Security -> outcome.error
 
-            is BondOutcome.Fail -> throw outcome.error
+                is BondOutcome.Fail -> outcome.error
 
-            BondOutcome.Success -> {
-                val currentState = _state.value
-                if (!currentState.bondedDevices.contains(device)) {
-                    _state.value = currentState.copy(bondedDevices = currentState.bondedDevices + device)
+                is BondOutcome.FailAfterBond -> {
+                    addBondedDevice(device)
+                    outcome.error
+                }
+
+                BondOutcome.Success -> {
+                    addBondedDevice(device)
+                    null
                 }
             }
+        error?.let { throw it }
+    }
+
+    private fun addBondedDevice(device: BleDevice) {
+        val currentState = _state.value
+        if (!currentState.bondedDevices.contains(device)) {
+            _state.value = currentState.copy(bondedDevices = currentState.bondedDevices + device)
         }
     }
 
@@ -371,6 +383,9 @@ class FakeBluetoothRepository :
         /** bond() throws [error] — models a generic/flaky bonding failure (timeout, dropped broadcast, etc.). */
         data class Fail(val error: Throwable) : BondOutcome
 
+        /** bond() records the device as bonded, then throws [error] — models a lost terminal bond signal. */
+        data class FailAfterBond(val error: Throwable) : BondOutcome
+
         /** bond() throws [error] — models a missing-permission (BLUETOOTH_CONNECT) failure. */
         data class Security(val error: Throwable) : BondOutcome
     }
@@ -379,4 +394,9 @@ class FakeBluetoothRepository :
 /** Make the next [FakeBluetoothRepository.bond] call throw a generic [error] (the flaky/interrupted-bonding path). */
 fun FakeBluetoothRepository.failBondWith(error: Throwable = Exception("bond failed")) {
     bondOutcome = FakeBluetoothRepository.BondOutcome.Fail(error)
+}
+
+/** Make the next [FakeBluetoothRepository.bond] call record the device as bonded and then throw [error]. */
+fun FakeBluetoothRepository.failBondAfterRecording(error: Throwable = Exception("bond failed after pairing")) {
+    bondOutcome = FakeBluetoothRepository.BondOutcome.FailAfterBond(error)
 }

--- a/docs/fi-rFI/user/connections.md
+++ b/docs/fi-rFI/user/connections.md
@@ -27,7 +27,7 @@ Bluetooth Low Energy on oletus ja yleisin yhteystapa Androidilla.
 4. Valitse laitteesi listasta.
 5. Hyväksy Bluetooth-pariliitospyyntö, jos se tulee näkyviin.
 
-![Scanning for Bluetooth devices, with a discovered radio in the list](../../assets/screenshots/connections_bluetooth_scan.png)
+![Bluetooth-laitteiden haku, jossa löytynyt radio näkyy luettelossa](../../assets/screenshots/connections_bluetooth_scan.png)
 
 Voit suodattaa laitteita yhteystavan mukaan yläreunan suodatinpainikkeilla:
 
@@ -70,20 +70,20 @@ USB-yhteydet tarjoavat langallisen vaihtoehdon, hyödyllinen työpöytäkäytös
 
 > ⚠️ **Huom:** USB-yhteydet vaativat OTG-tuen Android-laitteissa.
 
-## TCP/IP (Network)
+## TCP/IP (Verkko)
 
-Some Meshtastic radios support WiFi/Ethernet connectivity, allowing TCP-based connections over your local network. Get the radio onto your network first — using the radio's own WiFi settings (via the firmware web interface or another connection) — then connect to it from the app.
+Jotkin Meshtastic-radiot tukevat WiFi tai Ethernet-yhteyttä, mikä mahdollistaa TCP-pohjaiset yhteydet lähiverkkosi kautta. Liitä radio ensin verkkoon käyttämällä radion omia WiFi-asetuksia (laiteohjelmiston verkkokäyttöliittymän tai muun yhteystavan kautta) — yhdistä siihen sitten sovelluksesta.
 
-### Connecting over the Network
+### Yhdistäminen verkon kautta
 
-1. Make sure the radio is on the same local network as your phone/desktop.
-2. On the Connect screen, select the **Network** transport filter.
-3. Choose the radio one of two ways:
-   - **Scan Network Devices** — toggle this on to auto-discover radios that advertise themselves on the local network (mDNS / `_meshtastic._tcp`). Discovered devices appear in the list; tap one to connect.
-   - **Add Network Device Manually** — enter the radio's IP address (or hostname) and port (default: `4403`).
-4. Previously-used network addresses are remembered under **Recent Network Devices** for quick reconnection (long-press to remove one).
+1. Varmista, että radio on samassa lähiverkossa kuin puhelimesi tai tietokoneesi.
+2. Valitse Yhdistä-näytössä **Verkko**-siirtotavan suodatin.
+3. Valitse radio jommallakummalla seuraavista tavoista:
+   - **Etsi verkkolaitteita** — ota tämä käyttöön löytääksesi automaattisesti lähiverkossa itsensä ilmoittavat radiot (mDNS / `_meshtastic._tcp`). Löydetyt laitteet näkyvät luettelossa; yhdistä napauttamalla haluamaasi laitetta.
+   - **Lisää verkkolaite manuaalisesti** — syötä radion IP-osoite (tai isäntänimi) ja portti (oletus: `4403`).
+4. Aiemmin käytetyt verkko-osoitteet tallennetaan **Viimeisimmät verkkolaitteet** -osioon nopeaa uudelleenyhdistämistä varten (poista pitämällä painettuna).
 
-> 💡 **Tip:** Network discovery uses mDNS, which only works when both devices are on the same subnet. On Android 17+ the app needs the local-network permission for scanning; if discovery finds nothing, add the device manually by IP.
+> 💡 **Vinkki:** Verkkolaitteiden haku käyttää mDNS:ää, joka toimii vain, kun molemmat laitteet ovat samassa aliverkossa. Android 17:ssä ja uudemmissa versioissa sovellus tarvitsee lähiverkon käyttöoikeuden laitteiden hakuun. Jos haku ei löydä mitään, lisää laite manuaalisesti IP-osoitteella.
 
 ### Milloin TCP-yhteyttä kannattaa käyttää
 

--- a/docs/fi-rFI/user/firmware.md
+++ b/docs/fi-rFI/user/firmware.md
@@ -64,11 +64,11 @@ Ennen päivityksen aloitamista:
 
 ## Päivityksen jälkeen
 
-After the firmware is written, the app verifies the update and waits for the device to come back online:
+Kun laiteohjelmisto on kirjoitettu, sovellus varmistaa päivityksen ja odottaa laitteen palaavan takaisin verkkoon:
 
-![Verifying update and waiting for the device to reconnect](../../assets/screenshots/firmware_verifying.png)
+![Päivityksen varmistus ja laitteen uudelleenyhdistymisen odottaminen](../../assets/screenshots/firmware_verifying.png)
 
-Once the update succeeds:
+Kun päivitys onnistuu:
 
 - Radio käynnistyy uudelleen automaattisesti
 - Bluetooth-yhteys muodostuu uudelleen

--- a/docs/fi-rFI/user/help-and-docs.md
+++ b/docs/fi-rFI/user/help-and-docs.md
@@ -1,49 +1,49 @@
 ---
-title: Help & In-App Docs
+title: Ohjeet jasovelluksen sisäinen dokumentaatio
 parent: Käyttöopas
 nav_order: 21
 last_updated: 2026-06-25
-description: Browse this documentation inside the app, search it, and ask Chirpy — the on-device AI assistant — questions about Meshtastic.
+description: Selaa tätä dokumentaatiota sovelluksessa, hae siitä tietoa ja kysy Meshtasticiin liittyviä kysymyksiä Chirpyltä — laitteella toimivalta tekoälyavustajalta.
 aliases:
-  - help
-  - docs-browser
+  - apua
+  - dokumenttiselain
   - chirpy
-  - assistant
+  - avustaja
 ---
 
-# Help & In-App Docs
+# Ohjeet jasovelluksen sisäinen dokumentaatio
 
-This same user documentation ships **inside the app**, so you can read it offline without leaving Meshtastic. Open it from **Settings → Help & Documentation**.
+Sama käyttöohje sisältyy myös **sovellukseen**, joten voit lukea sitä offline-tilassa poistumatta Meshtasticista. Avaa se kohdasta **Asetukset → Ohjeet & dokumentaatio**.
 
-## Browsing
+## Selaaminen
 
-The docs browser lists every user-guide page. Tap a page to read it; images and cross-links work just like they do here.
+Dokumentaation selain näyttää kaikki käyttöohjeen sivut. Avaa sivu napauttamalla sitä. Kuvat ja ristiviittaukset toimivat samalla tavalla kuin tässä dokumentaatiossa.
 
-![In-app documentation browser table of contents](../../assets/screenshots/docs-browser_toc.png)
+![Sovelluksen sisäisen dokumentaation sisällysluettelo](../../assets/screenshots/docs-browser_toc.png)
 
-### Search
+### Haku
 
-Tap the search icon and type to filter pages by title and keywords — results update as you type.
+Napauta hakukuvaketta ja kirjoita hakusanoja suodattaaksesi sivuja otsikon ja avainsanojen perusteella — tulokset päivittyvät kirjoittaessasi.
 
-![Searching the in-app documentation](../../assets/screenshots/docs-browser_search.png)
+![Haku sovelluksen sisäisessä dokumentaatiossa](../../assets/screenshots/docs-browser_search.png)
 
-A page open in the browser:
+Dokumentaatiosivu avattuna selaimessa:
 
-![A documentation page rendered in the app](../../assets/screenshots/docs-browser_page.png)
+![Dokumentaatiosivu avattuna sovelluksessa](../../assets/screenshots/docs-browser_page.png)
 
-## Chirpy — the AI Assistant
+## Chirpy — tekoälyn avustaja
 
-**Chirpy** answers plain-language questions about Meshtastic using this bundled documentation as its source. Tap the Chirpy button in the docs browser, type a question, and it replies with an answer and links to the relevant pages.
+**Chirpy** vastaa Meshtasticia koskeviin luonnollisella kielellä esitettyihin kysymyksiin käyttäen lähteenään tätä sovellukseen sisältyvää dokumentaatiota. Napauta Chirpy-painiketta dokumentaatioselaimessa, kirjoita kysymyksesi, niin se vastaa ja linkittää aiheeseen liittyville sivuille.
 
-![Chirpy AI assistant answering a question with page links](../../assets/screenshots/docs-browser_chirpy.png)
+![Chirpy-tekoälyavustaja vastaa kysymykseen ja näyttää linkkejä sivuille](../../assets/screenshots/docs-browser_chirpy.png)
 
-> 🔒 **Privacy:** On supported Google-flavor devices, Chirpy runs **on-device** using Gemini Nano — your questions never leave your phone. A small model downloads on first use.
+> ⚠️ **Tietosuoja:** Google-versiota käyttävillä laitteilla Chirpy toimii **laitteella** Gemini Nanon avulla — kysymyksesi eivät poistu puhelimestasi. Pieni kielimalli ladataan ensimmäisellä käyttökerralla.
 
-> ⚠️ **Note:** On F-Droid, Desktop, and iOS builds, Chirpy falls back to a **keyword search** over the documentation rather than a generative model. If your device doesn't support on-device AI, the assistant is hidden and you can still browse and search the docs normally.
+> ⚠️ **Huomautus:** F-Droid-, Desktop- ja iOS-versioissa Chirpy käyttää generatiivisen mallin sijaan dokumentaatioon perustuvaa **avainsanahakua**. Jos laitteesi ei tue laitteella toimivaa tekoälyä, avustaja piilotetaan, mutta voit silti selata dokumentaatiota ja hakea siitä tietoa normaalisti.
 
 ## Aiheeseen liittyvät aiheet
 
-- [Translate the App](translate) — how these pages get localized into other languages
-- [App Functions](app-functions) — the separate system-AI integration (distinct from Chirpy)
+- [Käännä sovellus](translate) — miten nämä sivut lokalisoidaan muille kielille
+- [Sovelluksen toiminnot](app-functions) — erillinen järjestelmätekoälyintegraatio (ei sama kuin Chirpy)
 
 ---

--- a/docs/fi-rFI/user/map-and-waypoints.md
+++ b/docs/fi-rFI/user/map-and-waypoints.md
@@ -25,7 +25,7 @@ Kartta näyttää:
 
 ### Radioiden merkinnät
 
-Each node that reports a position is shown as a **node chip** marker displaying the node's short name. The chip is colored by the node's own identity color (a stable color derived from its node number) — the same chip used in the node list, so a node looks the same everywhere. Marker color does **not** encode online/offline status. When a node's position updates live, its marker briefly pulses. Nearby markers are clustered as you zoom out.
+Jokainen sijaintinsa raportoiva radio näytetään **radiotunnisteena**, jossa näkyy radion lyhyt nimi. Tunniste väritetään radion oman tunnistevärin mukaan (pysyvä väri, joka muodostetaan radion numerosta) — sama radiotunniste näkyy myös radioluettelossa, joten radio näyttää kaikkialla samalta. Merkin väri **ei** ilmaise, onko radio verkossa vai poissa verkosta. Kun radion sijainti päivittyy reaaliajassa, sen merkki sykkii hetken. Lähekkäiset merkit ryhmitellään, kun loitonnat karttaa.
 
 ### Kartan hallinta
 

--- a/docs/fi-rFI/user/messages-and-channels.md
+++ b/docs/fi-rFI/user/messages-and-channels.md
@@ -79,7 +79,7 @@ Kun viestin toimitus epäonnistuu, virheilmaisin näyttää, mikä meni pieleen:
 | Ei Käyttöliittymää                                     | Lähetykseen ei ole käytettävissä radioliitäntää | Tarkista, että radio on yhdistetty ja kanava on määritetty.                                                                                                              |
 | Kaikki uudelleenyritykset käytetty                     | Uudelleenyritysten enimmäismäärä saavutettu     | Mesh-reitti ei ole luotettava. Kokeile toista kanavaa tai odota olosuhteiden parantumista.                                                               |
 | Ei Kanavaa                                             | Kohdekanavaa ei ole olemassa                    | Varmista, että molemmilla radioilla on sama kanavakonfiguraatio.                                                                                                         |
-| Liian suuri                                            | Viesti ylittää sallitun enimmäiskoon            | Shorten your message (max ~200 characters).                                                                                           |
+| Liian suuri                                            | Viesti ylittää sallitun enimmäiskoon            | Lyhennä viestisi (enintään noin 200 merkkiä).                                                                                                         |
 | Ei vastausta                                           | Radio vastaanotti viestin mutta ei vastannut    | Vastaanottajan radio voi olla varattu tai virransäästötilassa.                                                                                                           |
 | Käyttöasteen rajoitus                                  | Alueellinen lähetysajan raja saavutettu         | Radiosi on käyttänyt sallitun lähetysajan. Odota, että käyttöasteen rajoituksen ikkuna nollautuu (tyypillisesti 1 tunti EU-alueilla). |
 | Virheellinen pyyntö                                    | Viallinen tai virheellinen viesti               | Tämä yleensä viittaa ohjelmistovirheeseen. Kokeile käynnistää sovellus uudelleen.                                                                        |
@@ -99,9 +99,9 @@ Valmiiksi määritetyt viestit nopeaan viestintään:
 
 ![Pikachatti-vaihtoehto](../../assets/screenshots/messages_quick_chat.png)
 
-Each quick chat entry has a short **Name** (the button label), the **Message** it inserts, and an **Instantly send** toggle — when enabled, tapping the button sends the message immediately instead of placing it in the input field for editing:
+Jokaisella pikaviestillä on lyhyt **Nimi** (painikkeen teksti), lisättävä **Viesti** sekä **Lähetä heti** -kytkin. Kun se on käytössä, painikkeen napauttaminen lähettää viestin välittömästi sen sijaan, että se lisättäisiin muokattavaksi syöttökenttään:
 
-![New quick chat dialog with name, message, and instantly-send toggle](../../assets/screenshots/messages_edit_quick_chat.png)
+![Uusi pikakeskusteluviestin valintaikkuna, jossa näkyvät nimi, viesti ja Lähetä heti -kytkin](../../assets/screenshots/messages_edit_quick_chat.png)
 
 Kanavalista näyttää jokaisen kanavan ja sen viimeisimmän viestin esikatselun.
 
@@ -155,7 +155,7 @@ Viestit jonotetaan ja lähetetään prioriteetin mukaan:
 
 ### Viestirajoitukset
 
-- **Maximum length:** 200 bytes (approximately 200 characters for ASCII text)
+- **Enimmäispituus:** 200 tavua (noin 200 merkkiä ASCII-tekstille)
 - **Rajoitusnopeus:** mesh-verkko tasaa lähetysajan oikeudenmukaisesti; suuri viestimäärä voi joutua rajoitetuksi
 - **Toimitus:** viestit yritetään lähettää uudelleen automaattisesti, jos kuittausta ei saada
 

--- a/docs/fi-rFI/user/node-metrics.md
+++ b/docs/fi-rFI/user/node-metrics.md
@@ -45,9 +45,9 @@ Ympäristöanturien tiedot (edellyttää yhteensopivaa laitteistoa):
 
 Ympäristömittarit esitetään kaavioina ajan kuluessa tapahtuvan trendianalyysin helpottamiseksi — lämpötila, kosteus ja ilmanpaine saavat kukin oman viivakaavionsa, jossa mittayksikkö näkyy Y-akselilla.
 
-The BME680 **IAQ (Indoor Air Quality)** index is a single 0–500+ value derived from gas resistance, shown against a color-coded scale from _Excellent_ to _Dangerously Polluted_:
+BME680:n **IAQ (Indoor Air Quality)** -indeksi on yksi arvo väliltä 0–500+, joka perustuu kaasun resistanssiin. Se näytetään värikoodatulla asteikolla välillä _Erinomainen_–_Vaarallisen saastunut_:
 
-![IAQ index scale from Excellent to Dangerously Polluted](../../assets/screenshots/node-metrics_iaq_scale.png)
+![IAQ-indeksin asteikko välillä Erinomainen–Vaarallisen saastunut](../../assets/screenshots/node-metrics_iaq_scale.png)
 
 > 💡 **Vinkki:** Ympäristömittarit edellyttävät etäradioon liitettyä anturia. Kaikki radiot eivät raportoi ympäristötietoja. Katso [Telemetria ja anturit](telemetry-and-sensors) saadaksesi täydellisen luettelon tuetuista antureista.
 
@@ -96,16 +96,16 @@ Radiosignaalin laatutiedot:
 
 ### Signaalin laadun viitearvot
 
-Signal quality is rated from **SNR relative to the active LoRa modem preset's demodulation floor**, not from fixed thresholds — a given SNR means different things on different presets (e.g. −15 dB is fine on LongSlow but unusable on ShortFast). RSSI is shown but is not part of the rating. Letting `limit` be the preset's SNR limit:
+Signaalin laatu arvioidaan **SNR**-arvon perusteella suhteessa käytössä olevan LoRa-modeemiesiasetuksen **demodulaation alarajaan**, ei kiinteiden raja-arvojen perusteella. Sama SNR-arvo voi tarkoittaa eri asioita eri esiasetuksilla (esim. `-15 dB` on hyvä LongSlow-esiasetuksella, mutta käyttökelvoton ShortFast-esiasetuksella). RSSI näytetään, mutta sitä ei käytetä arvioinnissa. Jos `raja` tarkoittaa esiasetuksen SNR-rajaa:
 
-| Laatu       | Kriteerit                                        |
-| ----------- | ------------------------------------------------ |
-| Hyvä        | SNR above the preset's limit                     |
-| Kohtalainen | within 5.5 dB below the limit    |
-| Huono       | within 7.5 dB below the limit    |
-| ei mitään   | more than 7.5 dB below the limit |
+| Laatu       | Kriteerit                          |
+| ----------- | ---------------------------------- |
+| Hyvä        | SNR esiasetuksen rajan yläpuolella |
+| Kohtalainen | enintään 5,5 dB rajan alapuolella  |
+| Huono       | enintään 7,5 dB rajan alapuolella  |
+| ei mitään   | yli 7,5 dB rajan alapuolella       |
 
-See [Understanding the Signal Meter](signal-meter) for the full explanation.
+Katso [Signaalimittarin toiminta](signal-meter), jos haluat täydellisen selityksen.
 
 Yhdistetyn radion paikalliset tilastot näytetään myös Signaalin laatu -näkymässä silloin, kun ne ovat saatavilla. Nämä kerätyt tiedot sisältävät kohinatason, liikennelaskurit, välityslaskurit, verkossa olevien radioiden määrän sekä radion käyttöajan. Kohinatason kaaviossa käytetään katkoviivalla merkittyä viiteviivaa arvossa -85 dBm, jotta kuormittunut RF-ympäristö on helpompi tunnistaa. Käytä **Pyydä**-painiketta pyytääksesi yhdistetystä radiosta tuoreen Paikalliset tilastot -telemetriaraportin, **Tyhjennä**-painiketta poistaaksesi Paikalliset tilastot -lokit kyseiseltä radiolta ja **Tallenna**-painiketta viedäksesi näkyvän Paikalliset tilastot -historian CSV-tiedostoksi.
 

--- a/docs/fi-rFI/user/nodes.md
+++ b/docs/fi-rFI/user/nodes.md
@@ -27,13 +27,13 @@ Radioluettelo näyttää kaikki radiot, joista radiosi on vastaanottanut tietoja
 
 ### Radion tilailmaisimet
 
-| Tunniste    | Tarkoitus                              |
-| ----------- | -------------------------------------- |
-| 🟢 Verkossa | Radio kuultu viimeisen 2 tunnin aikana |
-| ⚪ Offline   | Radiosta ei ole kuultu yli 2 tuntiin   |
-| ⭐ Suosikki  | Käyttäjän suosikiksi merkitsemä radio  |
+| Tunniste     | Tarkoitus                              |
+| ------------ | -------------------------------------- |
+| 🟢 Verkossa  | Radio kuultu viimeisen 2 tunnin aikana |
+| Ei verkkossa | Radiosta ei ole kuultu yli 2 tuntiin   |
+| ⭐ Suosikki   | Käyttäjän suosikiksi merkitsemä radio  |
 
-A node is considered **online** if it was heard within the last 2 hours, and **offline** otherwise — there is no separate "away" tier.
+Radio katsotaan **verkossa olevaksi**, jos siitä on kuultu viimeisten 2 tunnin aikana. Muussa tapauksessa se katsotaan **poissa verkosta** olevaksi — erillistä "poissa"-tilaa ei ole.
 
 ### Radion roolit
 
@@ -104,7 +104,7 @@ Kirjoita hakukenttään suodattaaksesi radioita nimen tai lyhyen nimen perusteel
 
 | Suodatus                              | Kuvaus                                                                                          |
 | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Vain verkossa olevat**              | Show only nodes heard within the last 2 hours                                                   |
+| **Vain verkossa olevat**              | Näytä vain radiot, joista on kuultu viimeisten 2 tunnin aikana                                  |
 | **Vain suorat**                       | Näytä vain radiot, joihin on suora yhteys (ei välitetty yhteys)              |
 | **Näytä tuntemattomat**               | Näytä radiot, jotka eivät ole vielä lähettäneet käyttäjätietoja                                 |
 | **Ohita infrastruktuurilaitteet**     | Piilottaa infrastruktuuriroolit (Router, Repeater, Router Late, Client Base) |

--- a/docs/fi-rFI/user/settings-radio-user.md
+++ b/docs/fi-rFI/user/settings-radio-user.md
@@ -55,7 +55,7 @@ Asetusten muuttamisen jälkeen napauta **Tallenna** kirjoittaaksesi määritykse
 
 ### Esiasetukset
 
-> 💡 **Tip:** The **SNR Limit** values are negative on purpose. LoRa can decode signals _below_ the noise floor, so a more-negative limit means the preset tolerates a weaker, noisier signal (more range). See [How the Signal Meter Works](signal-meter) for the full explanation.
+> 💡 **Vinkki:** **SNR-raja**-arvot ovat tarkoituksella negatiivisia. LoRa pystyy purkamaan signaaleja _kohinatason alapuolelta_, joten negatiivisempi raja tarkoittaa, että esiasetus sietää heikomman ja kohinaisemman signaalin (suurempi kantama). Katso [Miten signaalimittari toimii](signal-meter) saadaksesi täydellisen selityksen.
 
 | Esiasetus          | Kantama                 | Nopeus                    | SNR-raja                 | Paras käyttöön                                                                                                                     |
 | ------------------ | ----------------------- | ------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/fi-rFI/user/signal-meter.md
+++ b/docs/fi-rFI/user/signal-meter.md
@@ -3,7 +3,7 @@ title: Kuinka Meshtastic-signaalimittari toimii
 parent: Käyttöopas
 nav_order: 15
 last_updated: 2026-06-25
-description: How the signal meter rates quality from SNR relative to the LoRa modem preset — spread spectrum, presets, and what the bars really mean.
+description: Miten signaalimittari arvioi signaalin laadun SNR-arvon perusteella suhteessa LoRa-modeemiesiasetukseen — hajaspektri, esiasetukset ja mitä palkit todellisuudessa tarkoittavat.
 aliases:
   - signaali
   - signaalimittari
@@ -13,7 +13,7 @@ aliases:
 
 # Kuinka Meshtastic-signaalimittari toimii
 
-The Meshtastic signal meter — the familiar bars or status color in the app — is calculated very differently than the "bars" on a traditional cell phone or WiFi router.
+Meshtasticin signaalimittari — sovelluksessa näkyvät tutut palkit tai tilan väri — lasketaan hyvin eri tavalla kuin perinteisen matkapuhelimen tai WiFi-reitittimen "palkit".
 
 Useimmat kuluttajalaitteet mittaavat yksinkertaisesti signaalin “voimakkuutta”. Koska Meshtastic käyttää **LoRa (Long Range)** -teknologiaa, signaalimittari arvioi sen sijaan kuinka “selkeä” signaali on suhteessa käytössä olevan mesh-verkon asetuksiin.
 
@@ -26,7 +26,7 @@ Aina kun LoRa-radio vastaanottaa viestin, se raportoi kaksi arvoa:
 - **RSSI (Received Signal Strength Indicator):** kuinka “voimakas” antenniin saapuva signaali on.
 - **SNR (Signal-to-Noise Ratio):** kuinka “selkeä” signaali on suhteessa taustakohinaan.
 
-> 💡 **Tip:** Here's an analogy — imagine you are trying to hear a friend talking to you.
+> 💡 **Vinkki:** Ajattele asiaa näin — yrität kuulla ystäväsi puhetta.
 >
 > - **RSSI** on kuinka kovaa hän puhuu.
 > - **Melutaso (Noise Floor)** on huoneen taustahäly (ilmastointi, muut ihmiset, liikenne).
@@ -38,7 +38,7 @@ Jos ystäväsi huutaa rock-konsertissa, signaali on erittäin voimakas (korkea R
 
 ## 2. LoRa:n “taika”: kuuleminen kohinan alta
 
-For standard radios (like FM or WiFi), if the background noise is louder than the signal (a negative SNR), the receiver just hears static.
+Tavallisessa radiossa (kuten FM- tai WiFi-yhteydessä), jos taustakohina on voimakkaampi kuin signaali (negatiivinen SNR), vastaanotin kuulee vain kohinaa.
 
 LoRa on erilainen. Se käyttää **hajaspektritekniikkaa (Spread Spectrum)**, joka mahdollistaa signaalin erottamisen myös silloin, kun se on taustakohinan alla. Siksi Meshtasticissa näkyy usein **negatiivisia SNR-arvoja** (esim. -10 dB tarkoittaa, että signaali on 10 dB heikompi kuin kohina).
 
@@ -48,18 +48,18 @@ Riippuen siitä, mitä Meshtastic-esiasetusta käytät (esim. “LongFast” vs.
 
 ## 3. Kuinka signaalimittari laskee laadun
 
-The app rates your signal quality (None, Bad, Fair, or Good) from **SNR alone, measured relative to the preset's SNR Limit** — the demodulation floor described above. It deliberately does **not** factor RSSI into the rating: without the local noise floor, RSSI cannot tell you whether a signal is actually decodable, so SNR-versus-the-preset-limit is the meaningful measure. (RSSI is still displayed to you elsewhere.)
+Sovellus arvioi signaalin laadun (Ei, Huono, Kohtalainen tai Hyvä) pelkästään **SNR**-arvon perusteella, suhteessa esiasetuksen **SNR-rajaan** — eli demodulaation alarajaan, joka on kuvattu aiemmin. Se ei tarkoituksella ota **RSSI**-arvoa huomioon arvioinnissa: ilman paikallista kohinatasoa RSSI ei kerro, voidaanko signaali todella purkaa, joten SNR suhteessa esiasetuksen rajaan on merkityksellinen mittari. (RSSI näytetään edelleen muualla sovelluksessa.)
 
-Because the rating is relative to the preset limit, the _same_ SNR can rate differently on different presets — `-15 dB` is healthy on `LongSlow` but unusable on `ShortFast`. Letting `limit` be the active preset's SNR Limit, here is how the app picks the bars (or color):
+Koska arviointi perustuu esiasetuksen rajaan, _sama_ SNR-arvo voi saada eri arvosanan eri esiasetuksilla — esimerkiksi `-15 dB` on hyvä arvo LongSlow-esiasetuksella, mutta käyttökelvoton ShortFast-esiasetuksella. Jos "raja" tarkoittaa käytössä olevan esiasetuksen SNR-rajaa, sovellus määrittää palkit (tai värin) seuraavasti:
 
-| Taso        | Palkit | Kriteerit                            | Merkitys                                                                                 |
-| ----------- | ------ | ------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Hyvä        | 3      | SNR **above** the preset's `limit`   | Signal is comfortably above the demodulation floor — healthy connection. |
-| Kohtalainen | 2      | within `5.5 dB` below the `limit`    | Decodable, but getting close to the floor.                               |
-| Huono       | 1      | within `7.5 dB` below the `limit`    | At the very edge of what the preset can recover.                         |
-| ei mitään   | 0      | more than `7.5 dB` below the `limit` | Below the floor — transmission lost to noise.                            |
+| Taso        | Palkit | Kriteerit                              | Merkitys                                                                                   |
+| ----------- | ------ | -------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Hyvä        | 3      | SNR **esiasetuksen rajan yläpuolella** | Signaali on selvästi demodulaation alarajan yläpuolella — hyvä yhteys.     |
+| Kohtalainen | 2      | enintään 5,5 dB "rajan" alapuolella    | Signaali voidaan vielä purkaa, mutta se on lähellä demodulaation alarajaa. |
+| Huono       | 1      | enintään 7,5 dB "rajan" alapuolella    | Signaali on aivan esiasetuksen palautumiskyvyn rajalla.                    |
+| ei mitään   | 0      | yli 7,5 dB "rajan" alapuolella         | Signaali on demodulaation alarajan alapuolella — lähetys hukkuu kohinaan.  |
 
-> **Note:** The fixed SNR thresholds you may have seen elsewhere (`-7 dB` / `-15 dB`) are now only used for coloring individual hops in traceroute results — not for the per-node signal meter described here.
+> **Huomautus:** Kiinteitä SNR-rajoja, joita olet ehkä nähnyt muualla (−7 dB / −15 dB), käytetään nykyisin vain traceroute-tulosten yksittäisten hyppyjen väritykseen — ei radion yleisen signaalin laadun arviointiin.
 
 ---
 
@@ -67,9 +67,9 @@ Because the rating is relative to the preset limit, the _same_ SNR can rate diff
 
 Koska Meshtasticin mittari toimii enemmän **selkeysmittarina**, se käyttäytyy eri tavalla kuin useimmat odottavat:
 
-> 💡 **Tip:** Don't panic over low RSSI. You might see a seemingly terrible RSSI value like `-118 dBm`. Tavallisessa puhelimessa tämä tarkoittaisi käytännössä nollakenttää. Mutta jos SNR on esimerkiksi +2 dB, Meshtastic voi silti näyttää vahvaa signaalia! _Kirjasto on hiljainen, joten kuiskaus kuuluu täydellisesti._
+> 💡 **Vinkki:** Älä huolestu matalasta RSSI-arvosta. Saatat nähdä näennäisesti erittäin huonon RSSI-arvon, kuten `-118 dBm`. Tavallisessa puhelimessa tämä tarkoittaisi käytännössä nollakenttää. Mutta jos SNR on esimerkiksi +2 dB, Meshtastic voi silti näyttää vahvaa signaalia! _Kirjasto on hiljainen, joten kuiskaus kuuluu täydellisesti._
 
-> ⚠️ **Warning:** Watch out for local noise. If you hook up a massive antenna and see a great RSSI (e.g., `-90 dBm`) but your signal meter is only showing **1 Bar (Bad)**, you have a problem. Se tarkoittaa paikallista häiriötä — esimerkiksi halpa virtalähde, kohiseva elektroniikka tai lähellä oleva radiolähetin voi luoda niin paljon kohinaa, että se peittää mesh-verkon.
+> ⚠️ **Varoitus:** Kiinnitä huomiota paikalliseen kohinaan. Jos liität suuren antennin ja näet hyvän RSSI-arvon (esim. `-90 dBm`), mutta signaalimittari näyttää silti vain **1 palkin (Huono)**, yhteydessä on ongelma. Se tarkoittaa paikallista häiriötä — esimerkiksi halpa virtalähde, kohiseva elektroniikka tai lähellä oleva radiolähetin voi luoda niin paljon kohinaa, että se peittää mesh-verkon.
 
 ## Missä signaalitieto näkyy
 
@@ -84,9 +84,9 @@ Sovelluksessa signaalidata näkyy useissa paikoissa:
 
 ## Aiheeseen liittyvät aiheet
 
-- [Nodes](nodes) — where signal bars appear in the node list
-- [Node Metrics](node-metrics) — SNR/RSSI history and the per-node signal quality reference
-- [Settings — Radio & User](settings-radio-user) — modem presets and their SNR limits
+- [Radiot](nodes) — missä signaalipalkit näkyvät radioluettelossa
+- [Radion mittarit](node-metrics) — SNR ja RSSI-historia ja radion signaalin laadun viitearvot
+- [Asetukset — Radio ja käyttäjä](settings-radio-user) — modeemiesiasetukset ja niiden SNR-rajat
 
 ---
 

--- a/docs/fi-rFI/user/tak.md
+++ b/docs/fi-rFI/user/tak.md
@@ -49,14 +49,14 @@ TAK-moduuli mahdollistaa Meshtastic-radioille:
 2. Avaa ATAK ja ota Meshtastic-lisäosa käyttöön.
 3. Lisäosa välittää viestejä ATAK:n ja mesh-verkkosi välillä.
 
-### Local TAK Server
+### Paikallinen TAK-palvelin
 
-The app can also run a **local TAK server** so ATAK/iTAK clients on the same device or network can connect directly, without a remote TAK server. Open **Settings → Module Config → TAK → TAK Server**:
+Sovellus voi toimia myös **paikallisena TAK-palvelimena**, jolloin samalla laitteella tai samassa verkossa olevat ATAK-/iTAK-asiakkaat voivat muodostaa yhteyden suoraan ilman etä-TAK-palvelinta. Avaa **Asetukset → Moduuliasetukset → TAK → TAK-palvelin**:
 
-![Local TAK Server settings with enable toggle and export option](../../assets/screenshots/tak_server_enabled.png)
+![Paikallisen TAK-palvelimen asetukset, joissa näkyvät käyttöönotto ja vientitoiminto](../../assets/screenshots/tak_server_enabled.png)
 
-- **Enable Local TAK Server** — starts a local TLS server on port **8089** for ATAK/iTAK connections.
-- **Export TAK Data Package** — generates a `.zip` data package that ATAK/iTAK can import to connect to this server.
+- **Ota paikallinen TAK-palvelin käyttöön** — käynnistää paikallisen TLS-palvelimen portissa **8089** ATAK-/iTAK-yhteyksiä varten.
+- **Vie TAK-tietopaketti** — luo `.zip`-tietopaketin, jonka ATAK/iTAK voi tuoda muodostaakseen yhteyden tähän palvelimeen.
 
 ## TAK-roolit
 

--- a/docs/fi-rFI/user/telemetry-and-sensors.md
+++ b/docs/fi-rFI/user/telemetry-and-sensors.md
@@ -103,7 +103,7 @@ Hiukkas- tai CO₂-antureilla varustetut radiot raportoivat ilmanlaatutietoja:
 | PM10                  | µg/m³   | Karkeat hiukkaset         |
 | CO₂                   | ppm     | Hiilidioksidipitoisuus    |
 
-The CO₂ reading is color-coded by severity (Good → Stuffy → Poor → Unsafe → Evacuate). See [Node Metrics — Air Quality](node-metrics#air-quality-metrics) for the exact ppm bands and colors.
+CO₂-arvo on värikoodattu vakavuuden mukaan (Hyvä → Tunkkainen → Huono → Epäturvallinen → Evakuoi). Katso [Radion metriikat — ilmanlaatu](node-metrics#air-quality-metrics) tarkat ppm-kaistat ja värit.
 
 Ilmanlaatutiedot voidaan näyttää tietokortteina radion tietonäytössä, esittää kaavioina ajan kuluessa ja viedä CSV-tiedostoon.
 

--- a/docs/fi-rFI/user/translate.md
+++ b/docs/fi-rFI/user/translate.md
@@ -3,7 +3,7 @@ title: Käännä sovellus
 parent: Käyttöopas
 nav_order: 17
 last_updated: 2026-06-25
-description: How the app and its documentation are translated via Crowdin, and guidelines for contributing translations.
+description: Miten sovellus ja sen dokumentaatio käännetään Crowdinin avulla sekä ohjeet käännöksiin osallistumiseen.
 aliases:
   - käännä
   - crowdin
@@ -24,7 +24,7 @@ Käännöksiin osallistuminen auttaa tekemään Meshtasticista saavutettavamman 
 | Käyttöoppaan sivut  | `docs/user/*.md`                      | Sovelluksen sisäinen dokumentaatio Ohjeet ja dokumentaatio -osiossa |
 | Fastlane-metatiedot | fastlane/metadata/android/en-US/      | Sovelluskaupan listauksen otsikko, kuvaus ja muutoslokit            |
 
-> ⚠️ **Note:** Developer Guide pages are English-only. Code-focused documentation targeting contributors is not translated.
+> ⚠️ **Huomautus:** Kehittäjän oppaan sivut ovat saatavilla vain englanniksi. Koodiin keskittyvää dokumentaatiota, joka on suunnattu kehitystyöhön osallistuville, ei käännetä.
 
 ---
 
@@ -36,7 +36,7 @@ Käännöksiin osallistuminen auttaa tekemään Meshtasticista saavutettavamman 
 4. **Tarkista konteksti.** Monet merkkijonot sisältävät kuvakaappauksia tai kontekstikommentteja — tarkista nämä ymmärtääksesi, missä teksti näkyy sovelluksessa.
 5. **Lähetä.** Hyväksytyt käännökset yhdistetään automaattisesti seuraavaan julkaisuun.
 
-> 💡 **Tip:** Keep translations short. UI strings often appear in buttons, chips, or narrow columns. Jos käännös on huomattavasti pidempi kuin englanninkielinen alkuperäinen, harkitse tiivistämistä niin, että merkitys säilyy selkeänä.
+> 💡 **Vinkki:** Pidä käännökset lyhyinä. Käyttöliittymän tekstit näkyvät usein painikkeissa, tunnisteissa tai kapeissa sarakkeissa. Jos käännös on huomattavasti pidempi kuin englanninkielinen alkuperäinen, harkitse tiivistämistä niin, että merkitys säilyy selkeänä.
 
 ---
 
@@ -80,7 +80,7 @@ docs/
 └── ...
 ```
 
-Locale folders use the Android resource convention `{lang}-r{REGION}` (e.g. `fr-rFR`, `de-rDE`, `ja-rJP`), matching the `values-*` directories used for app strings.
+Aluekansiot käyttävät Androidin resurssikäytäntöä `{kieli}-r{ALUE}` (esim. `fr-rFR`, `de-rDE`, `ja-rJP`), joka vastaa sovelluksen merkkijonoissa käytettyjä `values-*`-hakemistoja.
 
 Sovellus valitsee automaattisesti oikean kielialueen laitteen **Kieli & alue** -asetusten perusteella.
 

--- a/docs/fi-rFI/user/units-and-locale.md
+++ b/docs/fi-rFI/user/units-and-locale.md
@@ -3,7 +3,7 @@ title: Yksiköt, mittaus ja kieli- ja alueasetukset
 parent: Käyttöopas
 nav_order: 16
 last_updated: 2026-05-12
-description: How the app formats temperature, distance, speed, and other measurements based on your device locale.
+description: Miten sovellus muotoilee lämpötilan, etäisyyden, nopeuden ja muut mittayksiköt laitteesi alueasetusten perusteella.
 ---
 
 # Yksiköt, mittaus ja kieli- ja alueasetukset
@@ -18,7 +18,7 @@ Meshtastic-radiot lähettävät aina datan **metrisissä yksiköissä** (metrit,
 
 Androidissa mittausasetukset määräytyvät järjestelmän **Kieli ja alue** -asetusten mukaan. Työpöytäversiossa (JVM) sovellus käyttää JVM:n oletus-`Locale`-asetusta.
 
-> 💡 **Tip:** You never need to toggle units inside the app. Change your system measurement preferences and every screen in Meshtastic updates automatically — node details, telemetry charts, weather, altitude, and more.
+> 💡 **Vinkki:** Mittayksiköitä ei tarvitse koskaan vaihtaa sovelluksen sisältä. Muuta järjestelmäsi mittayksikköasetuksia, niin kaikki Meshtasticin näkymät päivittyvät automaattisesti — radion tiedot, telemetriakaaviot, sää, korkeus ja paljon muuta.
 
 ---
 
@@ -115,13 +115,13 @@ Androidissa mittausjärjestelmäsi (metrinen vs imperial) on sidottu alueasetuks
 2. Vaihda **Alue**- tai **Mittausyksiköt**-asetusta
 3. Palaa Meshtasticiin — arvot päivittyvät välittömästi
 
-> 💡 **Tip:** The app uses `MetricFormatter` from `core:common`. All measurement formatting is handled by a shared KMP utility that respects your platform's locale. Uusia mittausnäkymiä lisäävien kehittäjien tulisi käyttää `MetricFormatter`-toimintoa sen sijaan, että yksikkömuunnokset toteutetaan kovakoodattuna.
+> 💡 **Vinkki:** Sovellus käyttää `core:common`-moduulin `MetricFormatter`-luokkaa. Kaikkien mittausten muotoilu hoidetaan yhteisellä KMP-apuohjelmalla, joka noudattaa käyttöympäristösi alueasetuksia. Uusia mittausnäkymiä lisäävien kehittäjien tulisi käyttää `MetricFormatter`-toimintoa sen sijaan, että yksikkömuunnokset toteutetaan kovakoodattuna.
 
 ## Aiheeseen liittyvät aiheet
 
-- [Node Metrics](node-metrics) — where temperature, distance, and sensor values are displayed
-- [Telemetry & Sensors](telemetry-and-sensors) — the sensors that produce these measurements
-- [Settings — Radio & User](settings-radio-user) — region setting that drives unit selection
+- [Radion mittarit](node-metrics) — missä lämpötila-, etäisyys- ja anturiarvot näytetään
+- [Telemetria ja anturit](telemetry-and-sensors) — anturit, jotka tuottavat nämä mittaukset
+- [Asetukset — Radio ja käyttäjä](settings-radio-user) — alueasetus, joka määrittää käytettävät mittayksiköt
 
 ---
 

--- a/docs/fi-rFI/user/widget.md
+++ b/docs/fi-rFI/user/widget.md
@@ -1,46 +1,46 @@
 ---
-title: Home Screen Widget
+title: Aloitusnäytön widget
 parent: Käyttöopas
 nav_order: 20
 last_updated: 2026-06-25
-description: Add the Meshtastic home screen widget to glance at your connected radio's local stats without opening the app.
+description: Lisää Meshtasticin aloitusnäytön widget, jotta näet yhdellä silmäyksellä yhdistetyn radiosi paikalliset tilastot ilman, että avaat sovelluksen.
 aliases:
   - widget
-  - home-screen-widget
-  - local-stats-widget
+  - aloitusnäytön widget
+  - paikalliset tilastot widget
 ---
 
-# Home Screen Widget
+# Aloitusnäytön widget
 
-On Android, Meshtastic provides a home screen **widget** that shows live local statistics from your connected radio at a glance — no need to open the app.
+Androidissa Meshtastic tarjoaa aloitusnäytölle **widgetin**, joka näyttää yhdistetyn radiosi paikalliset tilastot yhdellä silmäyksellä — sovellusta ei tarvitse avata.
 
-## What It Shows
+## Mitä se näyttää
 
-The widget displays the **connected radio's** current local stats:
+Widget näyttää **yhdistetyn radion** tämänhetkiset paikalliset tilastot:
 
-- **Battery** — the radio's battery level, or _Powered_ when running on external power
-- **ChUtil** — channel utilization (how busy the LoRa channel is, as a percentage)
-- **AirUtil** — airtime utilization (how much of the duty cycle your radio is transmitting)
-- **Traffic** — packets transmitted / received, and duplicates seen
-- **Relays** — packets relayed and relay cancellations (shown when the radio is relaying)
+- **Akun varaustaso** — radion akun varaustaso tai **Verkkovirta**, jos radio käyttää ulkoista virtalähdettä
+- **ChUtil** — kanavan käyttöaste (kuinka kuormitettu LoRa-kanava on prosentteina)
+- **AirUtil** — lähetysajan käyttöaste (kuinka suuren osan lähetysajasta radiosi käyttää)
+- **Liikenne** — lähetetyt ja vastaanotetut paketit sekä havaitut kaksoiskappaleet
+- **Välitykset** — välitetyt paketit ja välityksen peruutukset (näytetään, kun radio toimii välittäjänä)
 
-Tap the widget to open the app, or use its refresh control to request fresh stats.
+Avaa sovellus napauttamalla widgetiä tai pyydä uudet tilastot sen päivityspainikkeella.
 
-> 💡 **Tip:** The values reflect the radio you are currently connected to. If the app isn't connected to a radio, the widget shows the last known stats until it reconnects.
+> 💡 **Vinkki:** Arvot vastaavat sitä radiota, johon olet parhaillaan yhdistetty. Jos sovellus ei ole yhdistetty radioon, widget näyttää viimeksi tunnetut tilastot, kunnes yhteys muodostuu uudelleen.
 
-## Adding the Widget
+## Widgetin lisääminen
 
-1. Long-press an empty area of your Android home screen.
-2. Tap **Widgets**.
-3. Find **Meshtastic** in the list and drag the **Local Stats** widget to your home screen.
-4. Resize it as needed — the layout adapts to the available space.
+1. Paina pitkään tyhjää kohtaa Androidin aloitusnäytössä.
+2. Napauta **Widgetit**.
+3. Etsi luettelosta **Meshtastic** ja vedä **Paikalliset tilastot** -widget aloitusnäyttöön.
+4. Muuta widgetin kokoa tarvittaessa — asettelu mukautuu käytettävissä olevaan tilaan.
 
-> ⚠️ **Note:** The widget is Android-only. It is not available on the Desktop or iOS builds.
+> ⚠️ **Huomautus:** Widget on käytettävissä vain Androidissa. Se ei ole käytettävissä Desktop- tai iOS-versioissa.
 
 ## Aiheeseen liittyvät aiheet
 
-- [Node Metrics](node-metrics) — the full Signal Quality and Local Stats history inside the app
-- [Connections](connections) — connect to a radio so the widget has stats to show
-- [Discovery](discovery) — channel and airtime utilization across the mesh
+- [Radion mittarit](node-metrics) — täydellinen signaalin laatu- ja paikalliset tilastot -historia sovelluksessa
+- [Yhteydet](connections) — yhdistä radioon, jotta widgetillä on näytettäviä tilastoja
+- [Haku](discovery) — kanavan ja lähetysajan käyttöaste koko verkossa
 
 ---

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -18,14 +18,19 @@ package org.meshtastic.feature.connections
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.jetbrains.compose.resources.getString
 import org.junit.runner.RunWith
 import org.meshtastic.core.network.repository.UsbRepository
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.bonding_failed_retry
 import org.meshtastic.core.testing.FakeBleDevice
+import org.meshtastic.core.testing.failBondAfterRecording
 import org.meshtastic.core.testing.failBondWith
 import org.meshtastic.core.testing.failBondWithSecurityException
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -41,10 +46,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Coverage for the #5849 fix in [AndroidScannerViewModel.requestBonding]: the transport is armed
- * (`changeDeviceAddress`) on every bonding outcome EXCEPT a permissions [SecurityException], so an interrupted bond no
- * longer strands the device. Driven through the public [ScannerViewModel.onSelected] entry point (which routes an
- * unbonded BLE entry to `requestBonding`).
+ * Coverage for [AndroidScannerViewModel.requestBonding]: only a successful bond arms the transport. Bond failures
+ * surface a warning and wait for an explicit retry so the Android pairing flow does not immediately re-enter through
+ * transport-side bonding.
  *
  * Robolectric is used only because the class under test lives in `androidMain`; the bonding outcomes themselves are
  * injected via [org.meshtastic.core.testing.FakeBluetoothRepository], keeping each assertion deterministic. The real
@@ -58,11 +62,12 @@ class AndroidScannerViewModelBondingTest {
     private val mac = "AA:BB:CC:DD:EE:FF"
     private val expectedFullAddress = "x$mac"
 
-    private val harness = ScannerViewModelHarness()
+    private lateinit var harness: ScannerViewModelHarness
     private lateinit var viewModel: AndroidScannerViewModel
 
     @BeforeTest
     fun setUp() {
+        harness = ScannerViewModelHarness()
         Dispatchers.setMain(harness.testDispatcher)
         viewModel =
             AndroidScannerViewModel(
@@ -119,10 +124,22 @@ class AndroidScannerViewModelBondingTest {
     }
 
     @Test
-    fun `generic bond failure still arms the transport`() = runTest(harness.testDispatcher) {
-        // The interrupted-bonding case the fix targets: bond() throws a non-permission error, but we must still
-        // arm the transport so its reconnect loop can converge instead of leaving the device inert.
+    fun `generic bond failure does not arm the transport and surfaces an error`() = runTest(harness.testDispatcher) {
+        // A failed pairing attempt should wait for another user action instead of immediately arming the transport,
+        // which would call transport-side bond() and risk a duplicate PIN dialog or Android createBond() throttle.
         harness.bluetoothRepository.failBondWith(Exception("Failed to initiate bonding"))
+
+        viewModel.onSelected(ScannerViewModelHarness.unbondedBleEntry(mac))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(1, harness.bluetoothRepository.bondCalls.size)
+        assertNull(harness.radioController.lastSetDeviceAddress)
+        assertEquals(getString(Res.string.bonding_failed_retry), harness.serviceRepository.errorMessage.value)
+    }
+
+    @Test
+    fun `bond failure after Android records bond still arms the transport`() = runTest(harness.testDispatcher) {
+        harness.bluetoothRepository.failBondAfterRecording(Exception("Timed out waiting for bonding to complete"))
 
         viewModel.onSelected(ScannerViewModelHarness.unbondedBleEntry(mac))
         testScheduler.advanceUntilIdle()
@@ -143,6 +160,23 @@ class AndroidScannerViewModelBondingTest {
         assertEquals(1, harness.bluetoothRepository.bondCalls.size)
         assertNull(harness.radioController.lastSetDeviceAddress)
         assertNotNull(harness.serviceRepository.errorMessage.value)
+    }
+
+    @Test
+    fun `CancellationException from bond propagates without arming transport`() = runTest(harness.testDispatcher) {
+        // CE must propagate — not be swallowed into an error message or transport arming.
+        // Discriminator: if the CE catch were removed, CE would fall through to catch(Exception),
+        // set an error message, and return false — errorMessage would be non-null, failing this test.
+        harness.bluetoothRepository.failBondWith(CancellationException("cancelled"))
+
+        viewModel.onSelected(ScannerViewModelHarness.unbondedBleEntry(mac))
+        testScheduler.advanceUntilIdle()
+
+        assertNull(harness.radioController.lastSetDeviceAddress, "transport must not be armed")
+        assertNull(
+            harness.serviceRepository.errorMessage.value,
+            "CE must propagate, not be caught as generic failure",
+        )
     }
 
     @Test

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
@@ -19,6 +19,7 @@ package org.meshtastic.feature.connections
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -36,6 +37,7 @@ import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.repository.UiPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.bonding_failed_permissions
+import org.meshtastic.core.resources.bonding_failed_retry
 import org.meshtastic.core.resources.usb_permission_denied
 import org.meshtastic.feature.connections.model.AndroidUsbDeviceData
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -86,17 +88,26 @@ class AndroidScannerViewModel(
                         severity = Severity.Warn,
                     )
                     false
+                } catch (ex: CancellationException) {
+                    throw ex
                 } catch (ex: Exception) {
-                    // Bonding is flaky and can fail for many reasons: user cancel/timeout, an unreliable
-                    // ACTION_BOND_STATE_CHANGED broadcast, or an OS/GATT-initiated bond already in flight
-                    // (see Kable #111). Don't treat any of these as terminal — arm the transport anyway so
-                    // its persistent reconnect loop (which bonds on demand and retries with backoff) can
-                    // converge, instead of leaving the device inert until the user re-selects it.
-                    Logger.w(ex) {
-                        "Bonding did not complete cleanly for ${entry.device.address.anonymize}; " +
-                            "arming transport to retry"
+                    if (bluetoothRepository.isBonded(entry.device.address)) {
+                        Logger.w(ex) {
+                            "Bonding did not complete cleanly for ${entry.device.address.anonymize}, " +
+                                "but Android now reports it bonded; selecting device"
+                        }
+                        true
+                    } else {
+                        Logger.w(ex) {
+                            "Bonding did not complete cleanly for ${entry.device.address.anonymize}; " +
+                                "waiting for an explicit retry"
+                        }
+                        serviceRepository.setErrorMessage(
+                            text = getString(Res.string.bonding_failed_retry),
+                            severity = Severity.Warn,
+                        )
+                        false
                     }
-                    true
                 }
             if (armTransport) {
                 changeDeviceAddress(entry.fullAddress)


### PR DESCRIPTION


## Summary by Sourcery

Guard BLE transport connection attempts behind explicit bonding outcome and improve handling of bond failures and cancellations.

Bug Fixes:
- Prevent BLE transport from proceeding to GATT connection when bonding fails and the device remains unbonded, surfacing a RadioNotConnectedException instead.
- Ensure CancellationException from bonding propagates as coroutine cancellation rather than triggering reconnect retries.

Enhancements:
- Extract bonding logic into a dedicated helper that re-checks bond state after failures and logs clearer outcomes.
- Allow RadioNotConnectedException to wrap an underlying cause for better error diagnostics.
- Extend FakeBluetoothRepository to model flaky bonding scenarios where the device becomes bonded despite a reported failure.

Tests:
- Add tests covering successful bonding, flaky bonding that still results in a bonded device, failed bonding with no bond, and cancellation during bonding to validate the new connection gating behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adjusts the BLE radio connection flow so a GATT connection is not attempted when bonding fails and the device is still unbonded. It also preserves coroutine cancellation semantics during bonding (so `CancellationException` stops the connection attempt immediately), while allowing “flaky/late bonding” cases to continue if the device becomes bonded after the initial bond call fails.

### Key changes
- **Fixes**
  - `BleRadioTransport.attemptConnection()` now stops and prevents GATT setup when `bond()` throws and `bluetoothRepository.isBonded(address)` is still false.
  - If bonding fails while the device is still unbonded, the transport now fails with `RadioNotConnectedException("Bonding failed and device is still not bonded", cause)` so reconnect/backoff logic can react earlier.
  - `RadioNotConnectedException` now supports exception chaining via an optional `cause`, improving observability of the underlying bonding failure.
  - `AndroidScannerViewModel` updates bonding/arming behavior:
    - Successful bonding arms the transport for connection retry.
    - Generic bond failures arm the transport only if `isBonded(...)` is already true; otherwise it surfaces `bonding_failed_retry` and does not arm.
    - `CancellationException` during bonding propagates without arming the transport and without setting the retry error.

- **Refactors**
  - Extracted “bond before connect” logic into a helper (`bondDeviceBeforeConnect(device)`) to centralize the post-failure bond-state re-check and simplify branching in `attemptConnection()`.

- **Features / Test & tooling support**
  - **Test support**
    - `FakeBluetoothRepository` adds `BondOutcome.FailAfterBond(error)` to model “bond call throws, but the device still ends up bonded” by recording the bond before throwing.
    - Added/expanded BLE transport tests covering:
      - bond success → `connectAndAwait` happens
      - bond throws but ends up bonded → `connectAndAwait` still happens
      - bond throws and remains unbonded → no `connectAndAwait`
      - `CancellationException` during bond → cancellation propagates and bypasses reconnect logic
    - Updated Android scanner view model bonding tests to reflect the new arming/error-message rules.
  - **UI strings**
    - Added `bonding_failed_retry` string resource and corresponding localized entry for user-facing messaging.

### Breaking changes / migration
- `RadioNotConnectedException` constructor now accepts an optional `cause: Throwable? = null`. Existing usages with only a message (or default parameters) should continue to compile and behave the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->