### PR TITLE
Add key rotation migration and radio transport suspension for OTA updates

### DIFF
--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -287,6 +287,9 @@ interface NodeInfoDao {
     @Query("DELETE FROM metadata WHERE num=:num")
     suspend fun deleteMetadata(num: Int)
 
+    @Query("SELECT * FROM metadata WHERE num=:num LIMIT 1")
+    suspend fun getMetadataByNum(num: Int): MetadataEntity?
+
     /** Snapshot used by DatabaseMerger to carry per-node DeviceMetadata across transports (newest timestamp wins). */
     @Query("SELECT * FROM metadata")
     suspend fun getAllMetadataSnapshot(): List<MetadataEntity>
@@ -404,7 +407,84 @@ interface NodeInfoDao {
     suspend fun installConfig(mi: MyNodeEntity, nodes: List<NodeEntity>) {
         clearMyNodeInfo()
         setMyNodeInfo(mi)
-        putAll(getVerifiedNodesForUpsert(nodes))
+
+        // Authoritative local-node migration: firmware 2.7→2.8 can regenerate the public key from an
+        // unchanged private key and then unconditionally call createNewIdentity(), which changes the
+        // node's NodeNum while keeping the same 32-byte public key. Without this branch, the general
+        // duplicate-public-key protection in getVerifiedNodesForUpsert would retain the old conflicting
+        // row and MyNodeInfo would name a node number with no matching row in the node table.
+        //
+        // Runs before the batch-validated putAll so that, on a successful migration, the new local row is
+        // inserted directly and the incoming local node is excluded from the batch pass; remote nodes and
+        // the ordinary update path are untouched when the conditions do not match.
+        val localNode = nodes.firstOrNull { it.num == mi.myNodeNum }
+        val remaining =
+            if (localNode != null && migrateLocalNodeForKeyRotation(localNode, mi)) {
+                nodes - localNode
+            } else {
+                nodes
+            }
+        putAll(getVerifiedNodesForUpsert(remaining))
+    }
+
+    /**
+     * Migrates an authoritative local node whose node number changed while retaining its public key (firmware 2.7→2.8
+     * createNewIdentity() path). Returns true when a migration was performed, in which case the caller MUST exclude
+     * [incomingLocal] from the subsequent batch validation pass.
+     *
+     * Migration runs (and only runs) when ALL of:
+     * - the incoming local node carries a full non-empty (KEY_SIZE-byte) public key;
+     * - there is no existing node row under the new local number [mi.myNodeNum];
+     * - exactly one existing row has the same public key under a different node number.
+     *
+     * Within this same Room transaction the old row and its DeviceMetadata (if any) are removed, a new local row is
+     * inserted under [mi.myNodeNum] built from the incoming firmware data while preserving the app-local fields
+     * (isFavorite, notes, powerChannelLabels, manuallyVerified), and the metadata is re-keyed to the new node number.
+     * Incoming values are authoritative for current firmware/network state including is_ignored and is_muted.
+     *
+     * This also repairs an already-broken database in which MyNodeInfo was already advanced to the new number while the
+     * node table still contained only the old public-key-matching row: at installConfig time mi is already stored, so
+     * the only state we observe is "no row under mi.myNodeNum + one row under a different num with the same key" — the
+     * same shape as a fresh transition.
+     */
+    @Suppress("ReturnCount")
+    private suspend fun migrateLocalNodeForKeyRotation(incomingLocal: NodeEntity, mi: MyNodeEntity): Boolean {
+        val incomingKey = incomingLocal.user.public_key
+        if (incomingKey.size != KEY_SIZE) return false
+        if (getNodeByNum(mi.myNodeNum) != null) return false
+
+        val keyMatches = findNodesByPublicKeys(listOf(incomingKey)).filter { it.num != mi.myNodeNum }
+        if (keyMatches.size != 1) return false
+
+        val oldRow = keyMatches.first()
+        val oldMetadata = getMetadataByNum(oldRow.num)
+
+        // Populate denormalized publicKey / name columns from the incoming firmware data, mirroring the
+        // batch-validation path so the new row's searchable columns are consistent.
+        val newLocalRow =
+            incomingLocal.copy(
+                num = mi.myNodeNum,
+                publicKey = incomingKey,
+                longName =
+                if (incomingLocal.user.hw_model != HardwareModel.UNSET) incomingLocal.user.long_name else null,
+                shortName =
+                if (incomingLocal.user.hw_model != HardwareModel.UNSET) incomingLocal.user.short_name else null,
+                // Preserve app-local fields that the firmware cannot repopulate.
+                isFavorite = oldRow.isFavorite,
+                notes = oldRow.notes,
+                powerChannelLabels = oldRow.powerChannelLabels,
+                manuallyVerified = oldRow.manuallyVerified,
+                // Incoming values are authoritative for current firmware/network state. isIgnored and isMuted
+                // default from incomingLocal (its user-supplied defaults), which matches the spec.
+            )
+
+        deleteNode(oldRow.num)
+        if (oldMetadata != null) {
+            deleteMetadata(oldRow.num)
+            upsert(oldMetadata.copy(num = mi.myNodeNum))
+        }
+        doUpsert(newLocalRow)
+        return true
     }
 
     /**

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonNodeInfoDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonNodeInfoDaoTest.kt
@@ -18,17 +18,22 @@ package org.meshtastic.core.database.dao
 
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.database.MeshtasticDatabase
+import org.meshtastic.core.database.entity.DeviceMetadata
+import org.meshtastic.core.database.entity.MetadataEntity
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.NodeEntity
 import org.meshtastic.core.database.getInMemoryDatabaseBuilder
 import org.meshtastic.core.testing.setupTestContext
+import org.meshtastic.proto.HardwareModel
 import org.meshtastic.proto.User
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 abstract class CommonNodeInfoDaoTest {
@@ -118,5 +123,258 @@ abstract class CommonNodeInfoDaoTest {
         val nodes = dao.nodeDBbyNum().first()
         assertEquals(1, nodes.size)
         assertTrue(nodes.containsKey(1))
+    }
+
+    // ── Local-node-key-rotation migration (firmware 2.7→2.8) ───────────────
+
+    /**
+     * Builds a 32-byte [okio.ByteString] distinct per [seed] so tests can give different nodes different keys (or share
+     * a key) without accidental collisions.
+     */
+    private fun fullPublicKey(seed: Byte) = ByteArray(NodeInfoDao.KEY_SIZE) { seed }.toByteString()
+
+    private fun myNodeEntityFor(num: Int) = MyNodeEntity(
+        myNodeNum = num,
+        model = "TBEAM",
+        firmwareVersion = "2.8.0",
+        couldUpdate = false,
+        shouldUpdate = false,
+        currentPacketId = 1L,
+        messageTimeoutMsec = 300000,
+        minAppVersion = 1,
+        maxChannels = 8,
+        hasWifi = false,
+    )
+
+    private fun localIncomingNode(num: Int, publicKey: okio.ByteString) = NodeEntity(
+        num = num,
+        user =
+        User(
+            id = "!local",
+            long_name = "Local Node",
+            short_name = "LOC",
+            hw_model = HardwareModel.TBEAM,
+            public_key = publicKey,
+        ),
+        lastHeard = (nowMillis / 1000).toInt(),
+    )
+
+    /**
+     * Migration scenario: firmware 2.7→2.8 transition reports the same physical local node with a new node number, the
+     * same 32-byte public key, and an existing row under the old number. installConfig must migrate the row to the new
+     * number, preserve app-local fields, move metadata, retain unrelated remote rows, and store the new MyNodeInfo.
+     */
+    @Test
+    fun testLocalNodeKeyRotationMigratesRowAndPreservesAppLocalFields() = runTest {
+        createDb()
+
+        val oldNum = 42424242
+        val newNum = 42424243
+        val sharedKey = fullPublicKey(seed = 0x42)
+
+        // Old local row under oldNum carrying app-local fields the firmware cannot repopulate.
+        // publicKey is set explicitly because putAll bypasses the validation path that would otherwise
+        // copy user.public_key into the denormalized public_key column.
+        val oldRow =
+            NodeEntity(
+                num = oldNum,
+                user =
+                User(
+                    id = "!old",
+                    long_name = "Old Local",
+                    short_name = "OLD",
+                    hw_model = HardwareModel.TBEAM,
+                    public_key = sharedKey,
+                ),
+                publicKey = sharedKey,
+                longName = "Old Local",
+                shortName = "OLD",
+                isFavorite = true,
+                notes = "field-notes",
+                powerChannelLabels = listOf("ch0", "ch1"),
+                manuallyVerified = true,
+                isIgnored = false,
+                isMuted = false,
+            )
+        dao.putAll(listOf(oldRow))
+        dao.upsert(MetadataEntity(num = oldNum, proto = DeviceMetadata(firmware_version = "2.7.0"), timestamp = 1L))
+
+        // Unrelated remote row that must be retained verbatim.
+        val remoteNum = 555
+        val remoteNode =
+            NodeEntity(
+                num = remoteNum,
+                user = User(id = "!remote", long_name = "Remote", short_name = "REM", hw_model = HardwareModel.TBEAM),
+            )
+        dao.putAll(listOf(remoteNode))
+
+        val newMi = myNodeEntityFor(newNum)
+        val incomingLocal = localIncomingNode(newNum, sharedKey).copy(isIgnored = true, isMuted = true)
+        dao.installConfig(newMi, listOf(incomingLocal, remoteNode))
+
+        // Old row removed, new row inserted under newNum.
+        assertNull(dao.getNodeByNum(oldNum), "Old local row must be removed")
+        val migrated = dao.getNodeByNum(newNum)
+        assertNotNull(migrated, "New local row must be inserted under the new node number")
+        assertEquals("Local Node", migrated.node.longName)
+        assertEquals(sharedKey, migrated.node.publicKey)
+
+        // App-local fields preserved from the old row.
+        assertTrue(migrated.node.isFavorite, "isFavorite must be preserved from the old row")
+        assertEquals("field-notes", migrated.node.notes, "notes must be preserved from the old row")
+        assertEquals(listOf("ch0", "ch1"), migrated.node.powerChannelLabels, "powerChannelLabels must be preserved")
+        assertTrue(migrated.node.manuallyVerified, "manuallyVerified must be preserved from the old row")
+
+        // Incoming values are authoritative for current firmware/network state including ignored/muted.
+        assertTrue(migrated.node.isIgnored, "Incoming isIgnored value must be authoritative")
+        assertTrue(migrated.node.isMuted, "Incoming isMuted value must be authoritative")
+
+        // Metadata moved from old to new number.
+        assertNull(dao.getMetadataByNum(oldNum), "Old metadata must be removed")
+        val movedMeta = dao.getMetadataByNum(newNum)
+        assertNotNull(movedMeta, "Metadata must be re-keyed to the new node number")
+        assertEquals("2.7.0", movedMeta.proto.firmware_version)
+
+        // Unrelated remote retained.
+        val retainedRemote = dao.getNodeByNum(remoteNum)
+        assertNotNull(retainedRemote, "Unrelated remote node must be retained")
+        assertEquals("Remote", retainedRemote.node.longName)
+
+        // MyNodeInfo now names the new number.
+        assertEquals(newNum, dao.getMyNodeInfo().first()?.myNodeNum)
+    }
+
+    /** Migration also repairs an already-broken DB where MyNodeInfo was already advanced to the new number. */
+    @Test
+    fun testLocalNodeKeyRotationRepairsAlreadyAdvancedMyNodeInfo() = runTest {
+        createDb()
+
+        val oldNum = 42424242
+        val newNum = 99999999
+        val sharedKey = fullPublicKey(seed = 0x11)
+
+        dao.putAll(
+            listOf(
+                NodeEntity(
+                    num = oldNum,
+                    user =
+                    User(
+                        id = "!old",
+                        long_name = "Old",
+                        short_name = "OLD",
+                        hw_model = HardwareModel.TBEAM,
+                        public_key = sharedKey,
+                    ),
+                    publicKey = sharedKey,
+                    longName = "Old",
+                    shortName = "OLD",
+                    isFavorite = true,
+                    manuallyVerified = true,
+                ),
+            ),
+        )
+        // Simulate the broken state: MyNodeInfo already advanced to the new number while the node table
+        // still contains only the old public-key-matching row.
+        dao.clearMyNodeInfo()
+        dao.setMyNodeInfo(myNodeEntityFor(newNum))
+
+        val newMi = myNodeEntityFor(newNum)
+        dao.installConfig(newMi, listOf(localIncomingNode(newNum, sharedKey)))
+
+        assertNull(dao.getNodeByNum(oldNum), "Old row must still be removed when repairing the broken DB state")
+        val migrated = dao.getNodeByNum(newNum)
+        assertNotNull(migrated, "New local row must be inserted even when MyNodeInfo was already advanced")
+        assertTrue(migrated.node.isFavorite, "App-local fields must still be preserved during repair")
+        assertTrue(migrated.node.manuallyVerified, "App-local fields must still be preserved during repair")
+        assertEquals(newNum, dao.getMyNodeInfo().first()?.myNodeNum)
+    }
+
+    /**
+     * Duplicate public keys on non-local nodes must keep using the existing security behavior — the incoming local node
+     * with its own distinct key is migrated (or inserted) without being mistaken for either conflicting remote, and the
+     * conflict-protection path runs normally on the remote batch.
+     */
+    @Test
+    fun testDuplicatePublicKeysOnRemoteNodesDoesNotTriggerLocalMigration() = runTest {
+        createDb()
+
+        val localNum = 42424242
+        val localKey = fullPublicKey(seed = 0x01)
+        val sharedRemoteKey = fullPublicKey(seed = 0x02)
+
+        // Two existing REMOTE rows that share a public key — pure duplicate-key remote conflict, NOT a
+        // local-node rotation. The local-node migration conditions must not match: the incoming local
+        // node's key (localKey) does not collide with any row.
+        dao.putAll(
+            listOf(
+                NodeEntity(
+                    num = 700,
+                    user = User(id = "!r1", long_name = "R1", short_name = "R1", public_key = sharedRemoteKey),
+                    publicKey = sharedRemoteKey,
+                    longName = "R1",
+                    shortName = "R1",
+                ),
+                NodeEntity(
+                    num = 701,
+                    user = User(id = "!r2", long_name = "R2", short_name = "R2", public_key = sharedRemoteKey),
+                    publicKey = sharedRemoteKey,
+                    longName = "R2",
+                    shortName = "R2",
+                ),
+            ),
+        )
+
+        val incomingLocal = localIncomingNode(localNum, localKey)
+        dao.installConfig(myNodeEntityFor(localNum), listOf(incomingLocal))
+
+        // Local row inserted under its own number with its own key.
+        val localRow = dao.getNodeByNum(localNum)
+        assertNotNull(localRow, "Local node must be inserted under its own number")
+        assertEquals(localKey, localRow.node.publicKey)
+
+        // Both conflicting remote rows remain (existing security behavior: do not silently drop either).
+        assertNotNull(dao.getNodeByNum(700), "Remote conflict row 700 must be retained by existing behavior")
+        assertNotNull(dao.getNodeByNum(701), "Remote conflict row 701 must be retained by existing behavior")
+    }
+
+    /**
+     * Ambiguous duplicate-key matches (more than one existing row sharing the incoming local key) must NOT trigger the
+     * migration — falling back to the existing batch validation behavior so we never guess which row to migrate from.
+     */
+    @Test
+    fun testAmbiguousDuplicateKeyMatchesDoNotTriggerLocalMigration() = runTest {
+        createDb()
+
+        val newLocalNum = 12345
+        val sharedKey = fullPublicKey(seed = 0x33)
+
+        // Two pre-existing rows share the SAME public key that the incoming local will report — the
+        // migration must refuse the ambiguous case (size != 1).
+        dao.putAll(
+            listOf(
+                NodeEntity(
+                    num = 800,
+                    user = User(id = "!a", long_name = "A", short_name = "A", public_key = sharedKey),
+                    publicKey = sharedKey,
+                    longName = "A",
+                    shortName = "A",
+                ),
+                NodeEntity(
+                    num = 801,
+                    user = User(id = "!b", long_name = "B", short_name = "B", public_key = sharedKey),
+                    publicKey = sharedKey,
+                    longName = "B",
+                    shortName = "B",
+                ),
+            ),
+        )
+
+        val incomingLocal = localIncomingNode(newLocalNum, sharedKey)
+        dao.installConfig(myNodeEntityFor(newLocalNum), listOf(incomingLocal))
+
+        // Migration did NOT run: no row under the new number was inserted; existing rows untouched.
+        assertNull(dao.getNodeByNum(newLocalNum), "Ambiguous case must not insert a row under the new number")
+        assertNotNull(dao.getNodeByNum(800), "Existing row 800 must be retained (no migration)")
+        assertNotNull(dao.getNodeByNum(801), "Existing row 801 must be retained (no migration)")
     }
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioController.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioController.kt
@@ -76,6 +76,23 @@ interface RadioController :
     suspend fun setDeviceAddress(address: String)
 
     /**
+     * Suspends the active radio transport for an OTA firmware update without deselecting the current device.
+     *
+     * Contract:
+     * - synchronously stops the current radio transport (suspending until teardown completes);
+     * - disables automatic reconnect until the normal post-update reconnect (e.g. [setDeviceAddress] with the original
+     *   address);
+     * - preserves the selected device address;
+     * - preserves the active per-device database;
+     * - does NOT clear NodeManager state, early packets, notifications, or preferences.
+     *
+     * Use this in place of [setDeviceAddress]`\("n")` when the goal is only to release the transport for an OTA tool —
+     * `setDeviceAddress("n")` additionally invokes the real-device-deselection path (database switch, in-memory reset,
+     * notification cancel, prefs write), which is unnecessary and disruptive for OTA.
+     */
+    suspend fun suspendTransportForFirmwareUpdate()
+
+    /**
      * Requests that the next BLE connection invalidates Android's GATT service cache. Call before [setDeviceAddress]
      * when reconnecting after a firmware update.
      */

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
@@ -134,6 +134,17 @@ class RadioControllerImpl(
         onDeviceAddressChanged?.invoke()
     }
 
+    override suspend fun suspendTransportForFirmwareUpdate() {
+        // Delegated to the lower-level transport's suspending disconnect, which:
+        // - tears down the active transport and suspends until teardown completes;
+        // - clears the connectionRequested gate so environmental listeners cannot auto-reconnect;
+        // - preserves the selected device address (currentDeviceAddressFlow) and the bonded-address pref;
+        // - touches none of the app-level per-device state (DatabaseManager, NodeManager, early packets,
+        //   notifications, prefs).
+        // The post-update path re-arms and reconnects the transport by calling setDeviceAddress(original).
+        radioInterfaceService.disconnect()
+    }
+
     override fun requestGattCacheInvalidationOnNextConnect() {
         radioInterfaceService.requestGattCacheInvalidationOnNextConnect()
     }
@@ -141,7 +152,7 @@ class RadioControllerImpl(
     private suspend fun switchDevice(deviceAddr: String) {
         val currentAddr = meshPrefs.deviceAddress.value
         if (deviceAddr != currentAddr) {
-            Logger.i { "Device address changed, switching database and clearing node DB" }
+            Logger.i { "Device address changed, switching database and clearing in-memory node state" }
             meshPrefs.setDeviceAddress(deviceAddr)
             nodeManager.clear()
             messageProcessor.value.clearEarlyPackets()

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -209,6 +209,26 @@ class RadioControllerImplTest {
     }
 
     @Test
+    fun suspendTransportForFirmwareUpdateDelegatesToRadioInterfaceServiceDisconnect() = runTest {
+        val controller = createController()
+        every { meshPrefs.deviceAddress } returns MutableStateFlow("ble:AA:BB:CC:DD:EE:FF")
+
+        controller.suspendTransportForFirmwareUpdate()
+
+        // Contract: the OTA suspension path MUST delegate to the lower-level transport's suspending
+        // disconnect() — nothing else.
+        verifySuspend(exactly(1)) { radioInterfaceService.disconnect() }
+        // Must NOT deselect the device, switch databases, write prefs, clear NodeManager / early packets,
+        // cancel notifications, or invoke the selected-address callback.
+        verify(exactly(0)) { radioInterfaceService.setDeviceAddress(any()) }
+        verifySuspend(exactly(0)) { meshPrefs.setDeviceAddress(any()) }
+        verify(exactly(0)) { databaseManager.switchActiveDatabase(any()) }
+        verify(exactly(0)) { nodeManager.clear() }
+        verify(exactly(0)) { nodeManager.loadCachedNodeDB() }
+        verify(exactly(0)) { notificationManager.cancelAll() }
+    }
+
+    @Test
     fun sendReactionPersistsToDatabase() = runTest {
         val controller = createController()
         val user = User(id = "!abcd1234", long_name = "Test", short_name = "T")

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -74,6 +74,13 @@ class FakeRadioController :
     var gattCacheInvalidationRequested = false
         private set
 
+    /**
+     * Number of times [suspendTransportForFirmwareUpdate] has been invoked — lets OTA tests assert that the
+     * transport-suspension path was used in place of `setDeviceAddress("n")`.
+     */
+    var suspendTransportForFirmwareUpdateCallCount: Int = 0
+        private set
+
     init {
         registerResetAction {
             sentPackets.clear()
@@ -90,6 +97,7 @@ class FakeRadioController :
             startProvideLocationCalled = false
             stopProvideLocationCalled = false
             gattCacheInvalidationRequested = false
+            suspendTransportForFirmwareUpdateCallCount = 0
         }
     }
 
@@ -227,6 +235,10 @@ class FakeRadioController :
 
     override suspend fun setDeviceAddress(address: String) {
         lastSetDeviceAddress = address
+    }
+
+    override suspend fun suspendTransportForFirmwareUpdate() {
+        suspendTransportForFirmwareUpdateCallCount++
     }
 
     override fun requestGattCacheInvalidationOnNextConnect() {

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandler.kt
@@ -330,12 +330,13 @@ class Esp32OtaUpdateHandler(
     }
 
     /**
-     * Disconnect the mesh service BLE connection to free up the GATT for OTA. Setting device address to "n" (NOP
-     * interface) cleanly disconnects without reconnection attempts.
+     * Suspend the mesh service transport to free up the radio link (BLE GATT / TCP socket) for OTA, without deselecting
+     * the current device. The post-update path re-arms the transport by re-calling `setDeviceAddress(originalAddress)`
+     * from `FirmwareUpdateViewModel.verifyUpdateResult`.
      */
     private suspend fun disconnectMeshService() {
-        Logger.i { "ESP32 OTA: Disconnecting mesh service for OTA" }
-        radioController.setDeviceAddress("n")
+        Logger.i { "ESP32 OTA: Suspending mesh service transport for OTA" }
+        radioController.suspendTransportForFirmwareUpdate()
     }
 
     private suspend fun obtainFirmwareFile(

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
@@ -470,13 +470,16 @@ class SecureDfuHandler(
                 val entries = firmwareFileHandler.extractZipEntries(zipFile)
                 val pkg = parseDfuZipEntries(entries)
 
-                // ── 3. Disconnect mesh service, trigger buttonless DFU ───────────
+                // ── 3. Suspend mesh transport, trigger buttonless DFU ──────────
                 updateState(
                     FirmwareUpdateState.Processing(
                         ProgressState(UiText.Resource(Res.string.firmware_update_enabling_dfu)),
                     ),
                 )
-                radioController.setDeviceAddress("n")
+                // Suspend the mesh transport (without deselecting the device or clearing the in-memory
+                // node DB) so the OTA bootloader has a free BLE GATT link. The post-update verification
+                // path re-arms and reconnects the transport via setDeviceAddress(originalAddress).
+                radioController.suspendTransportForFirmwareUpdate()
                 delay(GATT_RELEASE_DELAY_MS)
 
                 // The trigger always uses SecureDfuTransport — it speaks both Secure (FE59) and Legacy (1530)

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandlerTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandlerTest.kt
@@ -54,12 +54,13 @@ import kotlin.test.assertTrue
  * `triggerRebootOta` and tearing down the mesh transport.
  *
  * Each test drives `startUpdate` end-to-end just far enough to observe the preflight outcome:
- * - Confirmed → mesh disconnect (`setDeviceAddress("n")`) is invoked, then the handler proceeds into the BLE transport
- *   phase, which fails fast on the mocked BLE deps. We bound the call with `withTimeoutOrNull` so the post-preflight
- *   BLE-connect retry loop is cancelled before it costs real wall-clock time.
- * - Rejected → mesh transport is preserved (no `setDeviceAddress`) and an `Error` state is emitted; the handler returns
- *   cleanly with no exception to chase.
- * - Silent firmware → legacy fallback disconnects the mesh transport and proceeds toward OTA connection attempts.
+ * - Confirmed → mesh transport is suspended (`suspendTransportForFirmwareUpdate` is invoked, without deselecting the
+ *   device via `setDeviceAddress`), then the handler proceeds into the BLE transport phase, which fails fast on the
+ *   mocked BLE deps. We bound the call with `withTimeoutOrNull` so the post-preflight BLE-connect retry loop is
+ *   cancelled before it costs real wall-clock time.
+ * - Rejected → mesh transport is preserved (no suspension, no `setDeviceAddress`) and an `Error` state is emitted; the
+ *   handler returns cleanly with no exception to chase.
+ * - Silent firmware → legacy fallback suspends the mesh transport and proceeds toward OTA connection attempts.
  *
  * The firmware response is simulated by mutating [FakeRadioController.clientNotification] from a sibling coroutine
  * scheduled to fire after `triggerRebootOta`. Because baseline is captured BEFORE the trigger (see `performUpdate`), a
@@ -175,7 +176,14 @@ class Esp32OtaUpdateHandlerTest {
             }
         },
     ) {
-        assertEquals("n", radioController.lastSetDeviceAddress, "Confirmed preflight must disconnect mesh service")
+        assertTrue(
+            radioController.suspendTransportForFirmwareUpdateCallCount > 0,
+            "Confirmed preflight must suspend the mesh transport",
+        )
+        assertNull(
+            radioController.lastSetDeviceAddress,
+            "Transport suspension must NOT deselect the device via setDeviceAddress",
+        )
     }
 
     @Test
@@ -201,7 +209,14 @@ class Esp32OtaUpdateHandlerTest {
                 bleTransportFactory = { transports.removeFirst() }
             },
         ) {
-            assertEquals("n", radioController.lastSetDeviceAddress, "Confirmed preflight must disconnect mesh service")
+            assertTrue(
+                radioController.suspendTransportForFirmwareUpdateCallCount > 0,
+                "Confirmed preflight must suspend the mesh transport",
+            )
+            assertNull(
+                radioController.lastSetDeviceAddress,
+                "Transport suspension must NOT deselect the device via setDeviceAddress",
+            )
             assertTrue(events.contains("close:first"), "Failed transport must be closed before retry")
             assertTrue(events.contains("connect:second"), "Retry must create and connect a fresh transport")
             assertTrue(events.indexOf("close:first") < events.indexOf("connect:second"))
@@ -338,7 +353,14 @@ class Esp32OtaUpdateHandlerTest {
                 wifiTransportFactory = { transports.removeFirst() }
             },
         ) {
-            assertEquals("n", radioController.lastSetDeviceAddress, "Confirmed preflight must disconnect mesh service")
+            assertTrue(
+                radioController.suspendTransportForFirmwareUpdateCallCount > 0,
+                "Confirmed preflight must suspend the mesh transport",
+            )
+            assertNull(
+                radioController.lastSetDeviceAddress,
+                "Transport suspension must NOT deselect the device via setDeviceAddress",
+            )
             assertTrue(events.contains("close:wifi-first"), "Failed WiFi transport must be closed before retry")
             assertTrue(events.contains("connect:wifi-second"), "WiFi retry must create and connect a fresh transport")
             assertTrue(events.indexOf("close:wifi-first") < events.indexOf("connect:wifi-second"))
@@ -371,7 +393,14 @@ class Esp32OtaUpdateHandlerTest {
                 }
             },
         ) {
-            assertEquals("n", radioController.lastSetDeviceAddress, "Confirmed preflight must disconnect mesh service")
+            assertTrue(
+                radioController.suspendTransportForFirmwareUpdateCallCount > 0,
+                "Confirmed preflight must suspend the mesh transport",
+            )
+            assertNull(
+                radioController.lastSetDeviceAddress,
+                "Transport suspension must NOT deselect the device via setDeviceAddress",
+            )
             assertEquals(WIFI_CONNECT_ATTEMPTS, attempt, "WiFi should use the full post-confirm retry budget")
             repeat(WIFI_CONNECT_ATTEMPTS) { index ->
                 val name = "wifi-${index + 1}"
@@ -405,7 +434,14 @@ class Esp32OtaUpdateHandlerTest {
                 }
             },
         ) {
-            assertEquals("n", radioController.lastSetDeviceAddress, "Confirmed preflight must disconnect mesh service")
+            assertTrue(
+                radioController.suspendTransportForFirmwareUpdateCallCount > 0,
+                "Confirmed preflight must suspend the mesh transport",
+            )
+            assertNull(
+                radioController.lastSetDeviceAddress,
+                "Transport suspension must NOT deselect the device via setDeviceAddress",
+            )
             assertEquals(BLE_CONNECT_ATTEMPTS, attempt, "BLE should use the full post-confirm retry budget")
             repeat(BLE_CONNECT_ATTEMPTS) { index ->
                 val name = "ble-${index + 1}"
@@ -426,7 +462,15 @@ class Esp32OtaUpdateHandlerTest {
         // OTA-keyed message that is NOT the canonical "Rebooting to <mode> OTA" success prefix → Rejected.
         confirmationMessage = "Cannot start OTA: OTA Loader partition not found.",
     ) {
-        assertNull(radioController.lastSetDeviceAddress, "Rejected preflight must NOT disconnect mesh service")
+        assertNull(
+            radioController.lastSetDeviceAddress,
+            "Rejected preflight must NOT suspend or deselect the mesh transport",
+        )
+        assertEquals(
+            0,
+            radioController.suspendTransportForFirmwareUpdateCallCount,
+            "Rejected preflight must NOT suspend the mesh transport",
+        )
         assertTrue(states.any { it is FirmwareUpdateState.Error }, "Rejected preflight must emit Error state")
     }
 
@@ -449,10 +493,13 @@ class Esp32OtaUpdateHandlerTest {
             }
         },
     ) {
-        assertEquals(
-            "n",
+        assertTrue(
+            radioController.suspendTransportForFirmwareUpdateCallCount > 0,
+            "Silent preflight must still suspend the mesh transport via the legacy fallback path",
+        )
+        assertNull(
             radioController.lastSetDeviceAddress,
-            "Silent preflight must still disconnect mesh service",
+            "Legacy fallback transport suspension must NOT deselect the device via setDeviceAddress",
         )
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes firmware 2.8 transition issues by migrating local node data when the node number changes and preserving the selected device during OTA updates. It also adds tests covering migration edge cases and transport suspension behavior.

## Key changes

### Fixes
- Migrate the local node record by public key when firmware changes its node number.
- Preserve app-local fields such as favorites, notes, power labels, and manual verification.
- Re-key associated metadata to the new node number.
- Avoid migration when public-key matches are missing, duplicated, or ambiguous.
- Suspend the radio transport during OTA instead of deselecting the device or switching to a placeholder address.
- Preserve selected-device, database, NodeManager, and notification state during firmware updates.

### Features
- Add `suspendTransportForFirmwareUpdate()` to the radio controller API and fake implementation.
- Add metadata lookup by node number.
- Add tests for local-node migration, repair scenarios, duplicate-key handling, and OTA transport suspension.

### Refactors
- Update OTA handlers to use transport suspension and reconnect through the original device address after the update.
- Clarify logging and documentation around in-memory state switching and OTA reconnect behavior.

## Migration and compatibility

No database schema migration is required. OTA callers should use `suspendTransportForFirmwareUpdate()` and re-arm the transport with the original device address after the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->