### PR TITLE
Use per-channel selections for QR import add mode

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
@@ -63,6 +63,7 @@ import org.meshtastic.core.resources.replace
 import org.meshtastic.core.resources.replace_channels_and_settings_description
 import org.meshtastic.core.ui.component.ChannelSelection
 import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.core.ui.util.getChannelSelectionsForAdd
 import org.meshtastic.core.ui.util.mergeChannelSettingsForAdd
 import org.meshtastic.proto.ChannelSet
 
@@ -73,11 +74,13 @@ fun ScannedQrCodeDialog(
     viewModel: ScannedQrCodeViewModel = koinViewModel(),
 ) {
     val channels by viewModel.channels.collectAsStateWithLifecycle()
+    val maxChannels by viewModel.maxChannels.collectAsStateWithLifecycle()
 
     ScannedQrCodeDialog(
         channels = channels,
         incoming = incoming,
         onDismiss = onDismiss,
+        maxChannels = maxChannels,
         onConfirm = viewModel::setChannels,
     )
 }
@@ -90,6 +93,7 @@ fun ScannedQrCodeDialog(
     channels: ChannelSet,
     incoming: ChannelSet,
     onDismiss: () -> Unit,
+    maxChannels: Int = DEFAULT_MAX_CHANNELS,
     onConfirm: (ChannelSet) -> Unit,
 ) {
     var shouldReplace by rememberSaveable { mutableStateOf(incoming.lora_config != null) }
@@ -117,7 +121,27 @@ fun ScannedQrCodeDialog(
 
     /* Holds selections made by the user */
     val channelSelections =
-        remember(channelSet) { mutableStateListOf(elements = Array(size = channelSet.settings.size, init = { true })) }
+        remember(
+            shouldReplace,
+            channelSet.settings,
+            channels.settings,
+            incoming.settings,
+            channels.lora_config,
+            maxChannels,
+        ) {
+            val defaults =
+                if (shouldReplace) {
+                    List(channelSet.settings.size) { true }
+                } else {
+                    getChannelSelectionsForAdd(
+                        existing = channels.settings,
+                        incoming = incoming.settings,
+                        loraConfig = channels.lora_config ?: Channel.default.loraConfig,
+                        maxChannels = maxChannels,
+                    )
+                }
+            mutableStateListOf<Boolean>().apply { addAll(defaults) }
+        }
 
     val selectedChannelSet =
         if (shouldReplace) {
@@ -297,7 +321,7 @@ fun ScannedQrCodeDialog(
                                 onDismiss()
                                 onConfirm(selectedChannelSet)
                             },
-                            enabled = selectedChannelSet.settings.size in 1..8,
+                            enabled = selectedChannelSet.settings.size in 1..maxChannels,
                         ) {
                             Text(
                                 text = stringResource(Res.string.accept),

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
@@ -17,7 +17,9 @@
 package org.meshtastic.core.ui.qr
 
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.map
 import org.koin.core.annotation.KoinViewModel
+import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.ui.util.applyReplacementChannelSet
@@ -27,13 +29,21 @@ import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.LocalConfig
 
+internal const val DEFAULT_MAX_CHANNELS = 8
+
 @KoinViewModel
 class ScannedQrCodeViewModel(
     private val radioConfigRepository: RadioConfigRepository,
     private val radioController: RadioController,
+    nodeRepository: NodeRepository,
 ) : ViewModel() {
 
     val channels = radioConfigRepository.channelSetFlow.stateInWhileSubscribed(initialValue = ChannelSet())
+
+    val maxChannels =
+        nodeRepository.myNodeInfo
+            .map { it?.maxChannels ?: DEFAULT_MAX_CHANNELS }
+            .stateInWhileSubscribed(initialValue = DEFAULT_MAX_CHANNELS)
 
     private val localConfig = radioConfigRepository.localConfigFlow.stateInWhileSubscribed(initialValue = LocalConfig())
 

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ui.util
 
 import androidx.compose.runtime.Composable
 import kotlinx.coroutines.flow.first
+import okio.ByteString
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.DateFormatter
 import org.meshtastic.core.common.util.nowMillis
@@ -28,9 +29,11 @@ import org.meshtastic.core.resources.unknown_age
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.Position
 import kotlin.time.Duration.Companion.days
+import org.meshtastic.core.model.Channel as ModelChannel
 
 private const val SECONDS_TO_MILLIS = 1000L
 
@@ -171,3 +174,43 @@ fun mergeChannelSettingsForAdd(
     existing: List<ChannelSettings>,
     incoming: List<ChannelSettings>,
 ): List<ChannelSettings> = existing + incoming
+
+/**
+ * Computes default checkbox selections for ADD-mode QR import. Existing channels are always selected. Incoming channels
+ * are selected unless they are an exact semantic duplicate (same effective name + effective PSK) of an existing or
+ * earlier incoming channel, or unless the firmware channel limit would be exceeded.
+ *
+ * The preview list remains non-lossy — every incoming channel stays visible regardless of its selection state.
+ *
+ * @param existing The current [ChannelSettings] list on the radio.
+ * @param incoming The imported [ChannelSettings] list.
+ * @param loraConfig The current [Config.LoRaConfig], used to resolve effective channel names.
+ * @param maxChannels Firmware channel limit. Incoming selections stop when this is reached.
+ * @return Selection list aligned with `[existing..., incoming...]`.
+ */
+fun getChannelSelectionsForAdd(
+    existing: List<ChannelSettings>,
+    incoming: List<ChannelSettings>,
+    loraConfig: Config.LoRaConfig,
+    maxChannels: Int,
+): List<Boolean> {
+    val seen = existing.map { it.channelIdentity(loraConfig) }.toMutableSet()
+    var remaining = (maxChannels - existing.size).coerceAtLeast(0)
+    return List(existing.size) { true } +
+        incoming.map { channel ->
+            val identity = channel.channelIdentity(loraConfig)
+            val isDuplicate = !seen.add(identity)
+            val shouldSelect = !isDuplicate && remaining > 0
+            if (shouldSelect) remaining--
+            shouldSelect
+        }
+}
+
+/** Semantic channel identity based on effective name and effective PSK. */
+private data class ChannelIdentity(val name: String, val psk: ByteString)
+
+/** Resolves the [ChannelIdentity] of this [ChannelSettings] under the given [Config.LoRaConfig]. */
+private fun ChannelSettings.channelIdentity(loraConfig: Config.LoRaConfig): ChannelIdentity {
+    val channel = ModelChannel(settings = this, loraConfig = loraConfig)
+    return ChannelIdentity(name = channel.name, psk = channel.psk)
+}

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
@@ -19,9 +19,12 @@ package org.meshtastic.core.ui.util
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.meshtastic.core.model.Channel as ModelChannel
 
 /**
  * Coverage for [getChannelReplacementList]. The REPLACE helper must emit an authoritative slot list for QR imports:
@@ -211,5 +214,186 @@ class ProtoExtensionsTest {
         val result = mergeChannelSettingsForAdd(existing = emptyList(), incoming = emptyList())
 
         assertTrue(result.isEmpty())
+    }
+
+    // --- getChannelSelectionsForAdd tests ---
+
+    @Test
+    fun selections_existing_channels_are_always_selected() {
+        val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
+
+        val selections =
+            getChannelSelectionsForAdd(existing, emptyList(), ModelChannel.default.loraConfig, maxChannels = 8)
+
+        assertTrue(selections[0])
+        assertTrue(selections[1])
+    }
+
+    @Test
+    fun selections_unique_incoming_channels_are_selected() {
+        val incoming = listOf(ChannelSettings(name = "C"), ChannelSettings(name = "D"))
+
+        val selections =
+            getChannelSelectionsForAdd(emptyList(), incoming, ModelChannel.default.loraConfig, maxChannels = 8)
+
+        assertTrue(selections[0])
+        assertTrue(selections[1])
+    }
+
+    @Test
+    fun selections_incoming_duplicate_of_existing_is_unchecked() {
+        val channel = ChannelSettings(name = "Test", psk = byteArrayOf(1).toByteString())
+
+        val selections =
+            getChannelSelectionsForAdd(
+                listOf(channel),
+                listOf(channel),
+                ModelChannel.default.loraConfig,
+                maxChannels = 8,
+            )
+
+        assertFalse(selections[1])
+    }
+
+    @Test
+    fun selections_duplicate_inside_incoming_first_selected_second_unchecked() {
+        val a = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
+        val b = ChannelSettings(name = "B", psk = byteArrayOf(2).toByteString())
+
+        val selections =
+            getChannelSelectionsForAdd(emptyList(), listOf(a, a, b), ModelChannel.default.loraConfig, maxChannels = 8)
+
+        assertTrue(selections[0])
+        assertFalse(selections[1])
+        assertTrue(selections[2])
+    }
+
+    @Test
+    fun selections_same_name_different_psk_remains_selected() {
+        val existingChan = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
+        val incomingChan = ChannelSettings(name = "A", psk = byteArrayOf(2).toByteString())
+
+        val selections =
+            getChannelSelectionsForAdd(
+                listOf(existingChan),
+                listOf(incomingChan),
+                ModelChannel.default.loraConfig,
+                maxChannels = 8,
+            )
+
+        assertTrue(selections[1])
+    }
+
+    @Test
+    fun selections_same_psk_different_name_remains_selected() {
+        val psk = byteArrayOf(1, 2).toByteString()
+        val existingChan = ChannelSettings(name = "A", psk = psk)
+        val incomingChan = ChannelSettings(name = "B", psk = psk)
+
+        val selections =
+            getChannelSelectionsForAdd(
+                listOf(existingChan),
+                listOf(incomingChan),
+                ModelChannel.default.loraConfig,
+                maxChannels = 8,
+            )
+
+        assertTrue(selections[1])
+    }
+
+    @Test
+    fun selections_empty_name_default_matches_explicit_preset_name() {
+        val loraConfig = ModelChannel.default.loraConfig
+        val existingChan = ChannelSettings(psk = byteArrayOf(1).toByteString())
+        val incomingChan = ChannelSettings(name = "LongFast", psk = byteArrayOf(1).toByteString())
+
+        val selections =
+            getChannelSelectionsForAdd(listOf(existingChan), listOf(incomingChan), loraConfig, maxChannels = 8)
+
+        assertFalse(selections[1])
+    }
+
+    @Test
+    fun selections_explicit_preset_name_matches_empty_name_default() {
+        val loraConfig = ModelChannel.default.loraConfig
+        val existingChan = ChannelSettings(name = "LongFast", psk = byteArrayOf(1).toByteString())
+        val incomingChan = ChannelSettings(psk = byteArrayOf(1).toByteString())
+
+        val selections =
+            getChannelSelectionsForAdd(listOf(existingChan), listOf(incomingChan), loraConfig, maxChannels = 8)
+
+        assertFalse(selections[1])
+    }
+
+    @Test
+    fun selections_psk_marker_matches_expanded_default_key() {
+        val loraConfig = ModelChannel.default.loraConfig
+        val expandedPsk =
+            ModelChannel(settings = ChannelSettings(psk = byteArrayOf(1).toByteString()), loraConfig = loraConfig).psk
+        val markerChan = ChannelSettings(name = "Test", psk = byteArrayOf(1).toByteString())
+        val expandedChan = ChannelSettings(name = "Test", psk = expandedPsk)
+
+        val selections =
+            getChannelSelectionsForAdd(listOf(markerChan), listOf(expandedChan), loraConfig, maxChannels = 8)
+
+        assertFalse(selections[1])
+    }
+
+    @Test
+    fun selections_non_long_fast_preset_default_duplicate_is_unchecked() {
+        val loraConfig = Config.LoRaConfig(use_preset = true, modem_preset = Config.LoRaConfig.ModemPreset.MEDIUM_FAST)
+        val existingChan = ChannelSettings(psk = byteArrayOf(1).toByteString())
+        val incomingChan = ChannelSettings(name = "MediumFast", psk = byteArrayOf(1).toByteString())
+
+        val selections =
+            getChannelSelectionsForAdd(listOf(existingChan), listOf(incomingChan), loraConfig, maxChannels = 8)
+
+        assertFalse(selections[1])
+    }
+
+    @Test
+    fun selections_duplicates_do_not_consume_remaining_capacity() {
+        val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
+        val dup = ChannelSettings(name = "A")
+        val unique = listOf(ChannelSettings(name = "C"), ChannelSettings(name = "D"), ChannelSettings(name = "E"))
+
+        val selections =
+            getChannelSelectionsForAdd(existing, listOf(dup) + unique, ModelChannel.default.loraConfig, maxChannels = 5)
+
+        assertFalse(selections[2]) // duplicate A unchecked
+        assertTrue(selections[3]) // C selected
+        assertTrue(selections[4]) // D selected
+        assertTrue(selections[5]) // E selected because duplicate A did not consume capacity
+    }
+
+    @Test
+    fun selections_over_capacity_unique_incoming_after_limit_is_unchecked() {
+        val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
+        val incoming =
+            listOf(
+                ChannelSettings(name = "C"),
+                ChannelSettings(name = "D"),
+                ChannelSettings(name = "E"),
+                ChannelSettings(name = "F"),
+            )
+
+        val selections =
+            getChannelSelectionsForAdd(existing, incoming, ModelChannel.default.loraConfig, maxChannels = 4)
+
+        assertTrue(selections[2]) // C fits (3 total)
+        assertTrue(selections[3]) // D fits (4 total)
+        assertFalse(selections[4]) // E would exceed 4
+        assertFalse(selections[5]) // F would exceed 4
+    }
+
+    @Test
+    fun selections_existing_at_max_makes_all_incoming_unchecked() {
+        val existing = (1..8).map { ChannelSettings(name = "Ch$it") }
+        val incoming = listOf(ChannelSettings(name = "New"))
+
+        val selections =
+            getChannelSelectionsForAdd(existing, incoming, ModelChannel.default.loraConfig, maxChannels = 8)
+
+        assertFalse(selections[8])
     }
 }


### PR DESCRIPTION


## Summary by Sourcery

Introduce semantic per-channel selection defaults for ADD-mode QR imports to avoid duplicates and respect firmware channel limits.

Enhancements:
- Add logic to compute default checkbox selections for ADD-mode QR import based on existing channels, incoming channels, and LoRa configuration.
- Ensure channel identity comparisons use effective name and PSK so preset-based defaults and expanded keys are treated consistently.

Tests:
- Add unit tests covering selection behavior for existing channels, unique and duplicate incoming channels, preset name/PSK edge cases, and capacity limits in ADD-mode QR imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved QR import dialog to preselect channels intelligently in add mode, respecting the device’s available channel limit and reducing unnecessary selections.

* **Bug Fixes**
  * Existing channels are always kept selected.
  * Incoming channels are selected only if they’re not semantic duplicates and fit within `maxChannels`.
  * “Accept” button enablement now validates the selected channel count against `maxChannels`.

* **Tests**
  * Expanded coverage for add-mode preselection, duplicate handling, name/PSK matching rules, and capacity/limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->