### PR TITLE
Refactor local data sources to use currentDb instead of withDb

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
@@ -33,16 +33,16 @@ class DeviceHardwareLocalDataSource(private val dbManager: DatabaseProvider) {
     }
 
     suspend fun getByHwModel(hwModel: Int): List<DeviceHardwareEntity> =
-        dbManager.withDb { it.deviceHardwareDao().getByHwModel(hwModel) }.orEmpty()
+        dbManager.currentDb.value.deviceHardwareDao().getByHwModel(hwModel)
 
     suspend fun getByTarget(target: String): DeviceHardwareEntity? =
-        dbManager.withDb { it.deviceHardwareDao().getByTarget(target) }
+        dbManager.currentDb.value.deviceHardwareDao().getByTarget(target)
 
     suspend fun getByModelAndTarget(hwModel: Int, target: String): DeviceHardwareEntity? =
-        dbManager.withDb { it.deviceHardwareDao().getByModelAndTarget(hwModel, target) }
+        dbManager.currentDb.value.deviceHardwareDao().getByModelAndTarget(hwModel, target)
 
-    suspend fun hasAnyEntries(): Boolean = dbManager.withDb { it.deviceHardwareDao().count() > 0 } ?: false
+    suspend fun hasAnyEntries(): Boolean = dbManager.currentDb.value.deviceHardwareDao().count() > 0
 
     /** All known `platformioTarget` values — used to determine which msh.to links are vendor links. */
-    suspend fun getAllTargets(): List<String> = dbManager.withDb { it.deviceHardwareDao().getAllTargets() }.orEmpty()
+    suspend fun getAllTargets(): List<String> = dbManager.currentDb.value.deviceHardwareDao().getAllTargets()
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
@@ -29,7 +29,7 @@ class DeviceLinkLocalDataSource(private val dbManager: DatabaseProvider) {
     fun observeAll(): Flow<List<DeviceLinkEntity>> =
         dbManager.currentDb.flatMapLatest { db -> db.deviceLinkDao().observeAll() }
 
-    suspend fun getAll(): List<DeviceLinkEntity> = dbManager.withDb { it.deviceLinkDao().getAll() }.orEmpty()
+    suspend fun getAll(): List<DeviceLinkEntity> = dbManager.currentDb.value.deviceLinkDao().getAll()
 
     suspend fun upsertAll(links: List<DeviceLinkEntity>) {
         dbManager.withDb { it.deviceLinkDao().upsertAll(links) }
@@ -43,5 +43,5 @@ class DeviceLinkLocalDataSource(private val dbManager: DatabaseProvider) {
         dbManager.withDb { it.deviceLinkDao().deleteAll() }
     }
 
-    suspend fun count(): Int = dbManager.withDb { it.deviceLinkDao().count() } ?: 0
+    suspend fun count(): Int = dbManager.currentDb.value.deviceLinkDao().count()
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
@@ -41,7 +41,8 @@ class FirmwareReleaseLocalDataSource(private val dbManager: DatabaseProvider) {
         }
     }
 
-    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? = dbManager.withDb {
-        it.firmwareReleaseDao().getReleasesByType(releaseType).maxByOrNull { entity -> entity.asDeviceVersion() }
-    }
+    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? =
+        dbManager.currentDb.value.firmwareReleaseDao().getReleasesByType(releaseType).maxByOrNull { entity ->
+            entity.asDeviceVersion()
+        }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
@@ -51,8 +51,7 @@ class SwitchingNodeInfoReadDataSource(private val dbManager: DatabaseProvider) :
     }
 
     override suspend fun getNodesOlderThan(lastHeard: Int): List<NodeEntity> =
-        dbManager.withDb { it.nodeInfoDao().getNodesOlderThan(lastHeard) } ?: emptyList()
+        dbManager.currentDb.value.nodeInfoDao().getNodesOlderThan(lastHeard)
 
-    override suspend fun getUnknownNodes(): List<NodeEntity> =
-        dbManager.withDb { it.nodeInfoDao().getUnknownNodes() } ?: emptyList()
+    override suspend fun getUnknownNodes(): List<NodeEntity> = dbManager.currentDb.value.nodeInfoDao().getUnknownNodes()
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -441,7 +441,6 @@ open class DatabaseManager(
     private suspend fun <T> withCurrentDb(block: suspend (MeshtasticDatabase) -> T): T? {
         val db = beginWrite()
         val active = currentDbName
-        markLastUsed(active)
         try {
             return runCancellableDbBlock(db, block)
         } catch (e: CancellationException) {


### PR DESCRIPTION
## Summary by Sourcery

Refactor local data sources to read from the currently active database instance instead of using the generic withDb helper, and simplify database manager behavior around tracking last-used databases.

Enhancements:
- Update device hardware, firmware release, node info, and device link local data sources to query via dbManager.currentDb instead of withDb and remove redundant default empty/zero handling.
- Stop invoking last-used database tracking when executing withCurrentDb in DatabaseManager.