### PR TITLE
Handle BLE scan start registration failures

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -117,6 +117,7 @@ bluetooth_feature_config_description
 bluetooth_feature_discovery
 bluetooth_feature_discovery_description
 bluetooth_permission
+bluetooth_scan_start_failed
 bold_heading
 bonding_failed_permissions
 bonding_failed_retry

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartException.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartException.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+/** Known reasons a BLE discovery scan failed before Android registered the scanner. */
+enum class BleScanStartFailureReason(val androidCode: String, val description: String) {
+    ApplicationRegistrationFailed(
+        androidCode = "SCAN_FAILED_APPLICATION_REGISTRATION_FAILED(2)",
+        description = "Android could not register the app for BLE scanning",
+    ),
+}
+
+/** A discovery scan-start failure. No advertisements can be delivered until a future scan starts successfully. */
+class BleScanStartException(val reason: BleScanStartFailureReason, cause: Throwable) :
+    IllegalStateException("BLE scan could not start: ${reason.androidCode}", cause)

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.Advertisement
 import com.juul.kable.Scanner
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collect
@@ -26,6 +27,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
 import kotlin.time.Duration
 import kotlin.uuid.Uuid
+
+private const val MAX_SCAN_START_FAILURE_CAUSE_DEPTH = 10
 
 internal sealed interface KableScanFilter {
     data object None : KableScanFilter
@@ -67,16 +70,43 @@ open class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleSca
         // By wrapping it in a channelFlow with a timeout, we enforce the BleScanner contract cleanly.
         return channelFlow {
             withTimeoutOrNull(timeout) {
-                advertisements(filter).collect { advertisement ->
-                    send(
-                        MeshtasticBleDevice(
-                            address = advertisement.identifier,
-                            name = advertisement.name,
-                            advertisement = advertisement.advertisement,
-                        ),
-                    )
+                try {
+                    advertisements(filter).collect { advertisement ->
+                        send(
+                            MeshtasticBleDevice(
+                                address = advertisement.identifier,
+                                name = advertisement.name,
+                                advertisement = advertisement.advertisement,
+                            ),
+                        )
+                    }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: IllegalStateException) {
+                    throw ex.asBleScanStartExceptionOrNull() ?: ex
                 }
             }
         }
     }
 }
+
+private fun Throwable.asBleScanStartExceptionOrNull(): BleScanStartException? {
+    var current: Throwable? = this
+    var depth = 0
+    while (current != null && depth < MAX_SCAN_START_FAILURE_CAUSE_DEPTH) {
+        if (current.isApplicationRegistrationFailure()) {
+            return BleScanStartException(BleScanStartFailureReason.ApplicationRegistrationFailed, this)
+        }
+        current = current.cause
+        depth++
+    }
+    return null
+}
+
+// Kable exposes Android scan-start registration failure as an IllegalStateException message,
+// so keep this matcher narrow and local to the scanner adapter.
+private fun Throwable.isApplicationRegistrationFailure(): Boolean = this is IllegalStateException &&
+    message?.let { failureMessage ->
+        failureMessage.contains("app cannot be registered", ignoreCase = true) ||
+            failureMessage.contains("SCAN_FAILED_APPLICATION_REGISTRATION_FAILED", ignoreCase = true)
+    } == true

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -119,6 +120,39 @@ class KableBleConnectionTest {
         scanner.scan(timeout = 1.seconds, serviceUuid = serviceUuid, address = "AA:BB:CC:DD:EE:FF").toList()
 
         assertEquals(KableScanFilter.Address("AA:BB:CC:DD:EE:FF"), scanner.lastFilter)
+    }
+
+    @Test
+    fun `scan wraps Android scanner registration failure`() = runTest {
+        val scanner =
+            TestKableBleScanner(
+                scanResults = flow { throw IllegalStateException("Failed to start scan as app cannot be registered") },
+            )
+
+        val failure = assertFailsWith<BleScanStartException> { scanner.scan(timeout = 1.seconds).toList() }
+
+        assertEquals(BleScanStartFailureReason.ApplicationRegistrationFailed, failure.reason)
+    }
+
+    @Test
+    fun `scan wraps nested scanner registration failure`() = runTest {
+        val innerCause = IllegalStateException("Failed to start scan as app cannot be registered")
+        val scanner =
+            TestKableBleScanner(scanResults = flow { throw IllegalStateException("Outer scanner failure", innerCause) })
+
+        val failure = assertFailsWith<BleScanStartException> { scanner.scan(timeout = 1.seconds).toList() }
+
+        assertEquals(BleScanStartFailureReason.ApplicationRegistrationFailed, failure.reason)
+    }
+
+    @Test
+    fun `scan preserves unrelated illegal state failure`() = runTest {
+        val scanner =
+            TestKableBleScanner(scanResults = flow { throw IllegalStateException("Unexpected scanner state") })
+
+        val failure = assertFailsWith<IllegalStateException> { scanner.scan(timeout = 1.seconds).toList() }
+
+        assertEquals("Unexpected scanner state", failure.message)
     }
 
     private class TestKableBleScanner(private val scanResults: Flow<KableScanResult>) :

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -135,6 +135,7 @@
     <string name="bluetooth_feature_discovery">Discovery</string>
     <string name="bluetooth_feature_discovery_description">Find and identify Meshtastic devices near you.</string>
     <string name="bluetooth_permission">Bluetooth</string>
