### PR TITLE
Use authoritative channel replacement list for QR imports

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
@@ -20,10 +20,9 @@ import androidx.lifecycle.ViewModel
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
-import org.meshtastic.core.ui.util.getChannelList
+import org.meshtastic.core.ui.util.applyReplacementChannelSet
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
-import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.LocalConfig
@@ -40,17 +39,12 @@ class ScannedQrCodeViewModel(
 
     /** Set the radio config (also updates our saved copy in preferences). */
     fun setChannels(channelSet: ChannelSet) = safeLaunch(tag = "setChannels") {
-        getChannelList(channelSet.settings, channels.value.settings).forEach(::setChannel)
-        radioConfigRepository.replaceAllSettings(channelSet.settings)
+        applyReplacementChannelSet(channelSet, radioController, radioConfigRepository)
 
         val loraConfig = channelSet.lora_config
         if (loraConfig != null && localConfig.value.lora != loraConfig) {
             setConfig(Config(lora = loraConfig))
         }
-    }
-
-    private fun setChannel(channel: Channel) {
-        safeLaunch(tag = "setChannel") { radioController.setLocalChannel(channel) }
     }
 
     // Set the radio config (also updates our saved copy in preferences)

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -17,12 +17,16 @@
 package org.meshtastic.core.ui.util
 
 import androidx.compose.runtime.Composable
+import kotlinx.coroutines.flow.first
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.DateFormatter
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.repository.RadioConfigRepository
+import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.unknown_age
 import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.Position
@@ -78,4 +82,75 @@ fun getChannelList(new: List<ChannelSettings>, old: List<ChannelSettings>): List
             )
         }
     }
