### PR TITLE
Use dynamic maxChannels and deduplicate QR channel defaults

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
@@ -63,7 +63,7 @@ import org.meshtastic.core.resources.replace
 import org.meshtastic.core.resources.replace_channels_and_settings_description
 import org.meshtastic.core.ui.component.ChannelSelection
 import org.meshtastic.core.ui.theme.AppTheme
-import org.meshtastic.core.ui.util.mergeChannelSettingsForAdd
+import org.meshtastic.core.ui.util.getChannelPreviewForAdd
 import org.meshtastic.proto.ChannelSet
 
 @Composable
@@ -73,11 +73,13 @@ fun ScannedQrCodeDialog(
     viewModel: ScannedQrCodeViewModel = koinViewModel(),
 ) {
     val channels by viewModel.channels.collectAsStateWithLifecycle()
+    val maxChannels by viewModel.maxChannels.collectAsStateWithLifecycle()
 
     ScannedQrCodeDialog(
         channels = channels,
         incoming = incoming,
         onDismiss = onDismiss,
+        maxChannels = maxChannels,
         onConfirm = viewModel::setChannels,
     )
 }
@@ -90,12 +92,30 @@ fun ScannedQrCodeDialog(
     channels: ChannelSet,
     incoming: ChannelSet,
     onDismiss: () -> Unit,
+    maxChannels: Int = DEFAULT_MAX_CHANNELS,
     onConfirm: (ChannelSet) -> Unit,
 ) {
     var shouldReplace by rememberSaveable { mutableStateOf(incoming.lora_config != null) }
 
+    // Freeze the channel limit for the dialog's lifetime so a late myNodeInfo emission (which updates
+    // viewModel.maxChannels from the DEFAULT_MAX_CHANNELS seed to the real device value) cannot rebuild
+    // addPreview/channelSelections and silently wipe the user's checkbox toggles.
+    val effectiveMaxChannels = rememberSaveable { maxChannels }
+
+    // Filtered ADD-mode preview: existing channels plus only the unique incoming channels. Duplicate incoming channels
+    // are omitted entirely. REPLACE mode ignores this and uses the raw incoming set.
+    val addPreview =
+        remember(channels.settings, incoming.settings, channels.lora_config, effectiveMaxChannels) {
+            getChannelPreviewForAdd(
+                existing = channels.settings,
+                incoming = incoming.settings,
+                loraConfig = channels.lora_config ?: Channel.default.loraConfig,
+                maxChannels = effectiveMaxChannels,
+            )
+        }
+
     val channelSet =
-        remember(shouldReplace, channels, incoming) {
+        remember(shouldReplace, channels, incoming, addPreview.settings) {
             if (shouldReplace) {
                 // When replacing, apply the incoming LoRa configuration but preserve certain
                 // locally safe fields such as MQTT flags and TX power. This prevents QR codes
@@ -108,8 +128,7 @@ fun ScannedQrCodeDialog(
                     ),
                 )
             } else {
-                val result = mergeChannelSettingsForAdd(channels.settings, incoming.settings)
-                channels.copy(settings = result)
+                channels.copy(settings = addPreview.settings)
             }
         }
 
@@ -117,7 +136,15 @@ fun ScannedQrCodeDialog(
 
     /* Holds selections made by the user */
     val channelSelections =
-        remember(channelSet) { mutableStateListOf(elements = Array(size = channelSet.settings.size, init = { true })) }
+        remember(shouldReplace, channelSet.settings, addPreview.selections) {
+            val defaults =
+                if (shouldReplace) {
+                    List(channelSet.settings.size) { true }
+                } else {
+                    addPreview.selections
+                }
+            mutableStateListOf<Boolean>().apply { addAll(defaults) }
+        }
 
     val selectedChannelSet =
         if (shouldReplace) {
@@ -297,7 +324,7 @@ fun ScannedQrCodeDialog(
                                 onDismiss()
                                 onConfirm(selectedChannelSet)
                             },
-                            enabled = selectedChannelSet.settings.size in 1..8,
+                            enabled = selectedChannelSet.settings.size in 1..effectiveMaxChannels,
                         ) {
                             Text(
                                 text = stringResource(Res.string.accept),

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
@@ -43,7 +43,9 @@ class ScannedQrCodeViewModel(
     val maxChannels =
         nodeRepository.myNodeInfo
             .map { it?.maxChannels?.takeIf { max -> max > 0 } ?: DEFAULT_MAX_CHANNELS }
-            .stateInWhileSubscribed(initialValue = DEFAULT_MAX_CHANNELS)
+            .stateInWhileSubscribed(
+                initialValue = nodeRepository.myNodeInfo.value?.maxChannels?.takeIf { it > 0 } ?: DEFAULT_MAX_CHANNELS,
+            )
 
     private val localConfig = radioConfigRepository.localConfigFlow.stateInWhileSubscribed(initialValue = LocalConfig())
 

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
@@ -17,7 +17,9 @@
 package org.meshtastic.core.ui.qr
 
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.map
 import org.koin.core.annotation.KoinViewModel
+import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.ui.util.applyReplacementChannelSet
@@ -27,13 +29,21 @@ import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.LocalConfig
 
+internal const val DEFAULT_MAX_CHANNELS = 8
+
 @KoinViewModel
 class ScannedQrCodeViewModel(
     private val radioConfigRepository: RadioConfigRepository,
     private val radioController: RadioController,
+    nodeRepository: NodeRepository,
 ) : ViewModel() {
 
     val channels = radioConfigRepository.channelSetFlow.stateInWhileSubscribed(initialValue = ChannelSet())
+
+    val maxChannels =
+        nodeRepository.myNodeInfo
+            .map { it?.maxChannels?.takeIf { max -> max > 0 } ?: DEFAULT_MAX_CHANNELS }
+            .stateInWhileSubscribed(initialValue = DEFAULT_MAX_CHANNELS)
 
     private val localConfig = radioConfigRepository.localConfigFlow.stateInWhileSubscribed(initialValue = LocalConfig())
 

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -186,13 +186,15 @@ fun getChannelPreviewForAdd(
     val previewSelections = MutableList(existing.size) { true }
     var remaining = (maxChannels - existing.size).coerceAtLeast(0)
     for (channel in incoming) {
-        val identity = channel.channelIdentity(loraConfig)
-        // Omit semantic duplicates entirely — they are not shown to the user.
-        if (!seen.add(identity)) continue
-        previewSettings += channel
-        val shouldSelect = remaining > 0
-        previewSelections += shouldSelect
-        if (shouldSelect) remaining--
+        val shouldShow = !channel.isPlaceholder()
+        val identity = if (shouldShow) channel.channelIdentity(loraConfig) else null
+        // Omit blank placeholders and semantic duplicates entirely — they are not shown to the user.
+        if (identity != null && seen.add(identity)) {
+            previewSettings += channel
+            val shouldSelect = remaining > 0
+            previewSelections += shouldSelect
+            if (shouldSelect) remaining--
+        }
     }
     return ChannelAddPreview(settings = previewSettings, selections = previewSelections)
 }
@@ -201,7 +203,14 @@ fun getChannelPreviewForAdd(
 data class ChannelAddPreview(val settings: List<ChannelSettings>, val selections: List<Boolean>)
 
 /** Semantic channel identity based on effective name and effective PSK. */
-private data class ChannelIdentity(val name: String, val psk: ByteString)
+private data class ChannelIdentity(val name: String, val psk: ByteString) {
+    // Redact the effective PSK from auto-generated diagnostics so a cryptographic key never leaks
+    // via toString() in exception messages, debug logs, or stack traces.
+    override fun toString(): String = "ChannelIdentity(name=$name, psk=<redacted>)"
+}
+
+/** True when a [ChannelSettings] carries no name and no PSK — a placeholder, not an intended channel. */
+private fun ChannelSettings.isPlaceholder(): Boolean = name.isNullOrBlank() && (psk == null || psk.size == 0)
 
 /** Resolves the [ChannelIdentity] of this [ChannelSettings] under the given [Config.LoRaConfig]. */
 private fun ChannelSettings.channelIdentity(loraConfig: Config.LoRaConfig): ChannelIdentity {

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ui.util
 
 import androidx.compose.runtime.Composable
 import kotlinx.coroutines.flow.first
+import okio.ByteString
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.DateFormatter
 import org.meshtastic.core.common.util.nowMillis
@@ -28,9 +29,11 @@ import org.meshtastic.core.resources.unknown_age
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.Position
 import kotlin.time.Duration.Companion.days
+import org.meshtastic.core.model.Channel as ModelChannel
 
 private const val SECONDS_TO_MILLIS = 1000L
 
@@ -156,18 +159,52 @@ suspend fun applyReplacementChannelSet(
 }
 
 /**
- * Builds the ADD-mode preview list for QR import. Existing channels are preserved at their positions; every incoming
- * channel is appended in order without deduplication.
+ * Builds the filtered ADD-mode preview for QR import: existing channels followed by only the unique incoming channels.
  *
- * Structural `.distinct()` was previously used here, but it silently dropped incoming channels that matched existing
- * entries, shifting later channels to wrong indices and hiding them from the user. The caller (UI) lets the user select
- * which incoming channels to keep.
+ * Incoming channels that are semantic duplicates (same effective name + effective PSK) of an existing or earlier
+ * incoming channel are omitted entirely from the preview — they are not shown to the user. Unique incoming channels are
+ * appended in scanned order and selected by default while firmware channel capacity remains; unique channels beyond
+ * [maxChannels] stay visible but unchecked.
  *
- * @param existing The current [ChannelSettings] list on the radio. Preserved in order.
- * @param incoming The imported [ChannelSettings] list. Appended in order.
- * @return The concatenated list `[existing..., incoming...]`.
+ * Semantic identity is resolved via the [Channel] domain model so preset/default channels match correctly across modem
+ * presets: empty names resolve to the preset display name, and 1-byte PSK markers expand to the full default key.
+ *
+ * @param existing The current [ChannelSettings] list on the radio. Always shown, always selected.
+ * @param incoming The imported [ChannelSettings] list. Duplicates omitted; uniques appended in order.
+ * @param loraConfig The current [Config.LoRaConfig], used to resolve effective channel identity.
+ * @param maxChannels Firmware channel limit. Unique incoming selections stop when this is reached.
+ * @return A [ChannelAddPreview] whose [settings] and [selections] are aligned and size-matched.
  */
-fun mergeChannelSettingsForAdd(
+fun getChannelPreviewForAdd(
     existing: List<ChannelSettings>,
     incoming: List<ChannelSettings>,
-): List<ChannelSettings> = existing + incoming
+    loraConfig: Config.LoRaConfig,
+    maxChannels: Int,
+): ChannelAddPreview {
+    val seen = existing.map { it.channelIdentity(loraConfig) }.toMutableSet()
+    val previewSettings = existing.toMutableList()
+    val previewSelections = MutableList(existing.size) { true }
+    var remaining = (maxChannels - existing.size).coerceAtLeast(0)
+    for (channel in incoming) {
+        val identity = channel.channelIdentity(loraConfig)
+        // Omit semantic duplicates entirely — they are not shown to the user.
+        if (!seen.add(identity)) continue
+        previewSettings += channel
+        val shouldSelect = remaining > 0
+        previewSelections += shouldSelect
+        if (shouldSelect) remaining--
+    }
+    return ChannelAddPreview(settings = previewSettings, selections = previewSelections)
+}
+
+/** Filtered ADD-mode preview: the visible channel list paired with its default selections (always size-matched). */
+data class ChannelAddPreview(val settings: List<ChannelSettings>, val selections: List<Boolean>)
+
+/** Semantic channel identity based on effective name and effective PSK. */
+private data class ChannelIdentity(val name: String, val psk: ByteString)
+
+/** Resolves the [ChannelIdentity] of this [ChannelSettings] under the given [Config.LoRaConfig]. */
+private fun ChannelSettings.channelIdentity(loraConfig: Config.LoRaConfig): ChannelIdentity {
+    val channel = ModelChannel(settings = this, loraConfig = loraConfig)
+    return ChannelIdentity(name = channel.name, psk = channel.psk)
+}

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
@@ -19,9 +19,12 @@ package org.meshtastic.core.ui.util
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.meshtastic.core.model.Channel as ModelChannel
 
 /**
  * Coverage for [getChannelReplacementList]. The REPLACE helper must emit an authoritative slot list for QR imports:
@@ -142,74 +145,203 @@ class ProtoExtensionsTest {
         assertEquals(secondaryB, result[2].settings)
     }
 
-    // --- mergeChannelSettingsForAdd tests ---
+    // --- getChannelPreviewForAdd tests ---
 
     @Test
-    fun merge_preserves_all_existing_channels_in_order() {
+    fun preview_existing_channels_are_always_shown_and_selected() {
         val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
 
-        val result = mergeChannelSettingsForAdd(existing, incoming = emptyList())
+        val preview = getChannelPreviewForAdd(existing, emptyList(), ModelChannel.default.loraConfig, maxChannels = 8)
 
-        assertEquals(2, result.size)
-        assertEquals("A", result[0].name)
-        assertEquals("B", result[1].name)
+        assertEquals(existing, preview.settings)
+        assertTrue(preview.selections.all { it })
     }
 
     @Test
-    fun merge_appends_all_incoming_channels_in_order() {
+    fun preview_unique_incoming_channels_are_shown_and_selected() {
         val incoming = listOf(ChannelSettings(name = "C"), ChannelSettings(name = "D"))
 
-        val result = mergeChannelSettingsForAdd(existing = emptyList(), incoming)
+        val preview = getChannelPreviewForAdd(emptyList(), incoming, ModelChannel.default.loraConfig, maxChannels = 8)
 
-        assertEquals(2, result.size)
-        assertEquals("C", result[0].name)
-        assertEquals("D", result[1].name)
+        assertEquals(incoming, preview.settings)
+        assertTrue(preview.selections.all { it })
     }
 
     @Test
-    fun merge_preserves_structurally_equal_channels() {
-        val channel = ChannelSettings(name = "LongFast", psk = byteArrayOf(1).toByteString())
+    fun preview_incoming_duplicate_of_existing_is_omitted() {
+        val channel = ChannelSettings(name = "Test", psk = byteArrayOf(1).toByteString())
 
-        val result = mergeChannelSettingsForAdd(existing = listOf(channel), incoming = listOf(channel))
+        val preview =
+            getChannelPreviewForAdd(listOf(channel), listOf(channel), ModelChannel.default.loraConfig, maxChannels = 8)
 
-        assertEquals(2, result.size)
+        assertEquals(listOf(channel), preview.settings)
     }
 
     @Test
-    fun merge_preserves_same_name_different_psk() {
+    fun preview_duplicate_inside_incoming_keeps_first_and_omits_later() {
+        val a = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
+        val b = ChannelSettings(name = "B", psk = byteArrayOf(2).toByteString())
+
+        val preview =
+            getChannelPreviewForAdd(emptyList(), listOf(a, a, b), ModelChannel.default.loraConfig, maxChannels = 8)
+
+        assertEquals(listOf(a, b), preview.settings)
+        assertTrue(preview.selections[0])
+        assertTrue(preview.selections[1])
+    }
+
+    @Test
+    fun preview_same_name_different_psk_remains_visible() {
         val existingChan = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
         val incomingChan = ChannelSettings(name = "A", psk = byteArrayOf(2).toByteString())
 
-        val result = mergeChannelSettingsForAdd(listOf(existingChan), listOf(incomingChan))
+        val preview =
+            getChannelPreviewForAdd(
+                listOf(existingChan),
+                listOf(incomingChan),
+                ModelChannel.default.loraConfig,
+                maxChannels = 8,
+            )
 
-        assertEquals(2, result.size)
+        assertEquals(2, preview.settings.size)
+        assertTrue(preview.selections[1])
     }
 
     @Test
-    fun merge_preserves_same_psk_different_name() {
+    fun preview_same_psk_different_name_remains_visible() {
         val psk = byteArrayOf(1, 2).toByteString()
         val existingChan = ChannelSettings(name = "A", psk = psk)
         val incomingChan = ChannelSettings(name = "B", psk = psk)
 
-        val result = mergeChannelSettingsForAdd(listOf(existingChan), listOf(incomingChan))
+        val preview =
+            getChannelPreviewForAdd(
+                listOf(existingChan),
+                listOf(incomingChan),
+                ModelChannel.default.loraConfig,
+                maxChannels = 8,
+            )
 
-        assertEquals(2, result.size)
+        assertEquals(2, preview.settings.size)
+        assertTrue(preview.selections[1])
     }
 
     @Test
-    fun merge_preserves_duplicate_inside_incoming() {
-        val a = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
-        val b = ChannelSettings(name = "B", psk = byteArrayOf(2).toByteString())
+    fun preview_empty_name_default_matches_explicit_preset_name_and_is_omitted() {
+        val loraConfig = ModelChannel.default.loraConfig
+        val existingChan = ChannelSettings(psk = byteArrayOf(1).toByteString()) // resolves to "LongFast"
+        val incomingChan = ChannelSettings(name = "LongFast", psk = byteArrayOf(1).toByteString())
 
-        val result = mergeChannelSettingsForAdd(existing = emptyList(), incoming = listOf(a, a, b))
+        val preview = getChannelPreviewForAdd(listOf(existingChan), listOf(incomingChan), loraConfig, maxChannels = 8)
 
-        assertEquals(3, result.size)
+        assertEquals(listOf(existingChan), preview.settings)
     }
 
     @Test
-    fun merge_both_empty_produces_empty_list() {
-        val result = mergeChannelSettingsForAdd(existing = emptyList(), incoming = emptyList())
+    fun preview_explicit_preset_name_matches_empty_name_default_and_is_omitted() {
+        val loraConfig = ModelChannel.default.loraConfig
+        val existingChan = ChannelSettings(name = "LongFast", psk = byteArrayOf(1).toByteString())
+        val incomingChan = ChannelSettings(psk = byteArrayOf(1).toByteString()) // resolves to "LongFast"
 
-        assertTrue(result.isEmpty())
+        val preview = getChannelPreviewForAdd(listOf(existingChan), listOf(incomingChan), loraConfig, maxChannels = 8)
+
+        assertEquals(listOf(existingChan), preview.settings)
+    }
+
+    @Test
+    fun preview_psk_marker_matches_expanded_default_key_and_is_omitted() {
+        val loraConfig = ModelChannel.default.loraConfig
+        val expandedPsk =
+            ModelChannel(settings = ChannelSettings(psk = byteArrayOf(1).toByteString()), loraConfig = loraConfig).psk
+        val markerChan = ChannelSettings(name = "Test", psk = byteArrayOf(1).toByteString())
+        val expandedChan = ChannelSettings(name = "Test", psk = expandedPsk)
+
+        val preview = getChannelPreviewForAdd(listOf(markerChan), listOf(expandedChan), loraConfig, maxChannels = 8)
+
+        assertEquals(listOf(markerChan), preview.settings)
+    }
+
+    @Test
+    fun preview_non_long_fast_preset_default_duplicate_is_omitted() {
+        val loraConfig = Config.LoRaConfig(use_preset = true, modem_preset = Config.LoRaConfig.ModemPreset.MEDIUM_FAST)
+        val existingChan = ChannelSettings(psk = byteArrayOf(1).toByteString()) // resolves to "MediumFast"
+        val incomingChan = ChannelSettings(name = "MediumFast", psk = byteArrayOf(1).toByteString())
+
+        val preview = getChannelPreviewForAdd(listOf(existingChan), listOf(incomingChan), loraConfig, maxChannels = 8)
+
+        assertEquals(listOf(existingChan), preview.settings)
+    }
+
+    @Test
+    fun preview_omitted_duplicates_do_not_consume_capacity() {
+        val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
+        val dup = ChannelSettings(name = "A")
+        val unique = listOf(ChannelSettings(name = "C"), ChannelSettings(name = "D"), ChannelSettings(name = "E"))
+
+        val preview =
+            getChannelPreviewForAdd(existing, listOf(dup) + unique, ModelChannel.default.loraConfig, maxChannels = 5)
+
+        // Duplicate A omitted entirely (not in settings); C, D, E all selected because the omitted dup did not consume
+        // capacity.
+        assertEquals(listOf("A", "B", "C", "D", "E"), preview.settings.map { it.name })
+        assertTrue(preview.selections[2]) // C
+        assertTrue(preview.selections[3]) // D
+        assertTrue(preview.selections[4]) // E
+    }
+
+    @Test
+    fun preview_over_capacity_unique_incoming_remains_visible_but_unchecked() {
+        val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
+        val incoming =
+            listOf(
+                ChannelSettings(name = "C"),
+                ChannelSettings(name = "D"),
+                ChannelSettings(name = "E"),
+                ChannelSettings(name = "F"),
+            )
+
+        val preview = getChannelPreviewForAdd(existing, incoming, ModelChannel.default.loraConfig, maxChannels = 4)
+
+        // All unique incoming are visible; C and D fit (4 total), E and F over capacity remain visible but unchecked.
+        assertEquals(6, preview.settings.size)
+        assertTrue(preview.selections[2]) // C fits
+        assertTrue(preview.selections[3]) // D fits
+        assertFalse(preview.selections[4]) // E over capacity
+        assertFalse(preview.selections[5]) // F over capacity
+    }
+
+    @Test
+    fun preview_existing_at_max_omits_nothing_but_all_incoming_unchecked() {
+        val existing = (1..8).map { ChannelSettings(name = "Ch$it") }
+        val incoming = listOf(ChannelSettings(name = "New"))
+
+        val preview = getChannelPreviewForAdd(existing, incoming, ModelChannel.default.loraConfig, maxChannels = 8)
+
+        // Unique incoming still visible (not a duplicate) but unchecked because capacity is full.
+        assertEquals(9, preview.settings.size)
+        assertFalse(preview.selections[8])
+    }
+
+    @Test
+    fun preview_settings_and_selections_are_always_size_matched() {
+        val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
+        val incoming =
+            listOf(
+                ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString()), // duplicate of existing
+                ChannelSettings(name = "C"),
+                ChannelSettings(name = "D"),
+            )
+
+        val preview = getChannelPreviewForAdd(existing, incoming, ModelChannel.default.loraConfig, maxChannels = 8)
+
+        assertEquals(preview.settings.size, preview.selections.size)
+    }
+
+    @Test
+    fun preview_both_empty_produces_empty_preview() {
+        val preview =
+            getChannelPreviewForAdd(emptyList(), emptyList(), ModelChannel.default.loraConfig, maxChannels = 8)
+
+        assertTrue(preview.settings.isEmpty())
+        assertTrue(preview.selections.isEmpty())
     }
 }


### PR DESCRIPTION


## Summary by Sourcery

Implement dynamic channel limit handling and smarter default selections for QR ADD imports.

Enhancements:
- Compute default channel selection states for ADD-mode QR imports based on semantic channel identity and remaining capacity.
- Use the device-reported maximum channel count when validating and enabling QR import confirmation instead of a hardcoded limit.
- Resolve channel identity via effective name and PSK, including LoRa preset defaults, to avoid importing duplicate channels while preserving the full preview list.

Tests:
- Add unit tests covering channel selection behavior for existing, duplicate, preset-based, capacity-limited, and over-capacity QR ADD imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QR import now respects the device’s maximum channel count when selecting channels, including an improved add-mode preview.
  * Incoming channels are preprocessed to omit semantic duplicates and cap auto-selection based on remaining capacity.

* **Bug Fixes**
  * Prevented the accept action from enabling when the selected channel count exceeds the allowed limit.
  * Updated channel selection initialization: replace mode selects all channels; add mode selects according to the computed preview.

* **Tests**
  * Expanded automated coverage for add-mode preview rules, duplicate/preset matching behavior, and capacity-related selection outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->