+    <string name="bluetooth_scan_start_failed">Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues.</string>
     <string name="bold_heading">Bold Heading</string>
     <string name="bonding_failed_permissions">Pairing failed. Grant nearby device permissions and try again.</string>
     <string name="bonding_failed_retry">Pairing did not complete. Try pairing again.</string>

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -19,7 +19,9 @@ package org.meshtastic.feature.connections
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -34,9 +36,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import org.meshtastic.core.ble.BleDevice
+import org.meshtastic.core.ble.BleScanStartException
 import org.meshtastic.core.ble.BleScanner
 import org.meshtastic.core.ble.MeshtasticBleConstants
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.datastore.RecentAddressesDataSource
 import org.meshtastic.core.datastore.model.RecentAddress
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -49,12 +54,20 @@ import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.repository.UiPrefs
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.bluetooth_scan_start_failed
+import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.connections.model.DeviceListEntry
 import org.meshtastic.feature.connections.model.DiscoveredDevices
 import org.meshtastic.feature.connections.model.GetDiscoveredDevicesUseCase
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+internal val BLE_SCAN_START_FAILURE_RETRY_COOLDOWN = 15.seconds
+private const val BLE_SCAN_START_FAILURE_MESSAGE_FALLBACK =
+    "Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues."
 
 /**
  * Platform-neutral ViewModel that drives the Connections screen: device discovery (BLE/USB/TCP), scan state, current
@@ -107,6 +120,9 @@ open class ScannerViewModel(
     private val scannedBleDevices = MutableStateFlow<Map<String, BleDevice>>(emptyMap())
     private val discoveryOrder = MutableStateFlow<List<String>>(emptyList())
     private var scanJob: Job? = null
+    private var scanStartFailureCooldownJob: Job? = null
+    private val scanStartFailureCooldownActive = MutableStateFlow(false)
+    private var scanStartFailureCooldownGeneration = 0
 
     // Generation counter that owns the `_isBleScanning` flag's cleanup. The scan coroutine's `finally` block may run
     // asynchronously on the IO dispatcher after a stop+restart has already kicked off a new scan; without this guard
@@ -272,7 +288,7 @@ open class ScannerViewModel(
      * prior scan cannot reset the flag on this new scan's state.
      */
     fun startBleScan() {
-        if (_isBleScanning.value || bleScanner == null) return
+        if (_isBleScanning.value || bleScanner == null || scanStartFailureCooldownActive.value) return
         // Cancel the other scan first so only one flag is ever true. Both stop methods are idempotent.
         stopNetworkScan()
 
@@ -301,8 +317,13 @@ open class ScannerViewModel(
                                 discoveryOrder.update { it + device.address }
                             }
                         }
+                } catch (ex: BleScanStartException) {
+                    handleBleScanStartFailure(ex, generation)
                 } finally {
-                    if (scanGeneration.value == generation) _isBleScanning.value = false
+                    if (scanGeneration.value == generation) {
+                        _isBleScanning.value = false
+                        scanJob = null
+                    }
                 }
             }
     }