+}
+
+/**
+ * Builds an authoritative [Channel] list for a full REPLACE import. Every position in [new] is emitted (PRIMARY at
+ * index 0, SECONDARY for 1..new.lastIndex) and any trailing positions beyond [new]'s range are emitted as DISABLED so
+ * the radio stops using them.
+ *
+ * Unlike [getChannelList], this does NOT skip positions where `currentSettings[i] == new[i]`: the imported set is
+ * authoritative, the local cache must not gate the writes, and silent diff-skips during REPLACE were the source of
+ * stale channels.
+ *
+ * [currentSettings] is consulted only for its size (to determine trailing DISABLED writes); its values are never
+ * compared against [new]. Callers should read it from `radioConfigRepository.channelSetFlow.first().settings`, not from
+ * a `stateInWhileSubscribed` StateFlow's `.value` — the StateFlow placeholder window can return an empty list and
+ * suppress trailing DISABLED writes.
+ *
+ * Edge case: if [new] is empty, every emitted slot (including index 0) is DISABLED rather than wrongly promoting an
+ * empty [ChannelSettings] to PRIMARY.
+ *
+ * @param new The imported [ChannelSettings] list. Every index becomes a write to the radio.
+ * @param currentSettings The current [ChannelSettings] list. Only its size is used; trailing indices past [new] become
+ *   DISABLED writes so leftover slots are cleared.
+ * @return A [Channel] list covering every slot the radio needs written to materialize [new] and clear leftover slots.
+ */
+fun getChannelReplacementList(new: List<ChannelSettings>, currentSettings: List<ChannelSettings>): List<Channel> =
+    buildList {
+        for (i in 0..maxOf(currentSettings.lastIndex, new.lastIndex)) {
+            add(
+                Channel(
+                    role =
+                    when (i) {
+                        // Empty-new is a degenerate import: every slot (including 0) must be DISABLED.
+                        0 -> if (new.isEmpty()) Channel.Role.DISABLED else Channel.Role.PRIMARY
+
+                        in 1..new.lastIndex -> Channel.Role.SECONDARY
+
+                        else -> Channel.Role.DISABLED
+                    },
+                    index = i,
+                    settings = new.getOrNull(i) ?: ChannelSettings(),
+                ),
+            )
+        }
+    }
+
+/**
+ * Applies an imported [ChannelSet] as an authoritative replacement to the radio and local cache.
+ *
+ * Reads the current channel set from [radioConfigRepository]'s flow (avoiding the StateFlow placeholder window), builds
+ * the authoritative replacement list via [getChannelReplacementList], enqueues each channel write to the radio
+ * sequentially via [radioController], then atomically replaces the local cached settings.
+ *
+ * setLocalChannel returns once the packet is enqueued, not after firmware ACK — firmware echoes via
+ * MeshConfigHandlerImpl can still arrive after [radioConfigRepository.replaceAllSettings] and are tracked separately.
+ *
+ * Does NOT handle LoRa config — callers are responsible for comparing and sending `lora_config` if present.
+ *
+ * @param channelSet The imported [ChannelSet] to apply as a replacement.
+ * @param radioController The [RadioController] used to enqueue channel writes.
+ * @param radioConfigRepository The [RadioConfigRepository] providing the current channel flow and cache.
+ */
+suspend fun applyReplacementChannelSet(
+    channelSet: ChannelSet,
+    radioController: RadioController,
+    radioConfigRepository: RadioConfigRepository,
+) {
+    val currentSettings = radioConfigRepository.channelSetFlow.first().settings
+    for (channel in getChannelReplacementList(channelSet.settings, currentSettings)) {
+        radioController.setLocalChannel(channel)
+    }
+    radioConfigRepository.replaceAllSettings(channelSet.settings)
 }

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.util
+
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [getChannelReplacementList]. The REPLACE helper must emit an authoritative slot list for QR imports:
+ * every imported index becomes a write (PRIMARY at 0, SECONDARY thereafter), and any trailing slots present in the
+ * cached set are emitted as DISABLED so the radio stops using them. Critically, positions where the cache already
+ * matches the import are NOT skipped — the diff-skip was the source of stale channels.
+ */
+class ProtoExtensionsTest {
+    @Test
+    fun index_zero_emits_primary_with_new_settings_even_when_unchanged_from_old() {
+        val same = ChannelSettings(name = "Main", psk = byteArrayOf(1, 2, 3).toByteString())
+
+        val result = getChannelReplacementList(new = listOf(same), currentSettings = listOf(same))
+
+        assertEquals(1, result.size)
+        assertEquals(Channel.Role.PRIMARY, result.single().role)
+        assertEquals(0, result.single().index)
+        assertEquals(same, result.single().settings)
+    }
+
+    @Test
+    fun secondary_indices_emit_secondary_with_new_settings_even_when_unchanged_from_old() {
+        val primary = ChannelSettings(name = "Main")
+        val secondary = ChannelSettings(name = "Chat")
+
+        val result =
+            getChannelReplacementList(new = listOf(primary, secondary), currentSettings = listOf(primary, secondary))
+
+        assertEquals(2, result.size)
+        assertEquals(Channel.Role.PRIMARY, result[0].role)
+        assertEquals(primary, result[0].settings)
+        assertEquals(Channel.Role.SECONDARY, result[1].role)
+        assertEquals(1, result[1].index)
+        assertEquals(secondary, result[1].settings)
+    }
+
+    @Test
+    fun old_trailing_indices_beyond_new_are_emitted_as_disabled_with_empty_settings() {
+        val primary = ChannelSettings(name = "Main")
+
+        val result =
+            getChannelReplacementList(
+                new = listOf(primary),
+                currentSettings = listOf(primary, ChannelSettings(name = "Old")),
+            )
+
+        // index 0 PRIMARY (new), index 1 DISABLED (trailing old slot)
+        assertEquals(2, result.size)
+        assertEquals(Channel.Role.PRIMARY, result[0].role)
+        assertEquals(primary, result[0].settings)
+        assertEquals(Channel.Role.DISABLED, result[1].role)
+        assertEquals(1, result[1].index)
+        assertEquals(ChannelSettings(), result[1].settings)
+    }
+
+    @Test
+    fun empty_new_and_empty_old_produces_empty_list() {
+        val result = getChannelReplacementList(new = emptyList(), currentSettings = emptyList())
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun empty_new_with_non_empty_current_emits_disabled_for_every_current_index() {
+        val currentSettings =
+            listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"), ChannelSettings(name = "C"))
+
+        val result = getChannelReplacementList(new = emptyList(), currentSettings = currentSettings)
+
+        assertEquals(3, result.size)
+        result.forEachIndexed { i, channel ->
+            assertEquals(Channel.Role.DISABLED, channel.role, "index $i should be DISABLED")
+            assertEquals(i, channel.index)
+            assertEquals(ChannelSettings(), channel.settings, "index $i should carry empty settings")
+        }
+    }
+
+    @Test
+    fun single_entry_new_with_multi_entry_current_emits_primary_then_disabled_trailing() {
+        val newPrimary = ChannelSettings(name = "Imported")
+        val currentSettings =
+            listOf(
+                ChannelSettings(name = "CurrentPrimary"),
+                ChannelSettings(name = "CurrentSecondary"),
+                ChannelSettings(name = "CurrentTertiary"),
+            )
+
+        val result = getChannelReplacementList(new = listOf(newPrimary), currentSettings = currentSettings)
+
+        assertEquals(3, result.size)
+        assertEquals(Channel.Role.PRIMARY, result[0].role)
+        assertEquals(0, result[0].index)
+        assertEquals(newPrimary, result[0].settings)
+        assertEquals(Channel.Role.DISABLED, result[1].role)
+        assertEquals(Channel.Role.DISABLED, result[2].role)
+        assertEquals(ChannelSettings(), result[1].settings)
+        assertEquals(ChannelSettings(), result[2].settings)
+    }
+
+    @Test
+    fun new_larger_than_old_emits_primary_plus_secondaries_for_every_new_index() {
+        val primary = ChannelSettings(name = "Main")
+        val secondaryA = ChannelSettings(name = "Chat")
+        val secondaryB = ChannelSettings(name = "Data")
+
+        val result =
+            getChannelReplacementList(new = listOf(primary, secondaryA, secondaryB), currentSettings = listOf(primary))
+
+        assertEquals(3, result.size)
+        assertEquals(Channel.Role.PRIMARY, result[0].role)
+        assertEquals(0, result[0].index)
+        assertEquals(primary, result[0].settings)
+        assertEquals(Channel.Role.SECONDARY, result[1].role)
+        assertEquals(1, result[1].index)
+        assertEquals(secondaryA, result[1].settings)
+        assertEquals(Channel.Role.SECONDARY, result[2].role)
+        assertEquals(2, result[2].index)
+        assertEquals(secondaryB, result[2].settings)
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/channel/ChannelViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/channel/ChannelViewModel.kt
@@ -27,10 +27,9 @@ import org.meshtastic.core.repository.DataPair
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
-import org.meshtastic.core.ui.util.getChannelList
+import org.meshtastic.core.ui.util.applyReplacementChannelSet
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
-import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.LocalConfig
@@ -86,17 +85,12 @@ class ChannelViewModel(
 
     /** Set the radio config (also updates our saved copy in preferences). */
     fun setChannels(channelSet: ChannelSet) = safeLaunch(tag = "setChannels") {
-        getChannelList(channelSet.settings, channels.value.settings).forEach(::setChannel)
-        radioConfigRepository.replaceAllSettings(channelSet.settings)
+        applyReplacementChannelSet(channelSet, radioController, radioConfigRepository)
 
         val newLoraConfig = channelSet.lora_config
         if (localConfig.value.lora != newLoraConfig) {
             setConfig(Config(lora = newLoraConfig))
         }
-    }
-
-    fun setChannel(channel: Channel) {
-        safeLaunch(tag = "setChannel") { radioController.setLocalChannel(channel) }
     }
 
     // Set the radio config (also updates our saved copy in preferences)


### PR DESCRIPTION
QR channel replacement imports previously launched each per-channel firmware write as a separate fire-and-forget safeLaunch coroutine, then immediately replaced the local cached ChannelSet. Two consequences made the import path non-deterministic:

1. N concurrent safeLaunch coroutines acquired the radio transport's queue mutex in scheduling-determined order, not iteration order, so the firmware received set_channel admin packets in an unpredictable sequence.
2. replaceAllSettings() ran before any of those in-flight writes were known to have been enqueued, let alone processed by the firmware, so the optimistic local cache was contestable by both the late- arriving per-channel cache updates inside AdminControllerImpl .setLocalChannel and by the asynchronous firmware channel-response echoes that arrive via MeshConfigHandlerImpl.handleChannel.

This change makes the REPLACE import path deterministic in two ways.

First, the per-channel writes are now issued from a sequential awaited for-loop inside the outer safeLaunch, so each radioController .getLocalChannel() completes (at the enqueue layer) before the next channel is sent. setLocalChannel is genuinely suspend, so the loop serializes the dispatch.

Second, the imported ChannelSet is treated as authoritative: every slot in the imported list is emitted as a write to the radio, with trailing slots beyond the imported range emitted as DISABLED so the radio stops using them. The local cache is no longer used as a diff authority that can suppress a needed write. This eliminates the silent diff-skip that previously left stale firmware slots intact when the cache happened to already match the imported value.

A new helper getChannelReplacementList(new, old) is added to ProtoExtensions.kt alongside the existing getChannelList (which is preserved unchanged for its existing caller on the manual channel edit path in RadioConfigViewModel.updateChannels). The helper:

  - emits Channel.Role.PRIMARY for index 0 of the imported set
  - emits Channel.Role.SECONDARY for indices 1..new.lastIndex
  - emits Channel.Role.DISABLED with empty ChannelSettings for any trailing slots present in the current set but beyond the imported range, so the radio clears them
  - special-cases empty-new (degenerate import) so every old slot including index 0 becomes DISABLED, rather than wrongly promoting an empty settings to PRIMARY
  - never skips positions where old[i] == new[i]; the imported set is authoritative

Both ScannedQrCodeViewModel.setChannels (the QR scan and channel URL share-link entry point) and ChannelViewModel.setChannels (the channel-settings-screen entry point) are converted to the sequential awaited for-loop and the new helper.

In ScannedQrCodeViewModel, the now-unused private setChannel helper is removed and the orphaned import of org.meshtastic.proto.Channel is dropped. In ChannelViewModel, the public setChannel(channel) function is retained because it remains part of the public API even though no statically-discoverable caller remains in this repository.

Seven unit tests are added under core:ui commonTest covering every behavioral branch of the helper:

  - index 0 emits PRIMARY with the new settings even when old[0] equals new[0] (verifies no diff-skip)
  - secondary indices emit SECONDARY with the new settings even when unchanged from old
  - old trailing indices beyond new.lastIndex are emitted as DISABLED with empty ChannelSettings
  - empty new and empty old produces an empty list (degenerate case)
  - empty new with non-empty old emits DISABLED for every old slot including index 0
  - single-entry new with multi-entry old emits PRIMARY at 0 followed by DISABLED trailing slots
  - new larger than old emits PRIMARY plus one SECONDARY per added index (the most common real REPLACE pattern)

Out of scope for this change:

  - MeshConfigHandlerImpl.handleChannel unconditionally overwrites the local cache from firmware-reported channel state. Firmware echoes can therefore still arrive after replaceAllSettings and re-corrupt the cache. The inline comments in both viewmodels document this residual racer; it is tracked separately.
  - QR ADD-mode merge uses structural .distinct() over ChannelSettings which can collapse equal entries and shift later channels. Also tracked separately.
  - ChannelSet PRIMARY-reordering to position 0 (spec compliance) is a separate concern.
  - The sibling RadioConfigViewModel.updateChannels path still uses the original getChannelList and per-channel safeLaunch pattern. It is the manual single-channel edit path and is unchanged here.

## Summary by Sourcery

Make QR-based channel REPLACE imports deterministic and authoritative over radio channel slots.

New Features:
- Introduce getChannelReplacementList helper to build an authoritative Channel list for full QR REPLACE imports, including disabling trailing slots no longer present in the imported set.

Enhancements:
- Change ScannedQrCodeViewModel and ChannelViewModel channel REPLACE paths to sequentially enqueue per-channel writes using the authoritative replacement list before updating the local cache.
- Read current channel settings from RadioConfigRepository flows instead of the channels StateFlow to ensure trailing DISABLED slots are correctly emitted during replacement.

Tests:
- Add ProtoExtensionsTest suite covering all behavioral branches of getChannelReplacementList, including primary/secondary role assignment, trailing DISABLED slots, empty imports, and size mismatches between new and old channel sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves QR “REPLACE” channel imports by making channel writes deterministic and by treating the imported `ChannelSet` as the authoritative source for the full radio channel table (including clearing any leftover channels when the imported list is shorter). It also centralizes the replacement-write generation and application logic, and adds unit tests to lock in the expected slot-by-slot behavior.

- **Fixes**
  - Fix REPLACE-mode QR channel import ordering by switching from per-channel fire-and-forget writes to a sequential, awaited loop so dispatch/enqueue order is preserved.
  - Ensure trailing existing channel slots are cleared by emitting explicit `DISABLED` entries when the imported list is shorter than the current settings.
  - Keep LоRa config handling consistent: after applying the replacement channel set, conditionally update `lora` config only when it differs from the cached local config.

- **Features**
  - Add `getChannelReplacementList(new, old)` to generate a complete, authoritative `List<Channel>` for REPLACE writes (PRIMARY at index `0`, SECONDARY for indices within the imported range, DISABLED for trailing indices beyond the imported range).
  - Add `applyReplacementChannelSet(channelSet, radioController, radioConfigRepository)` to fetch current settings, perform the ordered channel writes, and then update the local cache via `replaceAllSettings(...)`.

- **Refactors**
  - Update both `ScannedQrCodeViewModel.setChannels` and `ChannelViewModel.setChannels` to use the new replacement path (`applyReplacementChannelSet`) instead of iterating/chaining channel writes inline.
  - Remove the unused private `setChannel(Channel)` helper and an orphaned `Channel` import from `ScannedQrCodeViewModel`.
  - Preserve the manual channel-edit path by keeping the existing `getChannelList` helper.
  - Keep `ChannelViewModel.setChannel(channel)` public API intact.

- **Tests**
  - Add seven unit tests for `getChannelReplacementList`, covering unchanged values (still rewritten), empty/empty, empty-new with non-empty-current (all disabled), trailing disabled behavior, and representative length-difference scenarios.

No breaking changes or migration steps are needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->