### PR TITLE
fix(messages): refresh channel placeholders after updates

### DIFF
--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
@@ -146,8 +146,8 @@ fun ContactsScreen(
     // Create channel placeholders (always show broadcast contacts, even when empty)
     val channels by viewModel.channels.collectAsStateWithLifecycle()
     val channelPlaceholders =
-        remember(channels.settings.size) {
-            (0 until channels.settings.size).map { ch ->
+        remember(channels) {
+            channels.settings.mapIndexed { ch, _ ->
                 Contact(
                     contactKey = "$ch^all",
                     shortName = "$ch",


### PR DESCRIPTION
Channel placeholder rows in the conversations pane were memoized only by channels.settings.size, so same-size updates (rename, role change) and lora_config changes left stale effective channel names rendered until the screen or process was recreated. Empty channel names could keep rendering as LongFast or Custom depending on the current/fallback LoRa config.

Key the memoization on the full ChannelSet value so placeholders recompute whenever settings or lora_config actually change, while unrelated recompositions reuse the cached list. ChannelSet is a Wire-generated message with structural equality, so the key correctly reflects content. Data shape is preserved (contactKey '$index^all', shortName '$index', longName via channels.getChannel(index)?.name).

## Summary by Sourcery

Bug Fixes:
- Ensure channel placeholder contact names update correctly on channel renames, role changes, and LoRa configuration changes instead of remaining stale.