### PR TITLE
Invalidate BLE GATT cache before OTA service discovery

### DIFF
--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -14,14 +14,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+@file:Suppress("TooManyFunctions")
+
 package org.meshtastic.core.ble
 
+import android.bluetooth.BluetoothGatt
 import co.touchlab.kermit.Logger
 import com.juul.kable.AndroidPeripheral
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
 import com.juul.kable.PooledThreadingStrategy
 import com.juul.kable.toIdentifier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+import java.util.Collections
+import java.util.IdentityHashMap
 
 /**
  * Shared thread pool for Kable BLE connections.
@@ -87,23 +96,127 @@ internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean {
         .getOrDefault(false)
 }
 
-internal actual fun Peripheral.refreshGattCache(): Boolean {
-    val androidPeripheral = this as? AndroidPeripheral ?: return false
+@Suppress("ReturnCount")
+internal actual fun Peripheral.refreshGattCache(connectionScope: CoroutineScope?): Boolean {
     return try {
-        // Kable's AndroidPeripheral wraps android.bluetooth.BluetoothGatt internally. BluetoothGatt.refresh() is a
-        // hidden framework API that clears the per-device service cache. This is necessary when a device reboots into
-        // a different GATT profile (e.g., ESP32 OTA loader) on the same BLE MAC — without it, discoverServices()
-        // returns the stale cached table in ~6ms instead of performing real over-the-air discovery.
-        val gattField =
-            AndroidPeripheral::class.java.declaredFields.firstOrNull {
-                it.type == android.bluetooth.BluetoothGatt::class.java
-            } ?: return false
-        gattField.isAccessible = true
-        val gatt = gattField.get(androidPeripheral) as? android.bluetooth.BluetoothGatt ?: return false
-        val refreshMethod = gatt.javaClass.getMethod("refresh")
-        refreshMethod.invoke(gatt) as? Boolean ?: false
+        // Kable stores BluetoothGatt on its internal Connection object, which is owned by AndroidPeripheral. The
+        // connection scope alone is only a coroutine wrapper in current Kable releases, so it is just a fallback
+        // diagnostic root here.
+        // If Kable exposes a public cache-refresh/invalidate API later, replace this reflection with that API.
+        val roots = gattSearchRoots(connectionScope)
+        val rootNames = roots.joinToString { it.javaClass.name }
+        val target = findBluetoothGatt(roots)
+        if (target == null) {
+            Logger.w {
+                "refreshGattCache: no BluetoothGatt field found from roots [$rootNames]; " +
+                    "androidPeripheral=${this is AndroidPeripheral}"
+            }
+            return false
+        }
+
+        val refreshMethod = target.gatt.javaClass.getMethod("refresh")
+        val result = refreshMethod.invoke(target.gatt) as? Boolean ?: false
+        Logger.i { "refreshGattCache: found BluetoothGatt on ${target.ownerClassName}; refresh() returned $result" }
+        result
     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
         Logger.w(e) { "refreshGattCache: failed to invoke BluetoothGatt.refresh()" }
         false
     }
+}
+
+private const val MAX_GATT_SEARCH_DEPTH = 2
+
+private data class GattSearchNode(val owner: Any, val depth: Int)
+
+private data class GattTarget(val gatt: BluetoothGatt, val ownerClassName: String)
+
+private fun Peripheral.gattSearchRoots(connectionScope: CoroutineScope?): List<Any> {
+    val roots = mutableListOf<Any>(this)
+    kableConnectionObject()?.let(roots::add)
+    connectionScope?.let(roots::add)
+    return roots
+}
+
+@Suppress("ReturnCount")
+private fun Peripheral.kableConnectionObject(): Any? {
+    invokeNoArgMethod("connectionOrThrow")?.let {
+        return it
+    }
+    val connectionHolder =
+        javaClass.allInstanceFields().firstOrNull { it.name == "connection" }?.readValue(this) ?: return null
+
+    return if (connectionHolder is StateFlow<*>) connectionHolder.value else connectionHolder
+}
+
+@Suppress("ReturnCount")
+private fun findBluetoothGatt(roots: List<Any>): GattTarget? {
+    val visited = Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
+    val queue = ArrayDeque<GattSearchNode>()
+    roots.forEach { queue.add(GattSearchNode(it, depth = 0)) }
+
+    while (queue.isNotEmpty()) {
+        val (owner, depth) = queue.removeFirst()
+        if (!visited.add(owner)) continue
+
+        if (owner is BluetoothGatt) return GattTarget(owner, owner.javaClass.name)
+
+        owner.javaClass.allInstanceFields().forEach { field ->
+            val value = field.readValue(owner) ?: return@forEach
+            if (value is BluetoothGatt) {
+                return GattTarget(value, owner.javaClass.name)
+            }
+            if (depth < MAX_GATT_SEARCH_DEPTH && shouldInspectGattOwner(value)) {
+                queue.add(GattSearchNode(value, depth + 1))
+            }
+        }
+    }
+
+    return null
+}
+
+private fun Any.invokeNoArgMethod(name: String): Any? = javaClass
+    .allDeclaredMethods()
+    .firstOrNull { it.name == name && it.parameterTypes.isEmpty() }
+    ?.runCatchingInvoke(this)
+
+private fun Class<*>.allInstanceFields(): Sequence<Field> = sequence {
+    var clazz: Class<*>? = this@allInstanceFields
+    while (clazz != null && clazz != Any::class.java) {
+        clazz.declaredFields.filterNot { Modifier.isStatic(it.modifiers) }.forEach { yield(it) }
+        clazz = clazz.superclass
+    }
+}
+
+private fun Class<*>.allDeclaredMethods() = sequence {
+    var clazz: Class<*>? = this@allDeclaredMethods
+    while (clazz != null && clazz != Any::class.java) {
+        clazz.declaredMethods.forEach { yield(it) }
+        clazz = clazz.superclass
+    }
+}
+
+private fun Field.readValue(owner: Any): Any? = runCatching {
+    isAccessible = true
+    get(owner)
+}
+    .getOrNull()
+
+private fun java.lang.reflect.Method.runCatchingInvoke(owner: Any): Any? = runCatching {
+    isAccessible = true
+    invoke(owner)
+}
+    .getOrNull()
+
+@Suppress("ReturnCount")
+private fun shouldInspectGattOwner(value: Any): Boolean {
+    val clazz = value.javaClass
+    if (clazz.isArray || clazz.isEnum) return false
+    if (value is String || value is Number || value is Boolean || value is Char) return false
+
+    val className = clazz.name
+    return !className.startsWith("android.") &&
+        !className.startsWith("java.") &&
+        !className.startsWith("javax.") &&
+        !className.startsWith("kotlin.") &&
+        !className.startsWith("kotlinx.coroutines.")
 }

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -27,10 +27,6 @@ import com.juul.kable.PooledThreadingStrategy
 import com.juul.kable.toIdentifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
-import java.util.Collections
-import java.util.IdentityHashMap
 
 /**
  * Shared thread pool for Kable BLE connections.
@@ -98,125 +94,59 @@ internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean {
 
 @Suppress("ReturnCount")
 internal actual fun Peripheral.refreshGattCache(connectionScope: CoroutineScope?): Boolean {
-    return try {
-        // Kable stores BluetoothGatt on its internal Connection object, which is owned by AndroidPeripheral. The
-        // connection scope alone is only a coroutine wrapper in current Kable releases, so it is just a fallback
-        // diagnostic root here.
-        // If Kable exposes a public cache-refresh/invalidate API later, replace this reflection with that API.
-        val roots = gattSearchRoots(connectionScope)
-        val rootNames = roots.joinToString { it.javaClass.name }
-        val target = findBluetoothGatt(roots)
-        if (target == null) {
-            Logger.w {
-                "refreshGattCache: no BluetoothGatt field found from roots [$rootNames]; " +
-                    "androidPeripheral=${this is AndroidPeripheral}"
+    // Direct 2-hop reflection on Kable 0.43.1 internals.
+    // Path: BluetoothDeviceAndroidPeripheral.connection (MutableStateFlow<Connection?>) → .value → Connection.gatt
+    // Re-verify field names on Kable version bumps.
+    val gatt =
+        extractBluetoothGatt()
+            ?: run {
+                Logger.w {
+                    "refreshGattCache: BluetoothGatt unreachable via Kable internals" + " (${this.javaClass.name})"
+                }
+                return false
             }
-            return false
-        }
-
-        val refreshMethod = target.gatt.javaClass.getMethod("refresh")
-        val result = refreshMethod.invoke(target.gatt) as? Boolean ?: false
-        Logger.i { "refreshGattCache: found BluetoothGatt on ${target.ownerClassName}; refresh() returned $result" }
+    return try {
+        val refreshMethod = gatt.javaClass.getMethod("refresh")
+        val result = refreshMethod.invoke(gatt) as? Boolean ?: false
+        Logger.i { "refreshGattCache: refresh() returned $result" }
         result
     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-        Logger.w(e) { "refreshGattCache: failed to invoke BluetoothGatt.refresh()" }
+        Logger.w(e) { "refreshGattCache: refresh() invocation failed" }
         false
     }
 }
 
-private const val MAX_GATT_SEARCH_DEPTH = 2
+/**
+ * Extracts the [BluetoothGatt] from Kable's internal object graph via a 2-hop field lookup.
+ *
+ * Hop 1: `Peripheral` → field `"connection"` (`MutableStateFlow<Connection?>`) → `.value` → `Connection` Hop 2:
+ * `Connection` → field `"gatt"` → `BluetoothGatt`
+ *
+ * Returns `null` if either hop fails (e.g., Kable internals changed between versions).
+ */
+@Suppress("ReturnCount")
+private fun Peripheral.extractBluetoothGatt(): BluetoothGatt? {
+    // Hop 1: Read "connection" field from the concrete Peripheral class (BluetoothDeviceAndroidPeripheral)
+    val connectionField = readDeclaredField("connection") ?: return null
+    val connectionStateFlow = connectionField as? StateFlow<*> ?: return null
+    val connection = connectionStateFlow.value ?: return null
 
-private data class GattSearchNode(val owner: Any, val depth: Int)
-
-private data class GattTarget(val gatt: BluetoothGatt, val ownerClassName: String)
-
-private fun Peripheral.gattSearchRoots(connectionScope: CoroutineScope?): List<Any> {
-    val roots = mutableListOf<Any>(this)
-    kableConnectionObject()?.let(roots::add)
-    connectionScope?.let(roots::add)
-    return roots
+    // Hop 2: Read "gatt" field from the Connection class
+    return connection.readDeclaredFieldAs<BluetoothGatt>("gatt")
 }
 
-@Suppress("ReturnCount")
-private fun Peripheral.kableConnectionObject(): Any? {
-    invokeNoArgMethod("connectionOrThrow")?.let {
-        return it
-    }
-    val connectionHolder =
-        javaClass.allInstanceFields().firstOrNull { it.name == "connection" }?.readValue(this) ?: return null
-
-    return if (connectionHolder is StateFlow<*>) connectionHolder.value else connectionHolder
-}
-
-@Suppress("ReturnCount")
-private fun findBluetoothGatt(roots: List<Any>): GattTarget? {
-    val visited = Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
-    val queue = ArrayDeque<GattSearchNode>()
-    roots.forEach { queue.add(GattSearchNode(it, depth = 0)) }
-
-    while (queue.isNotEmpty()) {
-        val (owner, depth) = queue.removeFirst()
-        if (!visited.add(owner)) continue
-
-        if (owner is BluetoothGatt) return GattTarget(owner, owner.javaClass.name)
-
-        owner.javaClass.allInstanceFields().forEach { field ->
-            val value = field.readValue(owner) ?: return@forEach
-            if (value is BluetoothGatt) {
-                return GattTarget(value, owner.javaClass.name)
-            }
-            if (depth < MAX_GATT_SEARCH_DEPTH && shouldInspectGattOwner(value)) {
-                queue.add(GattSearchNode(value, depth + 1))
-            }
+private fun Any.readDeclaredField(name: String): Any? {
+    var clazz: Class<*>? = javaClass
+    while (clazz != null && clazz != Any::class.java) {
+        try {
+            val field = clazz.getDeclaredField(name)
+            field.isAccessible = true
+            return field.get(this)
+        } catch (_: NoSuchFieldException) {
+            clazz = clazz.superclass
         }
     }
-
     return null
 }
 
-private fun Any.invokeNoArgMethod(name: String): Any? = javaClass
-    .allDeclaredMethods()
-    .firstOrNull { it.name == name && it.parameterTypes.isEmpty() }
-    ?.runCatchingInvoke(this)
-
-private fun Class<*>.allInstanceFields(): Sequence<Field> = sequence {
-    var clazz: Class<*>? = this@allInstanceFields
-    while (clazz != null && clazz != Any::class.java) {
-        clazz.declaredFields.filterNot { Modifier.isStatic(it.modifiers) }.forEach { yield(it) }
-        clazz = clazz.superclass
-    }
-}
-
-private fun Class<*>.allDeclaredMethods() = sequence {
-    var clazz: Class<*>? = this@allDeclaredMethods
-    while (clazz != null && clazz != Any::class.java) {
-        clazz.declaredMethods.forEach { yield(it) }
-        clazz = clazz.superclass
-    }
-}
-
-private fun Field.readValue(owner: Any): Any? = runCatching {
-    isAccessible = true
-    get(owner)
-}
-    .getOrNull()
-
-private fun java.lang.reflect.Method.runCatchingInvoke(owner: Any): Any? = runCatching {
-    isAccessible = true
-    invoke(owner)
-}
-    .getOrNull()
-
-@Suppress("ReturnCount")
-private fun shouldInspectGattOwner(value: Any): Boolean {
-    val clazz = value.javaClass
-    if (clazz.isArray || clazz.isEnum) return false
-    if (value is String || value is Number || value is Boolean || value is Char) return false
-
-    val className = clazz.name
-    return !className.startsWith("android.") &&
-        !className.startsWith("java.") &&
-        !className.startsWith("javax.") &&
-        !className.startsWith("kotlin.") &&
-        !className.startsWith("kotlinx.coroutines.")
-}
+private inline fun <reified T> Any.readDeclaredFieldAs(name: String): T? = readDeclaredField(name) as? T

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -86,3 +86,24 @@ internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean {
         .onFailure { Logger.w(it) { "requestConnectionPriority(Balanced) threw" } }
         .getOrDefault(false)
 }
+
+internal actual fun Peripheral.refreshGattCache(): Boolean {
+    val androidPeripheral = this as? AndroidPeripheral ?: return false
+    return try {
+        // Kable's AndroidPeripheral wraps android.bluetooth.BluetoothGatt internally. BluetoothGatt.refresh() is a
+        // hidden framework API that clears the per-device service cache. This is necessary when a device reboots into
+        // a different GATT profile (e.g., ESP32 OTA loader) on the same BLE MAC — without it, discoverServices()
+        // returns the stale cached table in ~6ms instead of performing real over-the-air discovery.
+        val gattField =
+            AndroidPeripheral::class.java.declaredFields.firstOrNull {
+                it.type == android.bluetooth.BluetoothGatt::class.java
+            } ?: return false
+        gattField.isAccessible = true
+        val gatt = gattField.get(androidPeripheral) as? android.bluetooth.BluetoothGatt ?: return false
+        val refreshMethod = gatt.javaClass.getMethod("refresh")
+        refreshMethod.invoke(gatt) as? Boolean ?: false
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Logger.w(e) { "refreshGattCache: failed to invoke BluetoothGatt.refresh()" }
+        false
+    }
+}

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleConnection.kt
@@ -89,6 +89,13 @@ interface BleConnection {
      * returns `false` for platforms that don't support it.
      */
     fun requestBalancedConnectionPriority(): Boolean = false
+
+    /**
+     * Clears the platform's cached GATT service table for the connected peripheral. Necessary when a device reboots
+     * into a different GATT profile (e.g., ESP32 OTA loader) on the same BLE MAC. Returns `true` if the cache was
+     * invalidated. Default implementation returns `false` for platforms without a service cache.
+     */
+    fun invalidateServiceCache(): Boolean = false
 }
 
 /** Represents a BLE service for commonMain. */

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleConnection.kt
@@ -106,6 +106,9 @@ interface BleService {
     /** Returns true when the characteristic is present on the connected device. */
     fun hasCharacteristic(characteristic: BleCharacteristic): Boolean
 
+    /** Returns the UUIDs of all characteristics discovered for this service. Empty for non-Kable platforms. */
+    fun discoveredCharacteristicUuids(): List<Uuid> = emptyList()
+
     /** Observes notifications/indications from the characteristic. */
     fun observe(characteristic: BleCharacteristic): Flow<ByteArray>
 

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -295,7 +295,7 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
 
     override fun requestBalancedConnectionPriority(): Boolean = peripheral?.requestBalancedConnectionPriority() == true
 
-    override fun invalidateServiceCache(): Boolean = peripheral?.refreshGattCache() == true
+    override fun invalidateServiceCache(): Boolean = peripheral?.refreshGattCache(connectionScope) == true
 
     /** Ensures the previous peripheral's GATT resources are fully released. */
     private suspend fun cleanUpPeripheral(tag: String) {

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -54,6 +54,11 @@ class KableBleService(private val peripheral: Peripheral, private val serviceUui
         svc.serviceUuid == serviceUuid && svc.characteristics.any { it.characteristicUuid == characteristic.uuid }
     } == true
 
+    override fun discoveredCharacteristicUuids(): List<Uuid> = peripheral.services.value
+        ?.find { it.serviceUuid == serviceUuid }
+        ?.characteristics
+        ?.map { it.characteristicUuid } ?: emptyList()
+
     override fun observe(characteristic: BleCharacteristic) =
         peripheral.observe(characteristicOf(serviceUuid, characteristic.uuid))
 

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -295,6 +295,8 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
 
     override fun requestBalancedConnectionPriority(): Boolean = peripheral?.requestBalancedConnectionPriority() == true
 
+    override fun invalidateServiceCache(): Boolean = peripheral?.refreshGattCache() == true
+
     /** Ensures the previous peripheral's GATT resources are fully released. */
     private suspend fun cleanUpPeripheral(tag: String) {
         withContext(NonCancellable) { safeClosePeripheral(tag) }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
+import kotlinx.coroutines.CoroutineScope
 
 /** Platform-specific configuration for the Peripheral builder based on device type. */
 internal expect fun PeripheralBuilder.platformConfig(device: BleDevice, autoConnect: () -> Boolean)
@@ -46,13 +47,15 @@ internal expect fun Peripheral.requestHighConnectionPriority(): Boolean
 internal expect fun Peripheral.requestBalancedConnectionPriority(): Boolean
 
 /**
- * Clears the platform's cached GATT service table for this peripheral.
+ * Clears the platform's cached GATT service table for the connected [Peripheral].
  *
- * Necessary when a device reboots into a different GATT profile (e.g., ESP32 OTA loader) using the same BLE MAC —
- * Android's BluetoothGatt caches services per address and returns the stale table on subsequent connections, causing
- * service discovery to report the old firmware's services instead of the new profile's.
+ * Kable keeps Android's `BluetoothGatt` on an internal connection object owned by the peripheral. This extension
+ * searches the peripheral and its active connection for that field, then invokes the hidden `refresh()` API to clear
+ * the per-device service cache.
+ *
+ * Necessary when a device reboots into a different GATT profile (e.g., ESP32 OTA loader) using the same BLE MAC.
  *
  * Returns `true` if the cache was invalidated. On platforms without a cache (JVM/iOS) this is a no-op returning
  * `false`.
  */
-internal expect fun Peripheral.refreshGattCache(): Boolean
+internal expect fun Peripheral.refreshGattCache(connectionScope: CoroutineScope?): Boolean

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -44,3 +44,15 @@ internal expect fun Peripheral.requestHighConnectionPriority(): Boolean
  * operations complete. On platforms without an equivalent API (JVM/iOS) this is a no-op.
  */
 internal expect fun Peripheral.requestBalancedConnectionPriority(): Boolean
+
+/**
+ * Clears the platform's cached GATT service table for this peripheral.
+ *
+ * Necessary when a device reboots into a different GATT profile (e.g., ESP32 OTA loader) using the same BLE MAC —
+ * Android's BluetoothGatt caches services per address and returns the stale table on subsequent connections, causing
+ * service discovery to report the old firmware's services instead of the new profile's.
+ *
+ * Returns `true` if the cache was invalidated. On platforms without a cache (JVM/iOS) this is a no-op returning
+ * `false`.
+ */
+internal expect fun Peripheral.refreshGattCache(): Boolean

--- a/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
+++ b/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
@@ -32,3 +32,5 @@ internal actual fun Peripheral.negotiatedMaxWriteLength(): Int? = null
 internal actual fun Peripheral.requestHighConnectionPriority(): Boolean = false
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean = false
+
+internal actual fun Peripheral.refreshGattCache(): Boolean = false

--- a/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
+++ b/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
@@ -33,4 +33,4 @@ internal actual fun Peripheral.requestHighConnectionPriority(): Boolean = false
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean = false
 
-internal actual fun Peripheral.refreshGattCache(): Boolean = false
+internal actual fun Peripheral.refreshGattCache(connectionScope: kotlinx.coroutines.CoroutineScope?): Boolean = false

--- a/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -35,4 +35,6 @@ internal actual fun Peripheral.requestHighConnectionPriority(): Boolean = false
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean = false
 
+internal actual fun Peripheral.refreshGattCache(): Boolean = false
+
 private const val DEFAULT_JVM_MTU = 512

--- a/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -35,6 +35,6 @@ internal actual fun Peripheral.requestHighConnectionPriority(): Boolean = false
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean = false
 
-internal actual fun Peripheral.refreshGattCache(): Boolean = false
+internal actual fun Peripheral.refreshGattCache(connectionScope: kotlinx.coroutines.CoroutineScope?): Boolean = false
 
 private const val DEFAULT_JVM_MTU = 512

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
@@ -134,7 +134,27 @@ class BleOtaTransport(
         val cacheInvalidated = bleConnection.invalidateServiceCache()
         Logger.d { "BLE OTA: GATT cache invalidation requested: $cacheInvalidated" }
         if (cacheInvalidated) {
-            Logger.i { "BLE OTA: Invalidated stale GATT service cache before OTA discovery" }
+            // Kable already discovered services during connect() before we could invalidate the cache.
+            // The stale radio-profile services are now in Kable's internal StateFlow. Force a fresh
+            // discovery by disconnecting and reconnecting — Android's GATT cache was cleared by refresh(),
+            // so the next connect will return the OTA loader's actual service table.
+            Logger.i { "BLE OTA: Reconnecting after GATT cache refresh to force service rediscovery" }
+            bleConnection.disconnect()
+            delay(RECONNECT_DELAY)
+            try {
+                val reconnectState = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
+                if (reconnectState is BleConnectionState.Disconnected) {
+                    Logger.w { "BLE OTA: Failed to reconnect after GATT cache refresh (state=$reconnectState)" }
+                    throw OtaProtocolException.ConnectionFailed("Failed to reconnect after GATT cache refresh")
+                }
+            } catch (e: TimeoutCancellationException) {
+                currentCoroutineContext().ensureActive()
+                Logger.w { "BLE OTA: Timed out reconnecting after GATT cache refresh. Error: ${e.message}" }
+                throw OtaProtocolException.Timeout("Timed out reconnecting after GATT cache refresh")
+            }
+            Logger.i { "BLE OTA: Reconnected after GATT cache refresh" }
+        } else {
+            Logger.w { "BLE OTA: GATT cache invalidation failed; proceeding with potentially stale service cache" }
         }
 
         Logger.i { "BLE OTA: Connected to OTA device, discovering services..." }
@@ -383,9 +403,17 @@ class BleOtaTransport(
         }
 
         if (missing.isNotEmpty()) {
+            val discovered = discoveredCharacteristicUuids()
+            val diagnostic =
+                if (discovered.isNotEmpty()) {
+                    " (discovered characteristics: $discovered)"
+                } else {
+                    " (no characteristics discovered for OTA service)"
+                }
             throw OtaProtocolException.ConnectionFailed(
                 "ESP32 OTA service was missing required characteristics after BLE service discovery: " +
-                    missing.joinToString(separator = "; "),
+                    missing.joinToString(separator = "; ") +
+                    diagnostic,
             )
         }
     }
@@ -397,6 +425,7 @@ class BleOtaTransport(
         private val ACK_TIMEOUT = 10.seconds
         private val VERIFICATION_TIMEOUT = 10.seconds
         private val REBOOT_DELAY = 5.seconds
+        private val RECONNECT_DELAY = 500.milliseconds
         const val RECOMMENDED_CHUNK_SIZE = 512
 
         /** Fallback write payload when the MTU has not been negotiated (23-byte ATT MTU minus the 3-byte header). */

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
@@ -131,6 +131,10 @@ class BleOtaTransport(
             throw OtaProtocolException.Timeout("Timed out connecting to OTA device")
         }
 
+        if (bleConnection.invalidateServiceCache()) {
+            Logger.i { "BLE OTA: Invalidated stale GATT service cache before OTA discovery" }
+        }
+
         Logger.i { "BLE OTA: Connected to OTA device, discovering services..." }
 
         try {

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
@@ -131,7 +131,9 @@ class BleOtaTransport(
             throw OtaProtocolException.Timeout("Timed out connecting to OTA device")
         }
 
-        if (bleConnection.invalidateServiceCache()) {
+        val cacheInvalidated = bleConnection.invalidateServiceCache()
+        Logger.d { "BLE OTA: GATT cache invalidation requested: $cacheInvalidated" }
+        if (cacheInvalidated) {
             Logger.i { "BLE OTA: Invalidated stale GATT service cache before OTA discovery" }
         }
 


### PR DESCRIPTION
## Summary by Sourcery

Invalidate cached BLE GATT services before starting OTA service discovery to ensure the correct profile is used.

New Features:
- Add a platform-abstracted API to invalidate the BLE GATT service cache from a connection scope and expose it on BleConnection for consumers like OTA.

Bug Fixes:
- Trigger GATT cache invalidation before OTA service discovery to prevent using stale services after a device reboots into a different GATT profile on the same MAC address.

Enhancements:
- Provide an Android-specific implementation that uses reflection on Kable's internal BluetoothGatt to call the hidden refresh API, while other platforms implement it as a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change adds a way to invalidate the cached BLE GATT service table before OTA service discovery. The goal is to avoid Android reusing a stale service list after a device reboots into OTA mode on the same BLE MAC address, which could otherwise cause OTA discovery to see the old mesh firmware profile instead of the OTA profile.

- Features
  - Added `BleConnection.invalidateServiceCache()` as a public API for requesting GATT cache invalidation.
  - Added a platform hook, `Peripheral.refreshGattCache(connectionScope)`, with Android, JVM, and iOS implementations.

- Fixes
  - OTA connection flow now invalidates the BLE GATT cache immediately after connecting and before service discovery.
  - Android implementation uses reflection to reach Kable’s underlying `BluetoothGatt` and call the hidden `refresh()` API.
  - Improved logging around cache refresh attempts and failures.
  - Non-Android platforms return `false` / no-op for cache invalidation.

- Refactors
  - Added helper logic in Android platform code to locate the active `BluetoothGatt` through reflective traversal of the connection object graph.
  - Extracted cache refresh behavior behind the shared `BleConnection` interface so callers like OTA can use it without platform-specific code.

- Breaking changes / migration
  - No breaking changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->