### PR TITLE
BluetoothRepository tolerates brief BOND_NONE after createBond

### DIFF
--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -289,6 +289,7 @@ class AndroidBluetoothRepositoryBondTest {
             val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
             val failure = launchBond(repo, mac)
+            deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
             advanceTimeBy(499L)
             assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
             advanceTimeBy(2L)

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -281,11 +281,7 @@ class AndroidBluetoothRepositoryBondTest {
             val mac = "AA:BB:CC:DD:EE:0E"
             RobolectricBleBonding.grantBluetoothConnectPermission()
             val deviceShadow =
-                RobolectricBleBonding.primeBond(
-                    mac,
-                    bondState = BluetoothDevice.BOND_NONE,
-                    createBondReturns = true,
-                )
+                RobolectricBleBonding.primeBond(mac, bondState = BluetoothDevice.BOND_NONE, createBondReturns = true)
             val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
             val failure = launchBond(repo, mac)

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -168,7 +168,7 @@ class AndroidBluetoothRepositoryBondTest {
             previousState = BluetoothDevice.BOND_BONDING,
         )
 
-        assertEquals("Bonding failed or rejected", failure.await()?.message)
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
     }
 
     @Test
@@ -272,7 +272,7 @@ class AndroidBluetoothRepositoryBondTest {
         deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
         advanceTimeBy(2L)
 
-        assertEquals("Bonding failed or rejected", failure.await()?.message)
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
     }
 
     @Test
@@ -285,11 +285,14 @@ class AndroidBluetoothRepositoryBondTest {
             val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
             val failure = launchBond(repo, mac)
+            // Robolectric synchronously marks createBond() as BONDED here; reset it to model
+            // Android's async BOND_NONE -> BOND_BONDING transition.
             deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
             advanceTimeBy(499L)
             assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
             advanceTimeBy(2L)
-            assertFalse(failure.isCompleted, "a newly initiated bond gets one poll before BOND_NONE is terminal")
+            assertFalse(failure.isCompleted, "a newly initiated bond should tolerate initial BOND_NONE")
+            // The same wait must still recover if Android later reports BONDING and then BONDED.
             deviceShadow.setBondState(BluetoothDevice.BOND_BONDING)
             advanceTimeBy(500L)
             assertFalse(failure.isCompleted, "BOND_BONDING should keep the bond wait active")
@@ -298,6 +301,79 @@ class AndroidBluetoothRepositoryBondTest {
 
             assertNull(failure.await(), "bond() should complete once Android reports BOND_BONDED")
         }
+
+    @Test
+    fun `createBond true fails on the BOND_NONE poll after grace is exhausted`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:0F"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(mac, bondState = BluetoothDevice.BOND_NONE, createBondReturns = true)
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        // Robolectric synchronously marks createBond() as BONDED here; reset it to model
+        // Android's async BOND_NONE -> BOND_BONDING transition.
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(499L)
+        assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
+        advanceTimeBy(2L)
+        assertFalse(failure.isCompleted, "the first BOND_NONE poll should still be within the grace")
+        advanceTimeBy(500L)
+        assertFalse(failure.isCompleted, "the second BOND_NONE poll should consume the grace")
+        advanceTimeBy(500L)
+
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
+    }
+
+    @Test
+    fun `createBond true fails when polled bonding later returns none`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:10"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(mac, bondState = BluetoothDevice.BOND_NONE, createBondReturns = true)
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        // Robolectric synchronously marks createBond() as BONDED here; reset it to model
+        // Android's async BOND_NONE -> BOND_BONDING transition.
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(501L)
+        assertFalse(failure.isCompleted, "initial BOND_NONE should not fail before bonding is observed")
+        // Covers the missed failure broadcast after polling observes BOND_BONDING. The createBond=false
+        // BOND_BONDING test pins the already-in-flight start path.
+        deviceShadow.setBondState(BluetoothDevice.BOND_BONDING)
+        advanceTimeBy(500L)
+        assertFalse(failure.isCompleted, "polled BOND_BONDING should keep the bond wait active")
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(500L)
+
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
+    }
+
+    @Test
+    fun `spurious none broadcast is ignored but later polled none fails`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:11"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(
+                mac,
+                bondState = BluetoothDevice.BOND_BONDING,
+                createBondReturns = false,
+            )
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        RobolectricBleBonding.sendBondStateChanged(
+            mac,
+            newState = BluetoothDevice.BOND_NONE,
+            previousState = BluetoothDevice.BOND_NONE,
+        )
+        assertFalse(failure.isCompleted, "a spurious BOND_NONE broadcast must not resolve the bond")
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(500L)
+
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
+    }
 
     @Test
     fun `bond succeeds when bond state becomes bonded at timeout boundary`() = runTest(UnconfinedTestDispatcher()) {

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -255,6 +255,54 @@ class AndroidBluetoothRepositoryBondTest {
         }
 
     @Test
+    fun `bond fails early when bond state returns none without broadcast`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:0D"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(
+                mac,
+                bondState = BluetoothDevice.BOND_BONDING,
+                createBondReturns = false,
+            )
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        advanceTimeBy(499L)
+        assertFalse(failure.isCompleted, "bond() should still be waiting before the poll interval")
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(2L)
+
+        assertEquals("Bonding failed or rejected", failure.await()?.message)
+    }
+
+    @Test
+    fun `createBond true does not fail immediately while bond state is initially none`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val mac = "AA:BB:CC:DD:EE:0E"
+            RobolectricBleBonding.grantBluetoothConnectPermission()
+            val deviceShadow =
+                RobolectricBleBonding.primeBond(
+                    mac,
+                    bondState = BluetoothDevice.BOND_NONE,
+                    createBondReturns = true,
+                )
+            val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+            val failure = launchBond(repo, mac)
+            advanceTimeBy(499L)
+            assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
+            advanceTimeBy(2L)
+            assertFalse(failure.isCompleted, "a newly initiated bond gets one poll before BOND_NONE is terminal")
+            deviceShadow.setBondState(BluetoothDevice.BOND_BONDING)
+            advanceTimeBy(500L)
+            assertFalse(failure.isCompleted, "BOND_BONDING should keep the bond wait active")
+            deviceShadow.setBondState(BluetoothDevice.BOND_BONDED)
+            advanceTimeBy(500L)
+
+            assertNull(failure.await(), "bond() should complete once Android reports BOND_BONDED")
+        }
+
+    @Test
     fun `bond succeeds when bond state becomes bonded at timeout boundary`() = runTest(UnconfinedTestDispatcher()) {
         val mac = "AA:BB:CC:DD:EE:0C"
         RobolectricBleBonding.grantBluetoothConnectPermission()

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -41,6 +41,7 @@ import kotlin.time.Duration.Companion.seconds
 
 private val BOND_TIMEOUT = 30.seconds
 private val BOND_STATE_POLL_INTERVAL = 500.milliseconds
+private const val CREATED_BOND_NONE_GRACE_POLLS = 1
 
 /** Android implementation of [BluetoothRepository]. */
 @Single
@@ -103,8 +104,8 @@ class AndroidBluetoothRepository(
                     ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
 
                     try {
-                        startOrObserveBond(remoteDevice, result)
-                        awaitBondResult(remoteDevice, result)
+                        val start = startOrObserveBond(remoteDevice, result)
+                        awaitBondResult(remoteDevice, result, start)
                     } finally {
                         unregisterBondReceiver(receiver)
                     }
@@ -122,44 +123,78 @@ class AndroidBluetoothRepository(
 
     @Suppress("TooGenericExceptionCaught")
     @SuppressLint("MissingPermission")
-    private fun startOrObserveBond(remoteDevice: android.bluetooth.BluetoothDevice, result: CompletableDeferred<Unit>) {
+    private fun startOrObserveBond(
+        remoteDevice: android.bluetooth.BluetoothDevice,
+        result: CompletableDeferred<Unit>,
+    ): BondWaitStart {
+        var start = BondWaitStart()
         try {
-            if (result.isCompleted) return
-
-            if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                result.complete(Unit)
-            } else if (!remoteDevice.createBond()) {
-                // createBond() returns false when a bond is already in flight, triggered by a GATT
-                // operation hitting a secured characteristic, or already established.
-                // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
-                // re-check bondState directly rather than failing the whole flow.
-                when (remoteDevice.bondState) {
-                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
-                        result.complete(Unit)
-                    }
-
-                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
-                        // Bond already in progress; leave the receiver registered to resolve it on
-                        // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
-                        // as a failure.
-                        Logger.d { "createBond() returned false but bonding is already in progress" }
-                    }
-
-                    else -> {
-                        result.completeExceptionally(Exception("Failed to initiate bonding"))
-                    }
+            if (!result.isCompleted) {
+                if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                    result.complete(Unit)
+                } else if (remoteDevice.createBond()) {
+                    start = BondWaitStart(createdBond = true)
+                } else {
+                    start = observeExistingBond(remoteDevice, result)
                 }
             }
         } catch (e: Exception) {
             result.completeExceptionally(e)
         }
+        return start
     }
+
+    @SuppressLint("MissingPermission")
+    private fun observeExistingBond(
+        remoteDevice: android.bluetooth.BluetoothDevice,
+        result: CompletableDeferred<Unit>,
+    ): BondWaitStart {
+        // createBond() returns false when a bond is already in flight, triggered by a GATT
+        // operation hitting a secured characteristic, or already established.
+        // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
+        // re-check bondState directly rather than failing the whole flow.
+        return when (remoteDevice.bondState) {
+            android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                result.complete(Unit)
+                BondWaitStart()
+            }
+
+            android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                // Bond already in progress; leave the receiver registered to resolve it on
+                // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
+                // as a failure.
+                Logger.d { "createBond() returned false but bonding is already in progress" }
+                BondWaitStart(bondingObserved = true)
+            }
+
+            else -> {
+                result.completeExceptionally(Exception("Failed to initiate bonding"))
+                BondWaitStart()
+            }
+        }
+    }
+
+    private data class BondWaitStart(
+        val bondingObserved: Boolean = false,
+        val createdBond: Boolean = false,
+    )
 
     @SuppressLint("MissingPermission")
     private suspend fun awaitBondResult(
         remoteDevice: android.bluetooth.BluetoothDevice,
         result: CompletableDeferred<Unit>,
+        start: BondWaitStart,
     ) {
+        var bondingWasInFlight = start.bondingObserved
+        // createBond() can return before Android reports BOND_BONDING; avoid treating
+        // that initial BOND_NONE state as a terminal failure.
+        var bondNoneGracePolls =
+            if (start.createdBond && !bondingWasInFlight) {
+                CREATED_BOND_NONE_GRACE_POLLS
+            } else {
+                0
+            }
+
         while (!result.isCompleted) {
             val completedFromReceiver =
                 withTimeoutOrNull(BOND_STATE_POLL_INTERVAL) {
@@ -167,8 +202,26 @@ class AndroidBluetoothRepository(
                     true
                 } == true
 
-            if (!completedFromReceiver && remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                result.complete(Unit)
+            if (!completedFromReceiver) {
+                when (remoteDevice.bondState) {
+                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                        result.complete(Unit)
+                    }
+
+                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                        bondingWasInFlight = true
+                        bondNoneGracePolls = 0
+                    }
+
+                    android.bluetooth.BluetoothDevice.BOND_NONE -> {
+                        if (bondingWasInFlight) {
+                            result.completeExceptionally(Exception("Bonding failed or rejected"))
+                        } else if (bondNoneGracePolls > 0) {
+                            bondNoneGracePolls--
+                            bondingWasInFlight = bondNoneGracePolls == 0
+                        }
+                    }
+                }
             }
         }
         result.await()

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -135,7 +135,27 @@ class AndroidBluetoothRepository(
                 } else if (remoteDevice.createBond()) {
                     start = BondWaitStart(createdBond = true)
                 } else {
-                    start = observeExistingBond(remoteDevice, result)
+                    // createBond() returns false when a bond is already in flight, triggered by a GATT
+                    // operation hitting a secured characteristic, or already established.
+                    // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
+                    // re-check bondState directly rather than failing the whole flow.
+                    when (remoteDevice.bondState) {
+                        android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                            result.complete(Unit)
+                        }
+
+                        android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                            // Bond already in progress; leave the receiver registered to resolve it on
+                            // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
+                            // as a failure.
+                            Logger.d { "createBond() returned false but bonding is already in progress" }
+                            start = BondWaitStart(bondingObserved = true)
+                        }
+
+                        else -> {
+                            result.completeExceptionally(Exception("Failed to initiate bonding"))
+                        }
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -144,40 +164,7 @@ class AndroidBluetoothRepository(
         return start
     }
 
-    @SuppressLint("MissingPermission")
-    private fun observeExistingBond(
-        remoteDevice: android.bluetooth.BluetoothDevice,
-        result: CompletableDeferred<Unit>,
-    ): BondWaitStart {
-        // createBond() returns false when a bond is already in flight, triggered by a GATT
-        // operation hitting a secured characteristic, or already established.
-        // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
-        // re-check bondState directly rather than failing the whole flow.
-        return when (remoteDevice.bondState) {
-            android.bluetooth.BluetoothDevice.BOND_BONDED -> {
-                result.complete(Unit)
-                BondWaitStart()
-            }
-
-            android.bluetooth.BluetoothDevice.BOND_BONDING -> {
-                // Bond already in progress; leave the receiver registered to resolve it on
-                // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
-                // as a failure.
-                Logger.d { "createBond() returned false but bonding is already in progress" }
-                BondWaitStart(bondingObserved = true)
-            }
-
-            else -> {
-                result.completeExceptionally(Exception("Failed to initiate bonding"))
-                BondWaitStart()
-            }
-        }
-    }
-
-    private data class BondWaitStart(
-        val bondingObserved: Boolean = false,
-        val createdBond: Boolean = false,
-    )
+    private data class BondWaitStart(val bondingObserved: Boolean = false, val createdBond: Boolean = false)
 
     @SuppressLint("MissingPermission")
     private suspend fun awaitBondResult(

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -36,12 +36,17 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.di.CoroutineDispatchers
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private val BOND_TIMEOUT = 30.seconds
 private val BOND_STATE_POLL_INTERVAL = 500.milliseconds
-private const val CREATED_BOND_NONE_GRACE_POLLS = 1
+
+// Fixed two-poll grace for slow BOND_NONE -> BOND_BONDING transitions after createBond() returns true.
+// Tune this or track observed transition latency if a specific OEM needs a longer window.
+private val CREATED_BOND_NONE_GRACE = BOND_STATE_POLL_INTERVAL + BOND_STATE_POLL_INTERVAL
+internal const val BOND_FAILED_OR_REJECTED_MESSAGE = "Bonding failed or rejected"
 
 /** Android implementation of [BluetoothRepository]. */
 @Single
@@ -173,13 +178,13 @@ class AndroidBluetoothRepository(
         start: BondWaitStart,
     ) {
         var bondingWasInFlight = start.bondingObserved
-        // createBond() can return before Android reports BOND_BONDING; avoid treating
-        // that initial BOND_NONE state as a terminal failure.
-        var bondNoneGracePolls =
-            if (start.createdBond && !bondingWasInFlight) {
-                CREATED_BOND_NONE_GRACE_POLLS
+        // createBond() can return true before Android reports BOND_BONDING. Tolerate two polled
+        // BOND_NONE samples (polls 1-2), then fail on the third persistent BOND_NONE.
+        var createdBondNoneGraceRemaining =
+            if (start.createdBond) {
+                CREATED_BOND_NONE_GRACE
             } else {
-                0
+                Duration.ZERO
             }
 
         while (!result.isCompleted) {
@@ -196,16 +201,32 @@ class AndroidBluetoothRepository(
                     }
 
                     android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                        // Once polling observes BOND_BONDING, a later BOND_NONE is terminal. Keep this
+                        // defensive for any path that observes in-flight bonding outside the start state.
                         bondingWasInFlight = true
-                        bondNoneGracePolls = 0
+                        createdBondNoneGraceRemaining = Duration.ZERO
                     }
 
                     android.bluetooth.BluetoothDevice.BOND_NONE -> {
-                        if (bondingWasInFlight) {
-                            result.completeExceptionally(Exception("Bonding failed or rejected"))
-                        } else if (bondNoneGracePolls > 0) {
-                            bondNoneGracePolls--
-                            bondingWasInFlight = bondNoneGracePolls == 0
+                        // Invariant: if start.createdBond is false, startOrObserveBond either completed
+                        // result or observed BOND_BONDING, which is represented by bondingWasInFlight.
+                        val pollFailureDetails =
+                            "bond poll failed: bondingWasInFlight=$bondingWasInFlight " +
+                                "createdBond=${start.createdBond} graceRemaining=$createdBondNoneGraceRemaining"
+                        when {
+                            bondingWasInFlight -> {
+                                Logger.d { pollFailureDetails }
+                                result.completeExceptionally(Exception(BOND_FAILED_OR_REJECTED_MESSAGE))
+                            }
+
+                            createdBondNoneGraceRemaining > Duration.ZERO -> {
+                                createdBondNoneGraceRemaining -= BOND_STATE_POLL_INTERVAL
+                            }
+
+                            start.createdBond -> {
+                                Logger.d { pollFailureDetails }
+                                result.completeExceptionally(Exception(BOND_FAILED_OR_REJECTED_MESSAGE))
+                            }
                         }
                     }
                 }
@@ -246,7 +267,7 @@ class AndroidBluetoothRepository(
                 state == android.bluetooth.BluetoothDevice.BOND_NONE &&
                 prevState == android.bluetooth.BluetoothDevice.BOND_BONDING
             ) {
-                result.completeExceptionally(Exception("Bonding failed or rejected"))
+                result.completeExceptionally(Exception(BOND_FAILED_OR_REJECTED_MESSAGE))
             }
         }
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change improves Android BLE bonding reliability by making `AndroidBluetoothRepository.bond()` tolerate brief `BOND_NONE` immediately after a successful `createBond()`, while still failing when bonding never transitions as expected (especially without an in-flight `BOND_BONDING` indication or after a bounded grace window).

- **Fixes**
  - Added a bounded grace window (`CREATED_BOND_NONE_GRACE`, two poll intervals) so that when `createBond()` returns `true` but `bondState` remains `BOND_NONE`, the bond wait won’t fail immediately; it only fails if `BOND_NONE` persists after the grace is exhausted.
  - Ensures `BOND_NONE` causes failure when it indicates rejection (e.g., `BOND_NONE` encountered while bonding was already observed/in-flight via `BOND_BONDING`), using the shared `BOND_FAILED_OR_REJECTED_MESSAGE`.
  - Ignores spurious `ACTION_BOND_STATE_CHANGED` broadcasts where `BOND_NONE` doesn’t come from the expected `BOND_BONDING -> BOND_NONE` transition, relying on polling/receiver completion for the final outcome.
  - Keeps the bonding receiver flow robust for cases like `createBond()` returning `false` while the device is already `BOND_BONDING` (waits for a later `BOND_BONDED` broadcast instead of failing outright).

- **Refactors**
  - Threaded bonding “start context” through the suspend flow by returning a `BondWaitStart` from `startOrObserveBond(...)` and passing it into `awaitBondResult(...)`, so polling/failure decisions consistently interpret whether bonding was just created vs already in-flight.

- **Tests**
  - Expanded Robolectric + coroutine tests in `AndroidBluetoothRepositoryBondTest` to cover:
    - waiting/resuming behavior when `createBond()` returns `false` but the device is `BOND_BONDING`,
    - early rejection with `BOND_NONE` when `createBond()` returns `false` and there was no in-flight bond,
    - successful bond resolution when `createBond()` returns `true`,
    - grace-window tolerance for initial `BOND_NONE` after `createBond()` succeeds, including failure once grace is exhausted,
    - failure when bonding later transitions to `BOND_NONE`,
    - spurious `BOND_NONE` broadcast handling (ignored, but a later polled `BOND_NONE` can still fail),
    - assertion updates to use `BOND_FAILED_OR_REJECTED_MESSAGE` for the standardized failure message.

No breaking changes or migration steps are needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->