### PR TITLE
Classify Legacy DFU Write Disconnect Races by BLE Connection State

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuProtocol.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuProtocol.kt
@@ -18,6 +18,7 @@
 
 package org.meshtastic.feature.firmware.ota.dfu
 
+import org.meshtastic.core.ble.BleConnectionState
 import kotlin.uuid.Uuid
 
 // ---------------------------------------------------------------------------
@@ -258,15 +259,24 @@ sealed class LegacyDfuException(message: String, cause: Throwable? = null) : Dfu
      * PRN-confirmed checkpoint (the last byte the bootloader explicitly acknowledged); `-1` means no PRN was received
      * before the drop. Do not treat [bytesSent] as confirmed device progress.
      *
+     * [connectionState] is the typed [BleConnectionState] observed at the moment of the drop (always
+     * [BleConnectionState.Disconnected]); the message renders it via `toString()` only for human-readable logging.
+     *
+     * The optional [cause] carries the underlying operational write exception when classification was triggered by a
+     * failed BLE write on an already-disconnected link. Watcher-originated disconnects (where the state-flow watcher
+     * detected the drop independently) may have no cause.
+     *
      * Typed — callers must NOT parse the message to detect a mid-stream drop.
      */
     class MidStreamDisconnect(
         val bytesSent: Int,
         val totalBytes: Int,
-        val connectionState: String,
+        val connectionState: BleConnectionState,
         val lastConfirmedBytes: Int,
+        cause: Throwable? = null,
     ) : LegacyDfuException(
         "BLE link dropped mid-upload at host in-flight offset $bytesSent/$totalBytes " +
             "(lastConfirmed=$lastConfirmedBytes, state=$connectionState)",
+        cause,
     )
 }

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransport.kt
@@ -349,13 +349,12 @@ internal constructor(
                 LegacyDfuException.MidStreamDisconnect(
                     bytesSent = streamOffset,
                     totalBytes = firmware.size,
-                    connectionState = state.toString(),
+                    connectionState = state,
                     lastConfirmedBytes = streamLastPrnOffset,
                 )
             },
         ) {
             var packetsSincePrn = 0
-            var bytesAtLastPrn = 0L
             bleConnection.profile(LegacyDfuUuids.SERVICE, timeout = STREAM_TIMEOUT) { service ->
                 val packetChar = service.characteristic(LEGACY_DFU_PACKET_UUID)
                 while (streamOffset < firmware.size) {
@@ -374,9 +373,26 @@ internal constructor(
                             "Legacy DFU: Write CANCELLED at offset $streamOffset/${firmware.size} cause=${e.cause}"
                         }
                         throw e
-                    } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+                    } catch (e: Exception) {
+                        // The outer stream tripwire watches `connectionState` for Disconnected, but `service.write()`
+                        // can throw BEFORE the state-flow watcher processes the Disconnected emission. In that ordering
+                        // the raw write exception would escape without typed MidStreamDisconnect classification, so
+                        // later retries would not switch to the RECOVERY profile. Re-check the typed state here: if the
+                        // link is already Disconnected, classify as MidStreamDisconnect so the retry coordinator can
+                        // react. Error subtypes are NOT caught here — they propagate unchanged.
+                        val state = bleConnection.connectionState.value
+                        if (state is BleConnectionState.Disconnected) {
+                            throw LegacyDfuException.MidStreamDisconnect(
+                                bytesSent = streamOffset,
+                                totalBytes = firmware.size,
+                                connectionState = state,
+                                lastConfirmedBytes = streamLastPrnOffset,
+                                cause = e,
+                            )
+                        }
                         Logger.w(e) {
-                            "Legacy DFU: Write FAILED at offset $streamOffset/${firmware.size}: ${e.message}"
+                            "Legacy DFU: Write FAILED for chunk ending at host in-flight offset $streamOffset/" +
+                                "${firmware.size}: ${e.message}"
                         }
                         throw e
                     }
@@ -412,13 +428,12 @@ internal constructor(
                         // not be reported as the last successful checkpoint in the link-drop log.
                         streamLastPrnOffset = streamOffset
                         streamLastPrnLatencyMs = latencyMs
-                        bytesAtLastPrn = receipt.bytesReceived
                         packetsSincePrn = 0
                         onProgress(streamOffset.toFloat() / firmware.size)
                     }
                 }
             }
