### PR TITLE
Simplify BLE OTA notification subscription flow

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
@@ -17,7 +17,6 @@
 package org.meshtastic.feature.firmware.ota
 
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -112,14 +111,14 @@ class BleOtaTransport(
             val maxLen = bleConnection.maximumWriteValueLength(BleWriteType.WITHOUT_RESPONSE)
             Logger.i { "BLE OTA: Service ready. Max write value length: $maxLen bytes" }
 
-            // Collect responses. onSubscription fires when the CCCD write completes — a precise readiness
-            // signal; the settle below is a conservative cushion.
-            val subscribed = CompletableDeferred<Unit>()
+            // Collect notification responses. Kable writes the CCCD descriptor as part of flow collection
+            // startup; the settle delay below gives that write time to complete before we issue OTA commands.
+            // We intentionally do NOT gate on the onSubscription callback — some OTA loaders' GATT servers
+            // don't reliably ack the CCCD write, which would cause onSubscription to never fire and the
+            // previous CompletableDeferred-based gate to hang until the profile timeout. The request-response
+            // retry loop in the OTA protocol handles any command that arrives before CCCD is fully enabled.
             service
-                .observe(txChar) {
-                    Logger.d { "BLE OTA: TX characteristic subscribed" }
-                    subscribed.complete(Unit)
-                }
+                .observe(txChar)
                 .onEach { notifyBytes ->
                     try {
                         val response = notifyBytes.decodeToString()
@@ -130,13 +129,12 @@ class BleOtaTransport(
                     }
                 }
                 .catch { e ->
-                    if (!subscribed.isCompleted) subscribed.completeExceptionally(e)
-                    Logger.e(e) { "BLE OTA: Error in TX characteristic subscription" }
+                    Logger.e(e) { "BLE OTA: Error in TX characteristic notification flow" }
+                    responseChannel.close(e)
                 }
                 .launchIn(this)
 
-            subscribed.await()
-            // Conservative settle after CCCD confirmation before issuing commands.
+            // Give the CCCD write time to complete before issuing OTA commands.
             delay(SUBSCRIPTION_SETTLE)
             Logger.i { "BLE OTA: Service discovered and ready" }
         }


### PR DESCRIPTION
The CompletableDeferred-based gate on Kable's onSubscription callback caused a 30-second hang when the OTA loader's GATT server didn't reliably ack the CCCD descriptor write. Kable's observationExceptionHandler swallowed the CCCD write failure, onSubscription never fired, and subscribed.await() blocked until the profile timeout.

Remove the gate entirely. The observe flow's collection startup handles the CCCD write internally; the existing SUBSCRIPTION_SETTLE delay gives it time to complete before OTA commands are issued. The request-response retry loop in the OTA protocol handles any command that arrives before notifications are fully enabled.

Also removes the unused CompletableDeferred and flow.catch imports.

## Summary by Sourcery

Simplify BLE OTA notification subscription flow to avoid hangs when CCCD writes are not acknowledged.

Enhancements:
- Remove the CompletableDeferred-based subscription gate and rely on Kable's notification flow startup plus an existing settle delay before issuing OTA commands.
- Streamline error handling and logging in the TX characteristic notification flow.
- Remove unused coroutine-related imports from the BLE OTA transport implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting Bluetooth firmware updates by streamlining the notification setup flow.
  * Reduced cases where firmware updates could stall while waiting for BLE notification readiness during the initial OTA connection phase.
  * Ensured errors during BLE notification decoding are handled cleanly so the update process can proceed predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->