### PR TITLE
Sequentially write remote radio channels by index

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.jetbrains.compose.resources.StringResource
 import org.koin.core.annotation.InjectedParam
 import org.koin.core.annotation.KoinViewModel
@@ -211,6 +213,7 @@ open class RadioConfigViewModel(
     val mqttProbeStatus: StateFlow<MqttProbeStatus?> = _mqttProbeStatus.asStateFlow()
 
     private var probeJob: Job? = null
+    private val channelUpdateMutex = Mutex()
 
     /**
      * Run a one-shot reachability/credentials probe against an MQTT broker. Cancels any in-flight probe before starting
@@ -402,18 +405,21 @@ open class RadioConfigViewModel(
         safeLaunch(tag = "setRemoteChannels") {
             // Manual channel saves are an ordered batch: only update canonical local state after every write request is
             // enqueued. If any enqueue fails, safeLaunch reports it and leaves the saved state unchanged instead of
-            // blessing a partial delete/reorder result.
-            applyManualChannelUpdatePlan(
-                updatePlan = updatePlan,
-                writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
-                registerRequestId = ::registerRequestId,
-            )
+            // blessing a partial delete/reorder result. Serialize batches so two ordered write plans cannot interleave
+            // on the radio link.
+            channelUpdateMutex.withLock {
+                applyManualChannelUpdatePlan(
+                    updatePlan = updatePlan,
+                    writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
+                    registerRequestId = ::registerRequestId,
+                )
 
-            if (destNum == myNodeNum) {
-                packetRepository.migrateChannelsByPSK(old, new)
-                radioConfigRepository.replaceAllSettings(new)
+                if (destNum == myNodeNum) {
+                    packetRepository.migrateChannelsByPSK(old, new)
+                    radioConfigRepository.replaceAllSettings(new)
+                }
+                _radioConfigState.update { it.copy(channelList = new) }
             }
-            _radioConfigState.update { it.copy(channelList = new) }
         }
     }
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -393,21 +393,25 @@ open class RadioConfigViewModel(
 
     fun updateChannels(new: List<ChannelSettings>, old: List<ChannelSettings>) {
         val destNum = destNum ?: destNode.value?.num ?: return
-        getChannelList(new, old).forEach { channel ->
-            safeLaunch(tag = "setRemoteChannel") {
+
+        val updatePlan = getManualChannelUpdatePlan(new, old)
+        if (updatePlan.isEmpty()) return
+        safeLaunch(tag = "setRemoteChannels") {
+            for (channel in updatePlan) {
                 val packetId = radioConfigUseCase.setRemoteChannel(destNum, channel)
                 registerRequestId(packetId)
             }
-        }
 
-        if (destNum == myNodeNum) {
-            safeLaunch(tag = "migrateChannels") {
+            if (destNum == myNodeNum) {
                 packetRepository.migrateChannelsByPSK(old, new)
                 radioConfigRepository.replaceAllSettings(new)
             }
+            _radioConfigState.update { it.copy(channelList = new) }
         }
-        _radioConfigState.update { it.copy(channelList = new) }
     }
+
+    private fun getManualChannelUpdatePlan(new: List<ChannelSettings>, old: List<ChannelSettings>): List<Channel> =
+        getChannelList(new, old).sortedBy { it.index }
 
     fun setConfig(config: Config) {
         val destNum = destNum ?: destNode.value?.num ?: return

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -90,7 +90,10 @@ import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.User
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+
+internal val MANUAL_CHANNEL_WRITE_DELAY: Duration = 1.seconds
 
 /** Data class that represents the current RadioConfig state. */
 data class RadioConfigState(
@@ -397,10 +400,11 @@ open class RadioConfigViewModel(
         val updatePlan = getManualChannelUpdatePlan(new, old)
         if (updatePlan.isEmpty()) return
         safeLaunch(tag = "setRemoteChannels") {
-            for (channel in updatePlan) {
-                val packetId = radioConfigUseCase.setRemoteChannel(destNum, channel)
-                registerRequestId(packetId)
-            }
+            applyManualChannelUpdatePlan(
+                updatePlan = updatePlan,
+                writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
+                registerRequestId = ::registerRequestId,
+            )
 
             if (destNum == myNodeNum) {
                 packetRepository.migrateChannelsByPSK(old, new)
@@ -882,6 +886,22 @@ open class RadioConfigViewModel(
             } else if (route.isEmpty()) {
                 setResponseStateSuccess()
             }
+        }
+    }
+}
+
+internal suspend fun applyManualChannelUpdatePlan(
+    updatePlan: List<Channel>,
+    writeChannel: suspend (Channel) -> Int,
+    registerRequestId: (Int) -> Unit,
+    writeDelay: Duration = MANUAL_CHANNEL_WRITE_DELAY,
+    delayFn: suspend (Duration) -> Unit = { delay(it) },
+) {
+    for ((index, channel) in updatePlan.withIndex()) {
+        val packetId = writeChannel(channel)
+        registerRequestId(packetId)
+        if (index < updatePlan.lastIndex) {
+            delayFn(writeDelay)
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -400,6 +400,9 @@ open class RadioConfigViewModel(
         val updatePlan = getManualChannelUpdatePlan(new, old)
         if (updatePlan.isEmpty()) return
         safeLaunch(tag = "setRemoteChannels") {
+            // Manual channel saves are an ordered batch: only update canonical local state after every write request is
+            // enqueued. If any enqueue fails, safeLaunch reports it and leaves the saved state unchanged instead of
+            // blessing a partial delete/reorder result.
             applyManualChannelUpdatePlan(
                 updatePlan = updatePlan,
                 writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
@@ -890,18 +893,23 @@ open class RadioConfigViewModel(
     }
 }
 
+internal data class ManualChannelUpdateResult(val packetIds: List<Int>)
+
 internal suspend fun applyManualChannelUpdatePlan(
     updatePlan: List<Channel>,
     writeChannel: suspend (Channel) -> Int,
     registerRequestId: (Int) -> Unit,
     writeDelay: Duration = MANUAL_CHANNEL_WRITE_DELAY,
     delayFn: suspend (Duration) -> Unit = { delay(it) },
-) {
+): ManualChannelUpdateResult {
+    val packetIds = mutableListOf<Int>()
     for ((index, channel) in updatePlan.withIndex()) {
         val packetId = writeChannel(channel)
+        packetIds.add(packetId)
         registerRequestId(packetId)
         if (index < updatePlan.lastIndex) {
             delayFn(writeDelay)
         }
     }
+    return ManualChannelUpdateResult(packetIds)
 }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -392,11 +392,8 @@ class RadioConfigViewModelTest {
     @Test
     fun `updateChannels keeps canonical channel list unchanged when ordered write fails`() = runTest {
         val node = Node(num = 123, user = User(id = "!123"))
-        val channelA = ChannelSettings(name = "A")
-        val channelB = ChannelSettings(name = "B")
-        val channelC = ChannelSettings(name = "C")
-        val channelD = ChannelSettings(name = "D")
-        val old = listOf(channelA, channelB, channelC, channelD)
+        val old = fourChannelFixture()
+        val (channelA, _, _, channelD) = old
         val new = listOf(channelA, channelD)
         val writtenIndexes = mutableListOf<Int>()
 
@@ -428,11 +425,8 @@ class RadioConfigViewModelTest {
     @Test
     fun `updateChannels serializes overlapping channel saves`() = runTest {
         val node = Node(num = 123, user = User(id = "!123"))
-        val channelA = ChannelSettings(name = "A")
-        val channelB = ChannelSettings(name = "B")
-        val channelC = ChannelSettings(name = "C")
-        val channelD = ChannelSettings(name = "D")
-        val old = listOf(channelA, channelB, channelC, channelD)
+        val old = fourChannelFixture()
+        val (channelA, _, channelC, channelD) = old
         val firstNew = listOf(channelA, channelD)
         val secondNew = listOf(channelA, channelC)
         val writtenChannels = mutableListOf<String>()
@@ -994,6 +988,13 @@ class RadioConfigViewModelTest {
 
         verifySuspend(exactly(0)) { radioConfigUseCase.getConfig(any(), any()) }
     }
+
+    private fun fourChannelFixture() = listOf(
+        ChannelSettings(name = "A"),
+        ChannelSettings(name = "B"),
+        ChannelSettings(name = "C"),
+        ChannelSettings(name = "D"),
+    )
 
     private fun myNodeInfo(myNodeNum: Int) = MyNodeInfo(
         myNodeNum = myNodeNum,

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -78,13 +78,13 @@ import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.User
-import kotlin.time.Duration
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RadioConfigViewModelTest {
@@ -390,6 +390,41 @@ class RadioConfigViewModelTest {
     }
 
     @Test
+    fun `updateChannels keeps canonical channel list unchanged when ordered write fails`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val channelA = ChannelSettings(name = "A")
+        val channelB = ChannelSettings(name = "B")
+        val channelC = ChannelSettings(name = "C")
+        val channelD = ChannelSettings(name = "D")
+        val old = listOf(channelA, channelB, channelC, channelD)
+        val new = listOf(channelA, channelD)
+        val writtenIndexes = mutableListOf<Int>()
+
+        every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet(settings = old))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        runCurrent()
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                val channel = it.args[1] as Channel
+                writtenIndexes.add(channel.index)
+                if (writtenIndexes.size == 2) {
+                    throw IllegalStateException("boom")
+                }
+                channel.index + 100
+            }
+
+        viewModel.updateChannels(new, old)
+        advanceUntilIdle()
+
+        assertEquals(listOf(1, 2), writtenIndexes)
+        assertEquals(old, viewModel.radioConfigState.value.channelList)
+        verifySuspend(exactly(0)) { packetRepository.migrateChannelsByPSK(any(), any()) }
+        verifySuspend(exactly(0)) { radioConfigRepository.replaceAllSettings(any()) }
+    }
+
+    @Test
     fun `applyManualChannelUpdatePlan paces writes except after final channel`() = runTest {
         val channelA = Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "A"))
         val channelB = Channel(index = 2, role = Channel.Role.DISABLED, settings = ChannelSettings())
@@ -398,17 +433,19 @@ class RadioConfigViewModelTest {
         val registeredRequestIds = mutableListOf<Int>()
         val delays = mutableListOf<Duration>()
 
-        applyManualChannelUpdatePlan(
-            updatePlan = listOf(channelA, channelB, channelC),
-            writeChannel = { channel ->
-                writtenIndexes.add(channel.index)
-                channel.index + 100
-            },
-            registerRequestId = { registeredRequestIds.add(it) },
-            delayFn = { delays.add(it) },
-        )
+        val result =
+            applyManualChannelUpdatePlan(
+                updatePlan = listOf(channelA, channelB, channelC),
+                writeChannel = { channel ->
+                    writtenIndexes.add(channel.index)
+                    channel.index + 100
+                },
+                registerRequestId = { registeredRequestIds.add(it) },
+                delayFn = { delays.add(it) },
+            )
 
         assertEquals(listOf(1, 2, 3), writtenIndexes)
+        assertEquals(listOf(101, 102, 103), result.packetIds)
         assertEquals(listOf(101, 102, 103), registeredRequestIds)
         assertEquals(listOf(MANUAL_CHANNEL_WRITE_DELAY, MANUAL_CHANNEL_WRITE_DELAY), delays)
     }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -63,6 +64,7 @@ import org.meshtastic.core.repository.UiPrefs
 import org.meshtastic.core.testing.FakeLockdownCoordinator
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.feature.settings.navigation.ConfigRoute
+import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config
@@ -349,6 +351,41 @@ class RadioConfigViewModelTest {
 
         verifySuspend { radioConfigUseCase.setRemoteChannel(123, any()) }
         assertEquals(new, viewModel.radioConfigState.value.channelList)
+    }
+
+    @Test
+    fun `updateChannels writes changed channels sequentially in index order`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+
+        val channelA = ChannelSettings(name = "A")
+        val channelB = ChannelSettings(name = "B")
+        val channelC = ChannelSettings(name = "C")
+        val old = listOf(channelA, channelB, channelC)
+        val new = listOf(channelA, channelC, channelB)
+        val writtenIndexes = mutableListOf<Int>()
+        var activeWrites = 0
+        var maxConcurrentWrites = 0
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                val channel = it.args[1] as Channel
+                activeWrites++
+                maxConcurrentWrites = maxOf(maxConcurrentWrites, activeWrites)
+                writtenIndexes.add(channel.index)
+                delay(1)
+                activeWrites--
+                writtenIndexes.size
+            }
+
+        viewModel.updateChannels(new, old)
+        advanceUntilIdle()
+
+        assertEquals(listOf(1, 2), writtenIndexes)
+        assertEquals(1, maxConcurrentWrites)
+        assertEquals(new, viewModel.radioConfigState.value.channelList)
+        verifySuspend(exactly(2)) { radioConfigUseCase.setRemoteChannel(123, any()) }
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -78,6 +78,7 @@ import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.User
+import kotlin.time.Duration
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -386,6 +387,30 @@ class RadioConfigViewModelTest {
         assertEquals(1, maxConcurrentWrites)
         assertEquals(new, viewModel.radioConfigState.value.channelList)
         verifySuspend(exactly(2)) { radioConfigUseCase.setRemoteChannel(123, any()) }
+    }
+
+    @Test
+    fun `applyManualChannelUpdatePlan paces writes except after final channel`() = runTest {
+        val channelA = Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "A"))
+        val channelB = Channel(index = 2, role = Channel.Role.DISABLED, settings = ChannelSettings())
+        val channelC = Channel(index = 3, role = Channel.Role.DISABLED, settings = ChannelSettings())
+        val writtenIndexes = mutableListOf<Int>()
+        val registeredRequestIds = mutableListOf<Int>()
+        val delays = mutableListOf<Duration>()
+
+        applyManualChannelUpdatePlan(
+            updatePlan = listOf(channelA, channelB, channelC),
+            writeChannel = { channel ->
+                writtenIndexes.add(channel.index)
+                channel.index + 100
+            },
+            registerRequestId = { registeredRequestIds.add(it) },
+            delayFn = { delays.add(it) },
+        )
+
+        assertEquals(listOf(1, 2, 3), writtenIndexes)
+        assertEquals(listOf(101, 102, 103), registeredRequestIds)
+        assertEquals(listOf(MANUAL_CHANNEL_WRITE_DELAY, MANUAL_CHANNEL_WRITE_DELAY), delays)
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -402,6 +402,7 @@ class RadioConfigViewModelTest {
 
         every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet(settings = old))
         nodeRepository.setNodes(listOf(node))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
         viewModel = createViewModel()
         runCurrent()
 
@@ -422,6 +423,47 @@ class RadioConfigViewModelTest {
         assertEquals(old, viewModel.radioConfigState.value.channelList)
         verifySuspend(exactly(0)) { packetRepository.migrateChannelsByPSK(any(), any()) }
         verifySuspend(exactly(0)) { radioConfigRepository.replaceAllSettings(any()) }
+    }
+
+    @Test
+    fun `updateChannels serializes overlapping channel saves`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val channelA = ChannelSettings(name = "A")
+        val channelB = ChannelSettings(name = "B")
+        val channelC = ChannelSettings(name = "C")
+        val channelD = ChannelSettings(name = "D")
+        val old = listOf(channelA, channelB, channelC, channelD)
+        val firstNew = listOf(channelA, channelD)
+        val secondNew = listOf(channelA, channelC)
+        val writtenChannels = mutableListOf<String>()
+        var firstWrite = true
+
+        every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet(settings = old))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        runCurrent()
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                val channel = it.args[1] as Channel
+                writtenChannels.add("${channel.index}:${channel.role}:${channel.settings?.name.orEmpty()}")
+                if (firstWrite) {
+                    firstWrite = false
+                    delay(10_000)
+                }
+                writtenChannels.size
+            }
+
+        viewModel.updateChannels(firstNew, old)
+        runCurrent()
+        viewModel.updateChannels(secondNew, old)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("1:SECONDARY:D", "2:DISABLED:", "3:DISABLED:", "1:SECONDARY:C", "2:DISABLED:", "3:DISABLED:"),
+            writtenChannels,
+        )
+        assertEquals(secondNew, viewModel.radioConfigState.value.channelList)
     }
 
     @Test


### PR DESCRIPTION
Apply manual channel saves through a single ordered channel update sequence instead of launching one coroutine per changed slot. The update plan is sorted by channel index so delete, re-add, and reorder-style edits enqueue radio writes deterministically while preserving each row's ChannelSettings payload, including its PSK.

Register every returned request ID from the ordered write loop so existing packet response tracking remains in place. Local channel migration and cache replacement now run after the ordered send loop for local nodes, and the visible channel list is updated after the same sequence completes.

Add focused ViewModel coverage that records write order and verifies changed channel writes do not overlap when setRemoteChannel suspends.

## Summary by Sourcery

Sequentialize remote channel updates into an ordered, paced write loop and adjust state updates accordingly.

Bug Fixes:
- Ensure manual remote channel writes execute one at a time in channel index order to avoid overlapping updates.

Enhancements:
- Introduce a reusable helper to apply an ordered manual channel update plan with configurable pacing between writes.
- Delay local channel migration, cache replacement, and UI channel list updates until after the ordered channel write sequence completes.

Tests:
- Add ViewModel tests verifying sequential, non-overlapping remote channel writes and correct index ordering when updating channels.
- Add tests covering the manual channel update plan helper, including request ID registration and inter-write delays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated channel settings application to use a deterministic, user-defined ordering.
  * Writes are now performed sequentially with a fixed pause between updates to avoid overlapping/partial application.
  * Preserved existing device-local migration behavior while still updating the channel list right away.

* **Tests**
  * Added coverage to ensure remote updates run strictly in order, with correct pacing and request tracking.
  * Added assertions that concurrency never exceeds a single in-flight write during channel updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->