-            Logger.d { "Legacy DFU: Streamed $streamOffset/${firmware.size} bytes (lastPRN=$bytesAtLastPrn)" }
+            Logger.d { "Legacy DFU: Streamed $streamOffset/${firmware.size} bytes (lastPRN=$streamLastPrnOffset)" }
         }
     }
 

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuRetryPolicyTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuRetryPolicyTest.kt
@@ -19,6 +19,7 @@
 package org.meshtastic.feature.firmware.ota.dfu
 
 import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.ble.BleConnectionState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -61,7 +62,7 @@ class LegacyDfuRetryPolicyTest {
                                 LegacyDfuException.MidStreamDisconnect(
                                     20,
                                     200,
-                                    "Disconnected",
+                                    BleConnectionState.Disconnected(),
                                     lastConfirmedBytes = -1,
                                 ),
                                 false,
@@ -111,7 +112,7 @@ class LegacyDfuRetryPolicyTest {
                                 LegacyDfuException.MidStreamDisconnect(
                                     20,
                                     200,
-                                    "Disconnected",
+                                    BleConnectionState.Disconnected(),
                                     lastConfirmedBytes = -1,
                                 ),
                                 false,
@@ -245,7 +246,12 @@ class LegacyDfuRetryPolicyTest {
 
                     2 ->
                         DfuUploadResult.Failure(
-                            LegacyDfuException.MidStreamDisconnect(20, 200, "Disconnected", lastConfirmedBytes = -1),
+                            LegacyDfuException.MidStreamDisconnect(
+                                20,
+                                200,
+                                BleConnectionState.Disconnected(),
+                                lastConfirmedBytes = -1,
+                            ),
                             false,
                         )
 
@@ -308,7 +314,7 @@ class LegacyDfuRetryPolicyTest {
                                 LegacyDfuException.MidStreamDisconnect(
                                     50,
                                     200,
-                                    "Disconnected",
+                                    BleConnectionState.Disconnected(),
                                     lastConfirmedBytes = -1,
                                 ),
                                 false,
@@ -425,7 +431,12 @@ class LegacyDfuRetryPolicyTest {
                     if (sessions.size == 1) {
                         // First attempt: engages, then drops mid-stream.
                         DfuUploadResult.Failure(
-                            LegacyDfuException.MidStreamDisconnect(50, 200, "Disconnected", lastConfirmedBytes = -1),
+                            LegacyDfuException.MidStreamDisconnect(
+                                50,
+                                200,
+                                BleConnectionState.Disconnected(),
+                                lastConfirmedBytes = -1,
+                            ),
                             true,
                         )
                     } else {
@@ -465,7 +476,7 @@ class LegacyDfuRetryPolicyTest {
                                 LegacyDfuException.MidStreamDisconnect(
                                     50,
                                     200,
-                                    "Disconnected",
+                                    BleConnectionState.Disconnected(),
                                     lastConfirmedBytes = -1,
                                 ),
                                 true,
@@ -607,7 +618,13 @@ class LegacyDfuRetryPolicyTest {
         cleanupDfuSessionTransport(
             transport,
             completed = false,
-            sessionFailure = LegacyDfuException.MidStreamDisconnect(20, 200, "Disconnected", lastConfirmedBytes = -1),
+            sessionFailure =
+            LegacyDfuException.MidStreamDisconnect(
+                20,
+                200,
+                BleConnectionState.Disconnected(),
+                lastConfirmedBytes = -1,
+            ),
         )
         assertFalse(transport.abortCalled, "abort must be skipped after MidStreamDisconnect")
         assertTrue(transport.closeCalled, "close must always run")

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/dfu/LegacyDfuTransportTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -49,6 +50,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 
@@ -378,14 +380,19 @@ class LegacyDfuTransportTest {
     private suspend fun createConnectedTransport(
         mtu: Int? = null,
         profile: LegacyDfuStreamProfile = LegacyDfuStreamProfile.NORMAL,
+        suppressDisconnectEmissions: Boolean = false,
     ): TestEnv {
         val scanner = FakeBleScanner()
         val fakeConnection = FakeBleConnection().apply { maxWriteValueLength = mtu }
         val autoService = AutoRespondingLegacyService(fakeConnection.service)
-        val wrappedConnection = AutoRespondingBleConnection(fakeConnection, autoService)
         val factory =
             object : BleConnectionFactory {
-                override fun create(scope: CoroutineScope, tag: String): BleConnection = wrappedConnection
+                override fun create(scope: CoroutineScope, tag: String): BleConnection = AutoRespondingBleConnection(
+                    delegate = fakeConnection,
+                    autoService = autoService,
+                    profileScope = scope,
+                    suppressDisconnectEmissions = suppressDisconnectEmissions,
+                )
             }
         val transport = LegacyDfuTransport(scanner, factory, address, Dispatchers.Unconfined, profile)
 
@@ -630,10 +637,35 @@ class LegacyDfuTransportTest {
             byteArrayOf(LegacyDfuOpcode.RESPONSE_CODE, opcode, LegacyDfuStatus.SUCCESS)
     }
 
+    /**
+     * [StateFlow] wrapper that exposes the delegate's [value][StateFlow.value] but filters
+     * [BleConnectionState.Disconnected] emissions from collectors. Used by the write-throws-on-disconnect race tests:
+     * the outer stream tripwire's `connectionState.first { Disconnected }` watcher stays suspended (modelling the race
+     * where the write throws before the watcher processes the emission), while `bleConnection.connectionState.value`
+     * still reads as Disconnected for the write-catch classification.
+     */
+    private class DisconnectEmissionsSuppressedStateFlow(private val delegate: StateFlow<BleConnectionState>) :
+        StateFlow<BleConnectionState> {
+        override val value: BleConnectionState
+            get() = delegate.value
+
+        override val replayCache: List<BleConnectionState>
+            get() = delegate.replayCache
+
+        override suspend fun collect(collector: FlowCollector<BleConnectionState>): Nothing {
+            delegate.collect { state ->
+                if (state is BleConnectionState.Disconnected) return@collect
+                collector.emit(state)
+            }
+        }
+    }
+
     /** BleConnection wrapper that swaps in the auto-responding service for `profile()` calls. */
     private class AutoRespondingBleConnection(
         private val delegate: FakeBleConnection,
         val autoService: AutoRespondingLegacyService,
+        private val profileScope: CoroutineScope,
+        suppressDisconnectEmissions: Boolean = false,
     ) : BleConnection {
         override val device: BleDevice?
             get() = delegate.device
@@ -641,8 +673,12 @@ class LegacyDfuTransportTest {
         override val deviceFlow: StateFlow<BleDevice?>
             get() = delegate.deviceFlow
 
-        override val connectionState: StateFlow<BleConnectionState>
-            get() = delegate.connectionState
+        override val connectionState: StateFlow<BleConnectionState> =
+            if (suppressDisconnectEmissions) {
+                DisconnectEmissionsSuppressedStateFlow(delegate.connectionState)
+            } else {
+                delegate.connectionState
+            }
 
         override suspend fun connect(device: BleDevice) = delegate.connect(device)
 
@@ -655,7 +691,7 @@ class LegacyDfuTransportTest {
             serviceUuid: kotlin.uuid.Uuid,
             timeout: Duration,
             setup: suspend CoroutineScope.(BleService) -> T,
-        ): T = CoroutineScope(Dispatchers.Unconfined).setup(autoService)
+        ): T = profileScope.setup(autoService)
 
         override fun maximumWriteValueLength(writeType: BleWriteType): Int? =
             delegate.maximumWriteValueLength(writeType)
@@ -770,7 +806,7 @@ class LegacyDfuTransportTest {
         assertEquals(200, error.totalBytes)
         // No PRN was received before the drop (first PRN would be at byte 200), so lastConfirmedBytes is -1.
         assertEquals(-1, error.lastConfirmedBytes)
-        assertTrue(error.connectionState.isNotBlank())
+        assertIs<BleConnectionState.Disconnected>(error.connectionState)
     }
 
     /**
@@ -815,6 +851,75 @@ class LegacyDfuTransportTest {
         assertEquals(220, ex.totalBytes)
     }
 
+    /**
+     * Race: `service.write()` throws BEFORE the outer stream tripwire's state-flow watcher processes the Disconnected
+     * emission. The write-catch re-check must classify the disconnect as [LegacyDfuException.MidStreamDisconnect] so
+     * the retry coordinator can switch to the RECOVERY profile — the raw write exception must NOT escape.
+     *
+     * [DisconnectEmissionsSuppressedStateFlow] models the race window: the tripwire watcher never sees Disconnected
+     * (its collector filters it), while `connectionState.value` still reads as Disconnected for the write-catch.
+     */
+    @Test
+    fun `failed write with disconnected connection classifies as MidStreamDisconnect`() = runTest {
+        val env = createConnectedTransport(suppressDisconnectEmissions = true)
+        env.responder.scheme = LegacyResponderScheme.HappyPath
+
+        val writeFailure = RuntimeException("simulated write failure on dead link")
+        env.responder.onFirmwarePacketWrite = { bytes ->
+            if (bytes >= 20L) {
+                env.connection.simulateRemoteDisconnect()
+                throw writeFailure
+            }
+        }
+
+        env.transport.transferInitPacket(ByteArray(14)).getOrThrow()
+        val result = env.transport.transferFirmware(ByteArray(200)) {}
+
+        val error =
+            assertIs<LegacyDfuException.MidStreamDisconnect>(
+                result.exceptionOrNull(),
+                "expected the write-catch to classify the disconnect that beat the tripwire watcher",
+            )
+        // streamOffset was published as 20 before the first firmware-packet write, so bytesSent == 20.
+        assertEquals(20, error.bytesSent)
+        assertEquals(200, error.totalBytes)
+        // No PRN was received before the drop (first PRN would be at byte 200), so lastConfirmedBytes is -1.
+        assertEquals(-1, error.lastConfirmedBytes)
+        assertIs<BleConnectionState.Disconnected>(error.connectionState)
+        assertSame(writeFailure, error.cause)
+    }
+
+    /**
+     * When the link is still Connected, a failed write must NOT be reclassified as
+     * [LegacyDfuException.MidStreamDisconnect] — the original exception must escape unchanged so the caller can react
+     * to the real cause instead of mistaking it for a link drop.
+     */
+    @Test
+    fun `failed write with active connection is not reclassified`() = runTest {
+        val env = createConnectedTransport()
+        env.responder.scheme = LegacyResponderScheme.HappyPath
+
+        val writeFailure = RuntimeException("simulated write failure on live link")
+        env.responder.onFirmwarePacketWrite = { bytes ->
+            if (bytes >= 20L) {
+                throw writeFailure
+            }
+        }
+
+        env.transport.transferInitPacket(ByteArray(14)).getOrThrow()
+        val result = env.transport.transferFirmware(ByteArray(200)) {}
+
+        // The write failure must NOT be classified as MidStreamDisconnect while the connection is active.
+        // assertIs<RuntimeException> proves it was not reclassified; message equality confirms it's the
+        // same failure (coroutine stack-trace recovery may copy the exception across coroutineScope boundaries).
+        val error =
+            assertIs<RuntimeException>(
+                result.exceptionOrNull(),
+                "a write failure on an active connection must not become MidStreamDisconnect",
+            )
+        assertEquals(writeFailure.message, error.message)
+    }
+
     // -----------------------------------------------------------------------
     // Bounded RESET (abort)
     // -----------------------------------------------------------------------
@@ -830,7 +935,7 @@ class LegacyDfuTransportTest {
     }
 
     @Test
-    fun `acknowledged RESET completes and logs acknowledgement`() = runTest {
+    fun `acknowledged RESET completes after response`() = runTest {
         val env = createConnectedTransport()
 
         env.transport.abort()


### PR DESCRIPTION


## Summary by Sourcery

Classify legacy DFU mid-stream write failures based on the BLE connection state and propagate richer disconnect context through the DFU pipeline.

Bug Fixes:
- Ensure firmware write failures on already-disconnected BLE links are reclassified as MidStreamDisconnect so retry logic can switch to the recovery profile.
- Ensure write failures on active BLE connections are not misclassified as MidStreamDisconnect and instead surface the original exception.

Enhancements:
- Add a state-flow wrapper and connection wrapper options to model disconnect emission races during DFU tests.
- Change MidStreamDisconnect to carry the typed BleConnectionState and optional underlying cause for more precise logging and handling.
- Refine DFU streaming logs to report the last PRN-confirmed offset using the existing stream tracking state.

Tests:
- Extend legacy DFU transport and retry policy tests to cover disconnect/write race conditions and verify correct MidStreamDisconnect classification and non-classification paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves Legacy DFU disconnect handling by classifying mid-stream write failures based on the BLE connection state at the time of failure (including a disconnect/write race where the disconnect emission may not yet have been observed), while preserving the original write exception for diagnostics. It also adds/adjusts unit tests to cover both disconnected and still-connected outcomes deterministically.

- **Fixes**
  - Reclassifies firmware stream `service.write(...)` failures as `LegacyDfuException.MidStreamDisconnect` when the BLE link is already `BleConnectionState.Disconnected` (even if the disconnect watcher hasn’t processed the emission yet).
  - Preserves the original write exception as the `cause` when reclassifying as `MidStreamDisconnect`.
  - Keeps the original exception when the BLE connection is still active (no reclassification in that case).
  - Updates streaming diagnostics to report the correct final PRN (`lastPRN`) and removes the incorrect/duplicate PRN tracking.

- **Features**
  - Changes `LegacyDfuException.MidStreamDisconnect` to store a typed `BleConnectionState` instead of a `String`.
  - Updates `MidStreamDisconnect` documentation to clarify that the stored value is the typed BLE connection state observed at disconnect time and that callers must not parse exception messages to detect mid-stream disconnects.

- **Refactors / Test changes**
  - Tightens write error handling to catch `Exception` (rather than `Throwable`) and re-reads the BLE connection state to classify the disconnect race.
  - Removes separate `bytesAtLastPrn` tracking.
  - Enhances test infrastructure with a `DisconnectEmissionsSuppressedStateFlow` and a `suppressDisconnectEmissions` option to deterministically model the disconnect/write race.
  - Adds race-focused tests validating `MidStreamDisconnect` fields (byte counts, `lastConfirmedBytes`, `BleConnectionState.Disconnected`, and `cause` identity via `assertSame`) plus the non-reclassified still-connected companion test.
  - Updates related tests to use typed `BleConnectionState.Disconnected()` instead of the `"Disconnected"` string, and adjusts one RESET test name to reflect completion-after-response semantics.
  - Adjusts `AutoRespondingBleConnection.profile()` to use the provided `profileScope` for `setup`.

- **Breaking changes / migration**
  - `LegacyDfuException.MidStreamDisconnect` constructor signature changed: callers must now pass `BleConnectionState` instead of a `String`.
  - Callers should rely on the typed `connectionState` field rather than parsing the exception message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->