@@ -310,9 +331,6 @@ open class ScannerViewModel(
     /**
      * Starts BLE scanning for screen-entry auto-scan only when no device is already selected. Manual scan toggles call
      * [startBleScan] directly so users can still discover/switch devices while connected.
-     *
-     * This controls only Connections-screen discovery. Selected-device reconnect still performs its fresh-advertisement
-     * scan in `BleRadioTransport.findDevice` before connecting.
      */
     fun startBleAutoScan() {
         if (activeTransport.value != DeviceType.BLE) return
@@ -352,6 +370,41 @@ open class ScannerViewModel(
                 uiPrefs.setNetworkAutoScan(false)
             }
         }
+    }
+
+    private suspend fun handleBleScanStartFailure(exception: BleScanStartException, generation: Int) {
+        if (scanGeneration.value != generation) return
+
+        scanGeneration.value = generation + 1
+        scanJob = null
+        _isBleScanning.value = false
+        uiPrefs.setBleAutoScan(false)
+        startBleScanRetryCooldown()
+
+        Logger.w(exception) {
+            "BLE scan could not start: ${exception.reason.androidCode} (${exception.reason.description})"
+        }
+        val errorMessage =
+            safeCatchingAll { getStringSuspend(Res.string.bluetooth_scan_start_failed) }
+                .getOrDefault(BLE_SCAN_START_FAILURE_MESSAGE_FALLBACK)
+        serviceRepository.setErrorMessage(text = errorMessage, severity = Severity.Warn)
+    }
+
+    private fun startBleScanRetryCooldown() {
+        val generation = ++scanStartFailureCooldownGeneration
+        scanStartFailureCooldownActive.value = true
+        scanStartFailureCooldownJob?.cancel()
+        scanStartFailureCooldownJob =
+            viewModelScope.launch {
+                try {
+                    delay(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN)
+                } finally {
+                    if (scanStartFailureCooldownGeneration == generation) {
+                        scanStartFailureCooldownActive.value = false
+                        scanStartFailureCooldownJob = null
+                    }
+                }
+            }
     }
 
     /**

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -23,9 +23,13 @@ import dev.mokkery.matcher.any
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.meshtastic.core.ble.BleDevice
+import org.meshtastic.core.ble.BleScanStartException
+import org.meshtastic.core.ble.BleScanStartFailureReason
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.network.repository.DiscoveredService
@@ -103,6 +107,57 @@ class ScannerViewModelTest {
             assertEquals(false, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `scan startup failure clears scanning state disables auto-scan and surfaces error`() = runTest {
+        harness.uiPrefs.setBleAutoScan(true)
+        every { bleScanner.scan(any(), any()) } returns failingScanFlow()
+
+        viewModel.startBleScan()
+
+        assertEquals(false, viewModel.isBleScanning.value)
+        assertEquals(false, viewModel.bleAutoScan.value)
+        assertEquals(
+            "Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues.",
+            serviceRepository.errorMessage.value,
+        )
+    }
+
+    @Test
+    fun `scan startup failure cooldown prevents immediate retry and allows later manual retry`() = runTest {
+        var scanAttempts = 0
+        every { bleScanner.scan(any(), any()) } returns
+            flow {
+                scanAttempts += 1
+                throw BleScanStartException(
+                    reason = BleScanStartFailureReason.ApplicationRegistrationFailed,
+                    cause = IllegalStateException("Failed to start scan as app cannot be registered"),
+                )
+            }
+
+        viewModel.startBleScan()
+        assertEquals(1, scanAttempts)
+        assertEquals(false, viewModel.isBleScanning.value)
+
+        viewModel.startBleScan()
+        assertEquals(1, scanAttempts)
+
+        harness.testDispatcher.scheduler.advanceTimeBy(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN.inWholeMilliseconds + 1)
+        viewModel.startBleScan()
+
+        assertEquals(2, scanAttempts)
+    }
+
+    @Test
+    fun `stopBleScan is idempotent after failed startup`() = runTest {
+        every { bleScanner.scan(any(), any()) } returns failingScanFlow()
+
+        viewModel.startBleScan()
+        viewModel.stopBleScan()
+        viewModel.stopBleScan()
+
+        assertEquals(false, viewModel.isBleScanning.value)
     }
 
     @Test
@@ -205,7 +260,7 @@ class ScannerViewModelTest {
         val bondedBle = FakeBleDevice(address = "0D:0E:0F:10:11:12", name = "Bonded C", rssi = null)
         val bondedDevice = DeviceListEntry.Ble(device = bondedBle, bonded = true)
 
-        val scanFlow = MutableStateFlow<org.meshtastic.core.ble.BleDevice?>(null)
+        val scanFlow = MutableStateFlow<BleDevice?>(null)
         every { bleScanner.scan(any(), any()) } returns scanFlow.filterNotNull()
 
         viewModel.bleDevicesForUi.test {
@@ -275,7 +330,7 @@ class ScannerViewModelTest {
     @Test
     fun `stopBleScan does not clear scanned devices`() = runTest {
         val device = FakeBleDevice(address = "01:02:03:04:05:06", name = "Node", rssi = -50)
-        val scanFlow = MutableStateFlow<org.meshtastic.core.ble.BleDevice?>(null)
+        val scanFlow = MutableStateFlow<BleDevice?>(null)
         every { bleScanner.scan(any(), any()) } returns scanFlow.filterNotNull()
 
         viewModel.bleDevicesForUi.test {
@@ -578,5 +633,12 @@ class ScannerViewModelTest {
 
         assertEquals(false, viewModel.isNetworkScanning.value)
         assertEquals("t192.168.1.99", radioController.lastSetDeviceAddress)
+    }
+
+    private fun failingScanFlow() = flow<BleDevice> {
+        throw BleScanStartException(
+            reason = BleScanStartFailureReason.ApplicationRegistrationFailed,
+            cause = IllegalStateException("Failed to start scan as app cannot be registered"),
+        )
     }
 }


### PR DESCRIPTION


## Summary by Sourcery

Handle BLE scan start failures gracefully and prevent immediate retry loops when Android cannot register the BLE scanner.

Bug Fixes:
- Ensure BLE scan start failures clear scanning state, disable auto-scan, and surface a user-visible warning message.
- Wrap Android scanner registration IllegalStateExceptions into a structured BleScanStartException for known registration failure messages.
- Maintain idempotent stopBleScan behavior even after a failed scan startup.

Enhancements:
- Introduce a cooldown period after BLE scan start failures to block immediate retries while still allowing manual retry after the cooldown.
- Add a structured BleScanStartFailureReason enum to classify known scan start failure scenarios.

Documentation:
- Add a user-facing string for Bluetooth scan start failures with guidance to retry or toggle Bluetooth.

Tests:
- Add unit tests covering BLE scan start failure handling, cooldown behavior, and stopBleScan idempotency in ScannerViewModel.
- Add unit tests validating KableBleScanner wrapping of Android scanner registration failures and preserving unrelated IllegalStateExceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change updates BLE scan startup failure handling so the app recovers more predictably when Android (via the Kable scanner) can’t register the scanner. It converts known registration-related `IllegalStateException` failures into a typed exception, resets scan UI/state, disables BLE auto-scan, shows a user-visible warning, and introduces a short retry cooldown with generation checks to avoid stale failures affecting subsequent scan attempts.

- **Features**
  - Added a typed BLE scan startup failure model:
    - `BleScanStartFailureReason` (currently `ApplicationRegistrationFailed` with an Android error-code string and description)
    - `BleScanStartException` to wrap/format the failure while chaining the original cause
  - Added localized user messaging for scan-start failure:
    - `bluetooth_scan_start_failed` in `core/resources/.../strings.xml`
    - `bluetooth_scan_start_failed` in `.skills/compose-ui/strings-index.txt`
  - Added scan-start failure recovery in the UI layer:
    - `ScannerViewModel` cooldown after `BleScanStartException`
    - scan “generation” checks to prevent stale cleanup from overwriting newer scan state

- **Fixes**
  - `KableBleScanner.scan(...)` now:
    - preserves coroutine cancellation by rethrowing `CancellationException`
    - catches `IllegalStateException` during scan collection/startup and, when it matches the known “application registration failure” signature (including nested causes), rethrows it as `BleScanStartException`
  - `ScannerViewModel` on `BleScanStartException` now:
    - clears BLE scanning state and stops/invalidates the current scan job
    - disables BLE auto-scan (`uiPrefs.setBleAutoScan(false)`)
    - logs a warning and sets `serviceRepository.errorMessage` using `bluetooth_scan_start_failed` (with a fallback)
    - starts a retry cooldown so immediate repeated attempts are blocked, but later manual retries are allowed

- **Refactors**
  - Added helper logic in `KableBleScanner` to detect the specific registration-failure signature by walking the exception cause chain up to a bounded depth and checking known message content.
  - Centralized `ScannerViewModel` failure handling into a dedicated `handleBleScanStartFailure(...)` path and guarded the scan coroutine `finally` cleanup with generation equality.

- **Breaking changes / migration**
  - None expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->