### PR TITLE
fix(messages): refresh channel placeholders after updates

### DIFF
--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
@@ -151,8 +151,8 @@ fun ContactsScreen(
     // Create channel placeholders (always show broadcast contacts, even when empty)
     val channels by viewModel.channels.collectAsStateWithLifecycle()
     val channelPlaceholders =
-        remember(channels.settings.size) {
-            (0 until channels.settings.size).map { ch ->
+        remember(channels) {
+            channels.settings.mapIndexed { ch, _ ->
                 Contact(
                     contactKey = "$ch^all",
                     shortName = "$ch",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure channel placeholder contacts are refreshed when channels settings are updated instead of being remembered with a fixed size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact list updates so channel placeholders refresh correctly when channel data changes.
  * Kept the contact placeholder layout consistent while making the list more responsive to current channel information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->