### PR TITLE
Use Transactional DAOs for Atomic Database Operations

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -136,7 +136,7 @@ open class MeshUtilApplication :
 
     override fun onTerminate() {
         // Shutdown managers (useful for Robolectric tests)
-        get<DatabaseManager>().close()
+        kotlinx.coroutines.runBlocking { get<DatabaseManager>().close() }
         applicationScope.cancel()
         super.onTerminate()
         org.koin.core.context.stopKoin()

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/MeshLogRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/MeshLogRepositoryImpl.kt
@@ -184,25 +184,18 @@ open class MeshLogRepositoryImpl(
     override suspend fun deleteLocalStatsLogs(nodeNum: Int) = withContext(dispatchers.io) {
         val myNodeNum = nodeInfoReadDataSource.myNodeInfoFlow().firstOrNull()?.myNodeNum
         val logId = if (nodeNum == myNodeNum) MeshLog.NODE_NUM_LOCAL else nodeNum
-        // One withDb block: the query and the chunked deletes all land on the same DB instance (previously each
-        // chunk
-        // re-fetched the DAO to survive a mid-op switch; capturing one instance is the more correct behavior, and
-        // the
-        // drain barrier now covers the whole read-modify-delete against a concurrent merge).
         dbManager.withDb { db ->
             val dao = db.meshLogDao()
-            val localStatsLogIds =
-                dao.getLogsFrom(logId, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE)
-                    .firstOrNull()
-                    .orEmpty()
+            // Snapshot read outside the transaction — the selection requires Kotlin protobuf parsing
+            // (parseTelemetryLog), so it cannot be a single SQL operation. The delete targets stable UUIDs,
+            // so a concurrent insert between snapshot and delete is simply not in the delete set.
+            val uuidsToDelete =
+                dao.getLogsSnapshot(logId, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE)
                     .map { it.asExternalModel() }
                     .filter { parseTelemetryLog(it)?.local_stats != null }
                     .map { it.uuid }
-
-            // Chunk to stay under SQLite's bind-variable limit.
-            for (chunk in localStatsLogIds.chunked(DELETE_CHUNK_SIZE)) {
-                dao.deleteLogsByUuid(chunk)
-            }
+            // The chunked delete runs inside one Room transaction — all-or-nothing.
+            dao.deleteLogsByUuidAtomic(uuidsToDelete)
         }
         Unit
     }
@@ -217,8 +210,5 @@ open class MeshLogRepositoryImpl(
 
     companion object {
         private const val MILLIS_PER_SEC = 1000L
-
-        /** Max UUIDs per DELETE IN-clause; keeps us under SQLite's bind-variable limit. */
-        private const val DELETE_CHUNK_SIZE = 500
     }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
@@ -31,7 +31,6 @@ import okio.ByteString.Companion.toByteString
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.dao.NodeInfoDao
-import org.meshtastic.core.database.dao.PacketDao
 import org.meshtastic.core.database.entity.PacketEntity
 import org.meshtastic.core.database.entity.toReaction
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -107,21 +106,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
 
     override suspend fun updateLastReadMessage(contact: String, messageUuid: Long, lastReadTimestamp: Long) {
         withContext(dispatchers.io + NonCancellable) {
-            // Read-modify-write in one withDb block so both statements land on the same DB instance.
-            dbManager.withDb { db ->
-                val dao = db.packetDao()
-                val current = dao.getContactSettings(contact)
-                val existingTimestamp = current?.lastReadMessageTimestamp ?: Long.MIN_VALUE
-                if (lastReadTimestamp <= existingTimestamp) {
-                    return@withDb
-                }
-                val updated =
-                    (current ?: ContactSettingsEntity(contact_key = contact)).copy(
-                        lastReadMessageUuid = messageUuid,
-                        lastReadMessageTimestamp = lastReadTimestamp,
-                    )
-                dao.upsertContactSettings(listOf(updated))
-            }
+            dbManager.withDb { it.packetDao().updateLastReadMessage(contact, messageUuid, lastReadTimestamp) }
         }
     }
 
@@ -310,39 +295,15 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         insertRoomPacket(packetToSave)
     }
 
-    override suspend fun update(packet: DataPacket, routingError: Int): Unit = withContext(dispatchers.io) {
-        // Read-modify-write in one withDb block so the lookup and update land on the same DB instance.
-        dbManager.withDb { db ->
-            val dao = db.packetDao()
-            // Match on key fields that identify the packet, rather than the entire data object
-            dao.findPacketsWithId(packet.id)
-                .find { it.data.id == packet.id && it.data.from == packet.from && it.data.to == packet.to }
-                ?.let { existing ->
-                    val updated =
-                        if (routingError >= 0) {
-                            existing.copy(data = packet, routingError = routingError)
-                        } else {
-                            existing.copy(data = packet)
-                        }
-                    dao.update(updated)
-                }
-        }
-        Unit
-    }
+    override suspend fun update(packet: DataPacket, routingError: Int): Unit =
+        withContext(dispatchers.io) { dbManager.withDb { it.packetDao().updatePacketByKey(packet, routingError) } }
 
     override suspend fun insertReaction(reaction: Reaction, myNodeNum: Int) {
         withContext(dispatchers.io) { dbManager.withDb { it.packetDao().insert(reaction.toEntity(myNodeNum)) } }
     }
 
     override suspend fun updateReaction(reaction: Reaction) {
-        withContext(dispatchers.io) {
-            dbManager.withDb { db ->
-                val dao = db.packetDao()
-                dao.findReactionsWithId(reaction.packetId)
-                    .find { it.userId == reaction.user.id && it.emoji == reaction.emoji }
-                    ?.let { dao.update(reaction.toEntity(it.myNodeNum)) }
-            }
-        }
+        withContext(dispatchers.io) { dbManager.withDb { it.packetDao().updateReactionByKey(reaction.toEntity(0)) } }
     }
 
     override suspend fun getReactionByPacketId(packetId: Int): Reaction? = withContext(dispatchers.io) {
@@ -366,120 +327,20 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         rxTime: Long,
         myNodeNum: Int?,
     ) = withContext(dispatchers.io) {
-        // One withDb block: the id lookups and the status updates all land on the same DB instance.
-        dbManager.withDb { db ->
-            val dao = db.packetDao()
-            val packets = dao.findPacketsWithId(packetId)
-            val reactions = dao.findReactionsWithId(packetId)
-            updateSFPPMatches(dao, packets, reactions, from, to, hash, status, rxTime, myNodeNum)
+        dbManager.withDb {
+            it.packetDao().applySFPPStatus(packetId, from, to, hash.toByteString(), status, rxTime, myNodeNum)
         }
         Unit
     }
 
-    @Suppress("CyclomaticComplexMethod", "LongParameterList")
-    private suspend fun updateSFPPMatches(
-        dao: PacketDao,
-        packets: List<RoomPacket>,
-        reactions: List<RoomReaction>,
-        from: Int,
-        to: Int,
-        hash: ByteArray,
-        status: MessageStatus,
-        rxTime: Long,
-        myNodeNum: Int?,
-    ) {
-        val fromId = NodeAddress.numToDefaultId(from)
-        val isFromLocalNode = myNodeNum != null && from == myNodeNum
-        val toId =
-            if (to == 0 || to == NodeAddress.NODENUM_BROADCAST) {
-                NodeAddress.ID_BROADCAST
-            } else {
-                NodeAddress.numToDefaultId(to)
-            }
-
-        val hashByteString = hash.toByteString()
-
-        packets.forEach { packet ->
-            // For sent messages, from is stored as ID_LOCAL, but SFPP packet has node number
-            val fromMatches =
-                packet.data.from == fromId || (isFromLocalNode && packet.data.from == NodeAddress.ID_LOCAL)
-            co.touchlab.kermit.Logger.d {
-                "SFPP match check: packetFrom=${packet.data.from} fromId=$fromId " +
-                    "isFromLocal=$isFromLocalNode fromMatches=$fromMatches " +
-                    "packetTo=${packet.data.to} toId=$toId toMatches=${packet.data.to == toId}"
-            }
-            if (fromMatches && packet.data.to == toId) {
-                // If it's already confirmed, don't downgrade it to routing
-                if (packet.data.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
-                    return@forEach
-                }
-                val newTime = if (rxTime > 0) rxTime * MILLISECONDS_IN_SECOND else packet.received_time
-                val updatedData = packet.data.copy(status = status, sfppHash = hashByteString, time = newTime)
-                dao.update(packet.copy(data = updatedData, sfpp_hash = hashByteString, received_time = newTime))
-            }
-        }
-
-        reactions.forEach { reaction ->
-            val reactionFrom = reaction.userId
-            // For sent reactions, from is stored as ID_LOCAL, but SFPP packet has node number
-            val fromMatches = reactionFrom == fromId || (isFromLocalNode && reactionFrom == NodeAddress.ID_LOCAL)
-
-            val toMatches = reaction.to == toId
-
-            co.touchlab.kermit.Logger.d {
-                "SFPP reaction match check: reactionFrom=$reactionFrom fromId=$fromId " +
-                    "isFromLocal=$isFromLocalNode fromMatches=$fromMatches " +
-                    "reactionTo=${reaction.to} toId=$toId toMatches=$toMatches"
-            }
-
-            if (fromMatches && (reaction.to == null || toMatches)) {
-                if (reaction.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
-                    return@forEach
-                }
-                val newTime = if (rxTime > 0) rxTime * MILLISECONDS_IN_SECOND else reaction.timestamp
-                val updatedReaction = reaction.copy(status = status, sfpp_hash = hashByteString, timestamp = newTime)
-                dao.update(updatedReaction)
-            }
-        }
-    }
-
     override suspend fun updateSFPPStatusByHash(hash: ByteArray, status: MessageStatus, rxTime: Long): Unit =
         withContext(dispatchers.io) {
-            // Read-modify-write in one withDb block so the hash lookups and updates land on the same DB instance.
-            dbManager.withDb { db ->
-                val dao = db.packetDao()
-                val hashByteString = hash.toByteString()
-                dao.findPacketBySfppHash(hashByteString)?.let { packet ->
-                    // If it's already confirmed, don't downgrade it
-                    if (packet.data.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
-                        return@let
-                    }
-                    val newTime = if (rxTime > 0) rxTime * MILLISECONDS_IN_SECOND else packet.received_time
-                    val updatedData = packet.data.copy(status = status, sfppHash = hashByteString, time = newTime)
-                    dao.update(packet.copy(data = updatedData, sfpp_hash = hashByteString, received_time = newTime))
-                }
-
-                dao.findReactionBySfppHash(hashByteString)?.let { reaction ->
-                    if (reaction.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
-                        return@let
-                    }
-                    val newTime = if (rxTime > 0) rxTime * MILLISECONDS_IN_SECOND else reaction.timestamp
-                    val updatedReaction =
-                        reaction.copy(status = status, sfpp_hash = hashByteString, timestamp = newTime)
-                    dao.update(updatedReaction)
-                }
-            }
+            dbManager.withDb { it.packetDao().applySFPPStatusByHash(hash.toByteString(), status, rxTime) }
             Unit
         }
 
     override suspend fun deleteMessages(uuidList: List<Long>) = withContext(dispatchers.io) {
-        // One withDb block: every chunk lands on the same DB instance (previously each chunk re-fetched the DAO to
-        // survive a mid-op switch; the drain barrier now covers the whole chunked delete instead).
-        dbManager.withDb { db ->
-            for (chunk in uuidList.chunked(DELETE_CHUNK_SIZE)) {
-                db.packetDao().deleteMessages(chunk)
-            }
-        }
+        dbManager.withDb { it.packetDao().deleteMessagesAtomic(uuidList) }
         Unit
     }
 
@@ -628,7 +489,5 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
     companion object {
         private const val CONTACTS_PAGE_SIZE = 30
         private const val MESSAGES_PAGE_SIZE = 50
-        private const val DELETE_CHUNK_SIZE = 500
-        private const val MILLISECONDS_IN_SECOND = 1000L
     }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/TracerouteSnapshotRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/TracerouteSnapshotRepositoryImpl.kt
@@ -43,25 +43,19 @@ class TracerouteSnapshotRepositoryImpl(
         .flowOn(dispatchers.io)
         .conflate()
 
-    // The delete+insert pair runs in one withDb block so both land on the same DB instance and stay visible to the
-    // cross-transport merge drain barrier (see DatabaseProvider).
     override suspend fun upsertSnapshotPositions(logUuid: String, requestId: Int, positions: Map<Int, Position>) {
         withContext(dispatchers.io) {
-            dbManager.withDb {
-                val dao = it.tracerouteNodePositionDao()
-                dao.deleteByLogUuid(logUuid)
-                if (positions.isEmpty()) return@withDb
-                val entities =
-                    positions.map { (nodeNum, position) ->
-                        TracerouteNodePositionEntity(
-                            logUuid = logUuid,
-                            requestId = requestId,
-                            nodeNum = nodeNum,
-                            position = position,
-                        )
-                    }
-                dao.insertAll(entities)
-            }
+            val entities =
+                positions.map { (nodeNum, position) ->
+                    TracerouteNodePositionEntity(
+                        logUuid = logUuid,
+                        requestId = requestId,
+                        nodeNum = nodeNum,
+                        position = position,
+                    )
+                }
+            // Single transactional DAO call — delete + insert is atomic.
+            dbManager.withDb { it.tracerouteNodePositionDao().replaceByLogUuid(logUuid, entities) }
         }
     }
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseConstants.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseConstants.kt
@@ -48,6 +48,12 @@ object DatabaseConstants {
     // Address anonymization sizing
     const val ADDRESS_ANON_SHORT_LEN: Int = 4
     const val ADDRESS_ANON_EDGE_LEN: Int = 2
+
+    /**
+     * SQLite's default maximum number of host parameters (bind variables) per statement. Used to chunk IN-clause
+     * queries.
+     */
+    const val SQLITE_MAX_BIND_PARAMETERS: Int = 999
 }
 
 fun shortSha1(s: String): String = s.encodeUtf8().sha1().hex().take(DatabaseConstants.DB_NAME_HASH_LEN)

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -26,6 +26,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -38,7 +39,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -71,12 +72,21 @@ open class DatabaseManager(
     // Per-source write barrier for merges. `withDb` deliberately does NOT take [mutex] (hot path), so a merge under
     // [mutex] must still drain any in-flight writer that captured the source DB before folding it away — otherwise a
     // late-committing write is lost when the source is retired. This dedicated lock (never held across a drain await,
-    // so it can't deadlock the merge) tracks live `withDb` blocks per captured DB instance. It also guards the merge's
-    // active-DB swap so a writer either registers against `source` before the swap and is drained, or captures `dest`
-    // after it and is safe — it can never slip through the gap between the two.
+    // so it can't deadlock the merge) tracks live `withDb` blocks per captured DB instance and the writer-admission
+    // gate. The gate is armed at the start of an association attempt: while it is pending, [beginWrite] blocks new
+    // writers instead of letting them capture a DB, so a new `withDb` can never write to `source` once it is being
+    // retired, nor land on `dest` before the merge commits. The gate completes with `source` if the attempt aborts
+    // (drain timeout, cancellation, or pre-commit merge failure) and with `dest` once the merge commits — source is
+    // never restored after the merge commits. The lock is released before any suspend (drain await, gate await, Room
+    // work, merge work, or DataStore work), so it can't deadlock any of them.
     private val writerTrackerMutex = Mutex()
     private val activeWriters = mutableMapOf<MeshtasticDatabase, Int>()
     private val drainWaiters = mutableMapOf<MeshtasticDatabase, MutableList<CompletableDeferred<Unit>>>()
+
+    // Armed at the start of an association attempt; null otherwise. A non-null gate blocks [beginWrite] until the
+    // attempt resolves. It completes with the canonical DB (source on abort, dest on commit) so blocked writers resume
+    // against the right instance. Never read or written outside [writerTrackerMutex].
+    private var writerGate: CompletableDeferred<MeshtasticDatabase>? = null
 
     private val cacheLimitKey = intPreferencesKey(DatabaseConstants.CACHE_LIMIT_KEY)
     private val legacyCleanedKey = booleanPreferencesKey(DatabaseConstants.LEGACY_DB_CLEANED_KEY)
@@ -108,16 +118,21 @@ open class DatabaseManager(
 
     private val dbCache = mutableMapOf<String, MeshtasticDatabase>()
 
-    private val _currentDb = MutableStateFlow<MeshtasticDatabase?>(null)
+    /** Databases merged and logically retired but kept open — app-wide consumers may still hold references. */
+    private val logicallyRetired = mutableSetOf<String>()
+
+    private val _currentDb = MutableStateFlow(getOrOpenDatabase(DatabaseConstants.DEFAULT_DB_NAME))
 
     /**
-     * The currently active database, built lazily on first access. Room's `onOpen` callback is itself lazy (not invoked
-     * until the first query), so construction only allocates the builder and connection pool — actual I/O is deferred.
+     * The currently active database. The default DB is opened eagerly at construction and every internal publication
+     * ([switchActiveDatabase], association rollback/release, active-DB reopen recovery) writes [_currentDb] directly,
+     * so [currentDb].value reflects the new instance on the same program step — no `stateIn`/`filterNotNull` derivation
+     * that would delay visibility to a coroutine dispatch.
+     *
+     * Room's `onOpen` callback is itself lazy (not invoked until the first query), so construction only allocates the
+     * builder and connection pool — actual I/O is deferred.
      */
-    override val currentDb: StateFlow<MeshtasticDatabase> =
-        _currentDb
-            .filterNotNull()
-            .stateIn(managerScope, SharingStarted.Eagerly, getOrOpenDatabase(DatabaseConstants.DEFAULT_DB_NAME))
+    override val currentDb: StateFlow<MeshtasticDatabase> = _currentDb.asStateFlow()
 
     private val _currentAddress = MutableStateFlow<String?>(null)
     val currentAddress: StateFlow<String?> = _currentAddress
@@ -140,7 +155,13 @@ open class DatabaseManager(
      * mutex is not yet relevant (single-threaded construction).
      */
     private fun getOrOpenDatabase(dbName: String): MeshtasticDatabase =
-        dbCache.getOrPut(dbName) { getDatabaseBuilder(dbName).build() }
+        dbCache.getOrPut(dbName) { buildDatabase(dbName) }
+
+    /**
+     * Builds a new [MeshtasticDatabase] for [dbName]. Tests override this to control file placement (temp directory
+     * instead of the platform data dir). Production delegates to the platform-specific [getDatabaseBuilder].
+     */
+    protected open fun buildDatabase(dbName: String): MeshtasticDatabase = getDatabaseBuilder(dbName).build()
 
     /**
      * Resolves the DB name to use for [address], honoring a cross-transport alias when one exists. A secondary
@@ -159,10 +180,10 @@ open class DatabaseManager(
         val dbName = resolveDbName(address)
 
         // Remember the previously active DB name (any) so we can record its last-used time as well.
-        val previousDbName = if (_currentDb.value != null) currentDbName else null
+        val previousDbName = currentDbName
 
         // Fast path: no-op if already on this address
-        if (_currentAddress.value == address && _currentDb.value != null) {
+        if (_currentAddress.value == address) {
             markLastUsed(dbName)
             return@withLock
         }
@@ -170,7 +191,7 @@ open class DatabaseManager(
         // Build/open Room DB off the main thread
         val db = withContext(dispatchers.io) { getOrOpenDatabase(dbName) }
 
-        // Emit the new DB BEFORE closing the old one. flatMapLatest collectors on
+        // Emit the new DB BEFORE closing the old ones. flatMapLatest collectors on
         // currentDb will cancel their in-flight queries on the previous database once
         // the new value is emitted. Closing the old pool first would race with those
         // collectors, causing "Connection pool is closed" crashes.
@@ -179,7 +200,7 @@ open class DatabaseManager(
         currentDbName = dbName
         markLastUsed(dbName)
         // Also mark the previous DB as used "just now" so LRU has an accurate, recent timestamp
-        previousDbName?.let { markLastUsed(it) }
+        markLastUsed(previousDbName)
 
         // Do NOT close the previous DB synchronously here. Even though _currentDb has been
         // updated, in-flight `withDb` calls may still hold a reference to the old database
@@ -188,6 +209,20 @@ open class DatabaseManager(
         // (enforceCacheLimit) handle cleanup — it only runs on databases that are not the
         // active target and have not been used recently.
 
+        schedulePostSwitchMaintenance(dbName = dbName, db = db)
+
+        Logger.i { "Switched active DB to ${anonymizeDbName(dbName)} for address ${anonymizeAddress(address)}" }
+    }
+
+    /**
+     * Schedules deferred maintenance that runs after switching the active database. Posts work to [managerScope] on
+     * [dispatchers.io] so the switch path is not blocked by filesystem or search-index I/O.
+     *
+     * In production this schedules LRU cache-limit enforcement, legacy-DB cleanup, and FTS search-index backfill.
+     * In-memory test fixtures override it to no-op because they do not have a filesystem-backed database directory and
+     * must not access platform context singletons (e.g. `ContextServices.app`).
+     */
+    protected open fun schedulePostSwitchMaintenance(dbName: String, db: MeshtasticDatabase) {
         // Defer LRU eviction so switch is not blocked by filesystem work
         managerScope.launch(dispatchers.io) { enforceCacheLimit(activeDbName = dbName) }
 
@@ -200,11 +235,9 @@ open class DatabaseManager(
         val shouldDelayBackfill = dbName != DatabaseConstants.DEFAULT_DB_NAME && !hasDelayedFirstDeviceBackfill
         if (shouldDelayBackfill) hasDelayedFirstDeviceBackfill = true
         scheduleSearchIndexBackfill(dbName = dbName, db = db, shouldDelayBackfill = shouldDelayBackfill)
-
-        Logger.i { "Switched active DB to ${anonymizeDbName(dbName)} for address ${anonymizeAddress(address)}" }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "CyclomaticComplexMethod", "LongMethod")
     override suspend fun associateDevice(nodeNum: Int, deviceId: String?) {
         mutex.withLock {
             val sourceName = currentDbName
@@ -233,68 +266,159 @@ open class DatabaseManager(
                 }
 
                 claimed == sourceName -> {
-                    // Already unified — just backfill/refresh any claim key that is missing or stale
-                    // (e.g. the first connect after this device renumbered, or after an app update
-                    // introduced device-id claims).
-                    if ((deviceKey != null && prefs[deviceKey] != sourceName) || prefs[nodeKey] != sourceName) {
-                        writeClaims(sourceName)
+                    // Already unified — backfill or refresh any stale/missing routing metadata atomically.
+                    // This also repairs a post-merge routing failure (merge committed but DataStore edit failed):
+                    // the next connect reaches this branch and writes claims + alias in one edit without
+                    // re-copying source (the merge marker prevents duplicate data).
+                    val address = _currentAddress.value
+                    val needsDeviceKey = deviceKey != null && prefs[deviceKey] != sourceName
+                    val needsNodeKey = prefs[nodeKey] != sourceName
+                    val needsAlias = prefs[addrDbKey(address)] != sourceName
+                    if (needsDeviceKey || needsNodeKey || needsAlias) {
+                        datastore.edit {
+                            deviceKey?.let { key -> if (needsDeviceKey) it[key] = sourceName }
+                            if (needsNodeKey) it[nodeKey] = sourceName
+                            if (needsAlias) it[addrDbKey(address)] = sourceName
+                            it[lastUsedKey(sourceName)] = nowMillis
+                        }
+                        Logger.i { "Refreshed routing metadata for ${anonymizeDbName(sourceName)}" }
                     }
                 }
 
                 else -> {
                     // Secondary transport reached an already-known node: fold this DB into the canonical one,
                     // switch the active DB to it, alias this address to it, and retire the now-merged source.
-                    val source = _currentDb.value ?: return@withLock
+                    val source = _currentDb.value
                     val dest = withContext(dispatchers.io) { getOrOpenDatabase(claimed) }
 
-                    // Redirect live writers to the canonical DB BEFORE merging (a connect triggers a full NodeDB
-                    // re-dump). The swap is published under the writer lock so a concurrent withDb write registers
-                    // against `source` before it — and is drained below — or captures `dest` after it and is safe.
-                    // New writers now capture `dest`; drainWriters then waits out any still writing to `source` so
-                    // the merge can't snapshot `source` mid-write and lose it when `source` is later retired.
-                    publishActiveDb(dest, claimed)
-                    try {
-                        withContext(dispatchers.io) {
-                            drainWriters(source, sourceName)
-                            DatabaseMerger.merge(source, dest, sourceName)
+                    // Arm the writer-admission gate BEFORE any drain/merge work. Source stays canonical (active) for
+                    // the
+                    // whole attempt, so a new `withDb` writer that arrives now blocks here (outside
+                    // [writerTrackerMutex])
+                    // instead of capturing `source` (which is about to be retired) or `dest` (which doesn't exist yet).
+                    // The gate completes with `source` if the attempt aborts, or `dest` once the merge commits — it can
+                    // never release a writer onto a DB that is being torn down.
+                    val gate = CompletableDeferred<MeshtasticDatabase>()
+                    writerTrackerMutex.withLock { writerGate = gate }
+                    val transportAddress = _currentAddress.value
+
+                    // Releases blocked writers onto `source` (the attempt aborted; source is still canonical). Runs
+                    // under NonCancellable so a cancelled attempt still unblocks its waiters instead of leaking them.
+                    suspend fun releaseGateToSource() {
+                        withContext(NonCancellable) {
+                            writerTrackerMutex.withLock {
+                                writerGate = null
+                                _currentDb.value = source
+                                currentDbName = sourceName
+                            }
+                            gate.complete(source)
                         }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        // merge() is atomic, so on failure `dest` is unchanged. Roll the active DB back to
-                        // `source` so the address still resolves consistently and the merge retries next connect.
-                        publishActiveDb(source, sourceName)
-                        Logger.w(e) {
-                            "Merge into ${anonymizeDbName(claimed)} failed; kept ${anonymizeDbName(sourceName)} active"
+                    }
+
+                    // Releases blocked writers onto `dest` (the merge committed; dest is now canonical).
+                    suspend fun releaseGateToDest() {
+                        withContext(NonCancellable) {
+                            writerTrackerMutex.withLock {
+                                writerGate = null
+                                _currentDb.value = dest
+                                currentDbName = claimed
+                            }
+                            gate.complete(dest)
+                        }
+                    }
+
+                    // ── Phase 1: Drain source writers (cancellable — safe to release onto source before merge
+                    // commits).
+                    val drained =
+                        try {
+                            withContext(dispatchers.io) { drainWriters(source, sourceName) }
+                        } catch (e: CancellationException) {
+                            releaseGateToSource()
+                            throw e
+                        }
+                    if (!drained) {
+                        releaseGateToSource()
+                        Logger.w {
+                            "Aborted merge of ${anonymizeDbName(sourceName)} into ${anonymizeDbName(claimed)}: " +
+                                "writer drain timed out; kept ${anonymizeDbName(sourceName)} active"
                         }
                         return@withLock
                     }
 
-                    markLastUsed(claimed)
-                    // Refresh both claim keys (migrates a legacy nodeNum-only claim forward to the
-                    // device-id key) and alias this transport's address to the canonical DB.
-                    writeClaims(claimed)
-                    datastore.edit { it[addrDbKey(_currentAddress.value)] = claimed }
-                    Logger.i {
-                        "Unified ${anonymizeDbName(sourceName)} into ${anonymizeDbName(claimed)} for node $nodeNum"
+                    // ── Phase 2: Merge + routing finalization (NonCancellable).
+                    // After mergeDatabases commits, a marker in dest makes retries skip the data copy.
+                    // Source must NEVER be reactivated past that point — post-merge writes to source would be lost
+                    // when a retry sees the marker and skips the copy. This phase runs under NonCancellable so no
+                    // cancellation window separates merge commit from routing finalization.
+                    var mergeCommitted = false
+                    try {
+                        withContext(NonCancellable + dispatchers.io) {
+                            mergeDatabases(source, dest, sourceName)
+                            mergeCommitted = true
+                            // Persist ALL routing metadata in one atomic DataStore edit.
+                            datastore.edit {
+                                deviceKey?.let { key -> it[key] = claimed }
+                                it[nodeKey] = claimed
+                                it[addrDbKey(transportAddress)] = claimed
+                                it[lastUsedKey(claimed)] = nowMillis
+                            }
+                            Logger.i {
+                                "Unified ${anonymizeDbName(
+                                    sourceName,
+                                )} into ${anonymizeDbName(claimed)} for node $nodeNum"
+                            }
+                            // Dest is canonical. Release blocked writers onto it, then retire source off the critical
+                            // path.
+                            releaseGateToDest()
+                            managerScope.launch(dispatchers.io) { retireDatabase(sourceName) }
+                        }
+                    } catch (e: CancellationException) {
+                        // NonCancellable suppresses parent cancellation, but a child could throw this.
+                        // Don't restore source after merge commit — release blocked writers onto dest.
+                        if (!mergeCommitted) {
+                            releaseGateToSource()
+                        } else {
+                            releaseGateToDest()
+                        }
+                        throw e
+                    } catch (e: Exception) {
+                        if (!mergeCommitted) {
+                            // merge() failed — transaction rolled back, no marker. Safe to release onto source.
+                            releaseGateToSource()
+                            Logger.w(e) {
+                                "Merge into ${anonymizeDbName(claimed)} failed; " +
+                                    "kept ${anonymizeDbName(sourceName)} active"
+                            }
+                        } else {
+                            // Merge committed but routing metadata persistence failed. Destination stays active
+                            // (merge marker exists); source is NOT retired. The already-unified branch on the
+                            // next connect repairs claims/alias atomically without re-copying source.
+                            releaseGateToDest()
+                            Logger.w(e) {
+                                "Routing metadata for ${anonymizeDbName(claimed)} failed after merge commit; " +
+                                    "destination remains active, routing will be repaired on next connect"
+                            }
+                        }
+                        return@withLock
                     }
-
-                    // Retire the merged source off the critical path; its data now lives in the canonical DB.
-                    managerScope.launch(dispatchers.io) { retireDatabase(sourceName) }
+                    // Propagate any cancellation that was suppressed during the NonCancellable finalization phase.
+                    currentCoroutineContext().ensureActive()
                 }
             }
         }
     }
 
-    /** Closes, deletes, and forgets a database whose contents have been merged into another. */
+    /**
+     * Logically retires a database whose contents have been merged into another.
+     *
+     * Physical close/delete is deferred — the merged source was published through [currentDb]; app-wide Flow, Paging,
+     * UI, worker, and one-shot read consumers may still hold its Room instance. Physically closing it now can surface
+     * "Connection pool is closed" to those readers (see [switchActiveDatabase] and [reopenActiveDatabaseIfStillCurrent]
+     * no-sync-close discipline). [close] or a later process performs the physical teardown.
+     */
     private suspend fun retireDatabase(dbName: String) = mutex.withLock {
-        runCatching {
-            closeCachedDatabase(dbName)
-            deleteDatabase(dbName)
-            datastore.edit { it.remove(lastUsedKey(dbName)) }
-        }
-            .onSuccess { Logger.i { "Retired merged DB ${anonymizeDbName(dbName)}" } }
-            .onFailure { Logger.w(it) { "Failed to retire merged database ${anonymizeDbName(dbName)}" } }
+        logicallyRetired.add(dbName)
+        Logger.i { "Logically retired merged DB ${anonymizeDbName(dbName)}; physical cleanup deferred" }
     }
 
     /**
@@ -305,7 +429,7 @@ open class DatabaseManager(
      * connections (5 per WAL-mode DB) indefinitely until explicitly closed. This method is the primary mechanism for
      * releasing those connections when a database is no longer the active target.
      */
-    private fun closeCachedDatabase(dbName: String) {
+    protected open suspend fun closeCachedDatabase(dbName: String) {
         val removed = dbCache.remove(dbName) ?: return
         runCatching { removed.close() }
             .onFailure { Logger.w(it) { "Failed to close cached database ${anonymizeDbName(dbName)}" } }
@@ -315,9 +439,9 @@ open class DatabaseManager(
     /**
      * Reopens the active database under [mutex], but only if it hasn't switched since the caller snapshotted it.
      *
-     * The replaced Room instance is intentionally left open for the rest of the process. [currentDb] is a derived
-     * StateFlow, so there is no deterministic handoff point where every app-wide collector has stopped using the old
-     * instance.
+     * The replaced Room instance is intentionally left open for the rest of the process. [currentDb] reads [_currentDb]
+     * directly, so every publication is visible to app-wide collectors on the same program step — but there is no
+     * deterministic handoff point where every collector has stopped using the previous instance.
      *
      * Returns the reopened DB, or null if another coroutine already switched to a different device.
      */
@@ -339,13 +463,13 @@ open class DatabaseManager(
         dbCache[expectedDbName] = reopened
         _currentDb.value = reopened
 
-        // Intentionally do not close expectedDb here. The public currentDb Flow is derived from
-        // _currentDb through stateIn, so downstream flatMapLatest collectors may still be using the
-        // replaced Room instance after this function emits the reopened DB. Closing the old pool here
-        // can surface "Connection pool is closed" to app-wide DB observers that do not have closed-pool
-        // recovery. This mirrors switchActiveDatabase's no-sync-close discipline; the leaked pool is
-        // bounded by rare active-DB reopen recovery events and is reclaimed on process death. Revisit
-        // once switching DB observers have explicit closed-pool resubscribe/retry handling.
+        // Intentionally do not close expectedDb here. The public currentDb Flow exposes _currentDb directly,
+        // so downstream flatMapLatest collectors may still be using the replaced Room instance after this
+        // function emits the reopened DB. Closing the old pool here can surface "Connection pool is closed"
+        // to app-wide DB observers that do not have closed-pool recovery. This mirrors switchActiveDatabase's
+        // no-sync-close discipline; the leaked pool is bounded by rare active-DB reopen recovery events and
+        // is reclaimed on process death. Revisit once switching DB observers have explicit closed-pool
+        // resubscribe/retry handling.
 
         reopened
     }
@@ -356,10 +480,10 @@ open class DatabaseManager(
     // one-shot DB-critical blocks through cancellation, then re-check cancellation so stale callers do not continue
     // after the DB releases. Long-lived Flow/Paging reads must stay out of withDb; revisit after direct currentDb.value
     // callers are audited and safe DB concurrency can be restored.
-    private val limitedIo = dispatchers.io.limitedParallelism(1)
+    protected open val limitedIo: CoroutineDispatcher by lazy { dispatchers.io.limitedParallelism(1) }
 
     /** Execute [block] with the current DB instance. Retries once if the pool closes during a DB switch. */
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "ReturnCount")
     override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? {
         val queuedAt = nowMillis
         return withContext(limitedIo) {
@@ -384,16 +508,33 @@ open class DatabaseManager(
     }
 
     /**
-     * Atomically snapshots the active DB and registers a writer against it. Before the first [switchActiveDatabase]
-     * `_currentDb` is still null, so fall back to the public [currentDb] view — the eagerly-opened default DB — giving
-     * withDb the exact DB-resolution semantics of a direct `currentDb.value` caller. Desktop never calls [init] until a
-     * device is selected, so without the fallback pre-connection writes (quick-chat actions, firmware/hardware cache
-     * refreshes) would silently no-op there instead of landing in the default DB the pre-connection flows read from.
+     * Atomically snapshots the canonical active DB (held by [_currentDb], which is initialized to the default DB at
+     * construction) and registers a writer against it.
+     *
+     * If an association attempt is in flight, the writer-admission gate is armed. The caller snapshots that gate under
+     * [writerTrackerMutex], awaits it outside the lock, then retries admission from the beginning. Selecting the active
+     * database and registering the writer happen in the same critical section, so an association cannot arm its gate
+     * between those operations. This guarantees a new `withDb` never writes to a DB that is being retired, nor lands on
+     * `dest` before its data exists.
      */
-    private suspend fun beginWrite(): MeshtasticDatabase = writerTrackerMutex.withLock {
-        val db = _currentDb.value ?: currentDb.value
-        activeWriters[db] = (activeWriters[db] ?: 0) + 1
-        db
+    private suspend fun beginWrite(): MeshtasticDatabase {
+        while (true) {
+            var admittedDb: MeshtasticDatabase? = null
+            val gate =
+                writerTrackerMutex.withLock {
+                    val pendingGate = writerGate
+                    if (pendingGate == null) {
+                        val db = _currentDb.value
+                        activeWriters[db] = (activeWriters[db] ?: 0) + 1
+                        admittedDb = db
+                    }
+                    pendingGate
+                }
+            admittedDb?.let {
+                return it
+            }
+            gate?.await()
+        }
     }
 
     /**
@@ -414,26 +555,66 @@ open class DatabaseManager(
         }
     }
 
-    /** Publishes [db]/[name] as active under the writer lock so concurrent [beginWrite]s order against the swap. */
-    private suspend fun publishActiveDb(db: MeshtasticDatabase, name: String) = writerTrackerMutex.withLock {
-        _currentDb.value = db
-        currentDbName = name
+    /**
+     * Folds [source] into [dest]. Override in tests to inject merge failures. Production delegates to
+     * [DatabaseMerger.merge]; the merge runs in a single transaction so a crash rolls back cleanly and the destination
+     * is never left half-merged.
+     */
+    protected open suspend fun mergeDatabases(
+        source: MeshtasticDatabase,
+        dest: MeshtasticDatabase,
+        sourceName: String,
+    ) {
+        DatabaseMerger.merge(source, dest, sourceName)
     }
+
+    /**
+     * Test-only snapshot of the writer tracker: total live writers and total pending drain waiters. Both are zero once
+     * every association attempt has released its gate and drained its source — a non-zero pair after a quiescent period
+     * indicates a leaked writer or waiter.
+     */
+    internal suspend fun debugWriterCounts(): Pair<Int, Int> =
+        writerTrackerMutex.withLock { activeWriters.values.sum() to drainWaiters.values.sumOf { it.size } }
 
     /**
      * Suspends until every writer that captured [db] before this call has finished, so a merge never snapshots [db]
      * while a write is still in flight (and then loses it when [db] is retired). Bounded by [WRITER_DRAIN_TIMEOUT_MS]
-     * so a wedged writer can't pin the merge — and [mutex] — forever; falling through on timeout is no worse than the
-     * old barrier-less behavior for that rare case.
+     * so a wedged writer can't pin the merge — and [mutex] — forever.
+     *
+     * Returns `true` if all writers drained (or none were active), `false` on timeout. The caller must abort the merge
+     * and roll the active DB back to source on `false`.
+     *
+     * The waiter is removed in a [finally] block on every exit path — success, timeout, and external cancellation — so
+     * a stale [CompletableDeferred] never leaks into [drainWaiters]. The cleanup runs under [NonCancellable] so
+     * cancellation during cleanup doesn't skip the removal.
      */
-    private suspend fun drainWriters(db: MeshtasticDatabase, dbName: String) {
+    @Suppress("ReturnCount")
+    private suspend fun drainWriters(db: MeshtasticDatabase, dbName: String): Boolean {
         val waiter =
             writerTrackerMutex.withLock {
-                if ((activeWriters[db] ?: 0) == 0) return
+                if ((activeWriters[db] ?: 0) == 0) return true
                 CompletableDeferred<Unit>().also { drainWaiters.getOrPut(db) { mutableListOf() }.add(it) }
             }
-        if (withTimeoutOrNull(WRITER_DRAIN_TIMEOUT_MS) { waiter.await() } == null) {
-            Logger.w { "Timed out draining writers on ${anonymizeDbName(dbName)} before merge" }
+        try {
+            val drained = withTimeoutOrNull(WRITER_DRAIN_TIMEOUT_MS) { waiter.await() }
+            if (drained == null) {
+                Logger.w { "Timed out draining writers on ${anonymizeDbName(dbName)} before merge" }
+                return false
+            }
+            return true
+        } finally {
+            // Remove our waiter on every exit path. On success, endWrite may have already removed the
+            // entire list — the removal is idempotent. On timeout or cancellation, the waiter is still
+            // registered and must be cleaned up so a late endWrite doesn't complete a dead deferred.
+            withContext(NonCancellable) {
+                writerTrackerMutex.withLock {
+                    val list = drainWaiters[db]
+                    if (list != null) {
+                        list.remove(waiter)
+                        if (list.isEmpty()) drainWaiters.remove(db)
+                    }
+                }
+            }
         }
     }
 
@@ -450,7 +631,7 @@ open class DatabaseManager(
             // If the active database switched while we held a reference to the old one,
             // and the exception indicates a closed pool/connection, retry with the new DB.
             val retryDb = _currentDb.value
-            if (retryDb != null && retryDb !== db && isDbClosedException(e)) {
+            if (retryDb !== db && isDbClosedException(e)) {
                 Logger.w { "withDb: database closed during switch (${e.message}), retrying with current DB" }
                 return retryRegisteredDbBlock(retryDb, e, block)
             }
@@ -458,7 +639,7 @@ open class DatabaseManager(
             // Same active DB but Room's connection pool is wedged — reopen onto a fresh active instance once.
             if (retryDb === db && isDbPoolAcquireTimeoutException(e)) {
                 val reopened = reopenActiveDatabaseIfStillCurrent(db, active)
-                val recoveredDb = reopened ?: _currentDb.value?.takeIf { it !== db } ?: throw e
+                val recoveredDb = reopened ?: _currentDb.value.takeIf { it !== db } ?: throw e
                 Logger.w {
                     if (reopened != null) {
                         "withDb: reopened active DB after transient Room connection-pool timeout"
@@ -606,7 +787,11 @@ open class DatabaseManager(
         val all = listExistingDbNames()
         // Only enforce the limit over device-specific DBs; exclude legacy and default DBs
         val deviceDbs =
-            all.filterNot { it == DatabaseConstants.LEGACY_DB_NAME || it == DatabaseConstants.DEFAULT_DB_NAME }
+            all.filterNot {
+                it in logicallyRetired ||
+                    it == DatabaseConstants.LEGACY_DB_NAME ||
+                    it == DatabaseConstants.DEFAULT_DB_NAME
+            }
 
         if (deviceDbs.size <= limit) return@withLock
         val usageSnapshot = deviceDbs.associateWith { lastUsed(it) }
@@ -685,13 +870,37 @@ open class DatabaseManager(
         }
     }
 
-    /** Closes all open databases and cancels background work. */
-    fun close() {
+    /** Closes all open databases, cancels background work, and physically cleans logically-retired sources. */
+    suspend fun close() {
         backfillJob?.cancel()
         backfillJob = null
         managerScope.cancel()
-        dbCache.values.forEach { it.close() }
-        dbCache.clear()
-        _currentDb.value = null
+        // Wait for manager-owned jobs, then transfer cache ownership while serialized against external switches and
+        // associations. Close outside the mutex so Room teardown cannot block other mutex cleanup.
+        managerScope.coroutineContext[Job]?.join()
+        val cachedDatabases =
+            mutex.withLock {
+                val cached = dbCache.values.distinct()
+                dbCache.clear()
+                cached
+            }
+        cachedDatabases.forEach { db ->
+            runCatching { db.close() }.onFailure { Logger.w(it) { "Failed to close database during shutdown" } }
+        }
+        // Physically delete logically-retired source databases now that no application consumer should remain.
+        // The Room instances were already closed from the ownership snapshot above; this loop removes the
+        // orphaned files and their last-used metadata. Idempotent: a later process also cleans these via
+        // cache-limit eviction since routing metadata points at the destination.
+        mutex.withLock {
+            logicallyRetired.forEach { name ->
+                runCatching {
+                    deleteDatabase(name)
+                    datastore.edit { it.remove(lastUsedKey(name)) }
+                }
+                    .onSuccess { Logger.i { "Physically retired merged DB ${anonymizeDbName(name)}" } }
+                    .onFailure { Logger.w(it) { "Failed to physically retire merged DB ${anonymizeDbName(name)}" } }
+            }
+            logicallyRetired.clear()
+        }
     }
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/MeshLogDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/MeshLogDao.kt
@@ -20,11 +20,24 @@ import androidx.room3.Dao
 import androidx.room3.Insert
 import androidx.room3.OnConflictStrategy
 import androidx.room3.Query
+import androidx.room3.Transaction
 import kotlinx.coroutines.flow.Flow
+import org.meshtastic.core.database.DatabaseConstants.SQLITE_MAX_BIND_PARAMETERS
 import org.meshtastic.core.database.entity.MeshLog
 
 @Dao
+@Suppress("TooManyFunctions")
 interface MeshLogDao {
+
+    companion object {
+        /** Shared SQL for querying logs by from_num and port_num, used by both Flow and snapshot variants. */
+        private const val LOGS_FROM_QUERY =
+            """
+            SELECT * FROM log
+            WHERE from_num = :fromNum AND (:portNum = -1 OR port_num = :portNum)
+            ORDER BY received_date DESC LIMIT :maxItem
+            """
+    }
 
     @Query("SELECT * FROM log ORDER BY received_date DESC LIMIT :maxItem")
     fun getAllLogs(maxItem: Int): Flow<List<MeshLog>>
@@ -37,13 +50,7 @@ interface MeshLogDao {
      *
      * @param portNum If -1, returns all logs regardless of port. If 0, returns logs with port 0.
      */
-    @Query(
-        """
-        SELECT * FROM log 
-        WHERE from_num = :fromNum AND (:portNum = -1 OR port_num = :portNum)
-        ORDER BY received_date DESC LIMIT :maxItem
-        """,
-    )
+    @Query(LOGS_FROM_QUERY)
     fun getLogsFrom(fromNum: Int, portNum: Int, maxItem: Int): Flow<List<MeshLog>>
 
     @Insert suspend fun insert(log: MeshLog)
@@ -72,4 +79,24 @@ interface MeshLogDao {
 
     @Query("DELETE FROM log WHERE received_date < :cutoffTimestamp")
     suspend fun deleteOlderThan(cutoffTimestamp: Long)
+
+    /**
+     * Suspend snapshot variant of [getLogsFrom] for one-shot reads (no Flow observer overhead). Used when a caller
+     * needs to read-then-process-then-delete in two steps — the selection requires Kotlin parsing so it stays outside
+     * the delete transaction, but the delete itself is atomic (see [deleteLogsByUuidAtomic]).
+     */
+    @Query(LOGS_FROM_QUERY)
+    suspend fun getLogsSnapshot(fromNum: Int, portNum: Int, maxItem: Int): List<MeshLog>
+
+    /**
+     * Atomically deletes all logs matching [uuids], chunking internally to stay under SQLite's bind-parameter limit.
+     * The entire batch is all-or-nothing: a failure rolls back every chunk.
+     */
+    @Transaction
+    suspend fun deleteLogsByUuidAtomic(uuids: List<String>) {
+        if (uuids.isEmpty()) return
+        for (chunk in uuids.chunked(SQLITE_MAX_BIND_PARAMETERS)) {
+            deleteLogsByUuid(chunk)
+        }
+    }
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
@@ -28,15 +28,17 @@ import androidx.room3.Upsert
 import kotlinx.coroutines.flow.Flow
 import okio.ByteString
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.database.DatabaseConstants.SQLITE_MAX_BIND_PARAMETERS
 import org.meshtastic.core.database.entity.ContactSettings
 import org.meshtastic.core.database.entity.Packet
 import org.meshtastic.core.database.entity.PacketEntity
 import org.meshtastic.core.database.entity.ReactionEntity
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.proto.ChannelSettings
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LargeClass")
 @Dao
 interface PacketDao {
 
@@ -574,6 +576,168 @@ interface PacketDao {
 
     @Query("UPDATE packet SET show_translated = :show WHERE uuid = :uuid")
     suspend fun setShowTranslated(uuid: Long, show: Boolean)
+
+    // region ── Atomic read-modify-write transactions ──
+
+    /**
+     * Atomically updates the last-read message pointer for [contact], preserving the monotonic-timestamp guard: if
+     * [lastReadTimestamp] is not newer than the stored value, the method is a no-op. Creates the contact-settings row
+     * if absent. Uses INSERT OR IGNORE + conditional UPDATE instead of a read-then-@Upsert so the existing row's
+     * unrelated columns (muteUntil, filteringDisabled) are preserved without a Kotlin-side read-modify-write.
+     */
+    @Transaction
+    suspend fun updateLastReadMessage(contact: String, messageUuid: Long, lastReadTimestamp: Long) {
+        insertContactSettingsIgnore(listOf(ContactSettings(contact_key = contact)))
+        updateLastReadMessageIfNewer(contact, messageUuid, lastReadTimestamp)
+    }
+
+    /**
+     * Conditional UPDATE that only writes newer timestamps. Callers must ensure the contact-settings row exists (e.g.
+     * via [insertContactSettingsIgnore]) before calling this inside the same transaction.
+     *
+     * Returns the affected row count (1 = updated, 0 = no-op) for testability; callers outside tests typically ignore
+     * it.
+     */
+    @Query(
+        """
+        UPDATE contact_settings
+        SET last_read_message_uuid = :messageUuid,
+            last_read_message_timestamp = :lastReadTimestamp
+        WHERE contact_key = :contact
+          AND (
+              last_read_message_timestamp IS NULL
+              OR last_read_message_timestamp < :lastReadTimestamp
+          )
+        """,
+    )
+    suspend fun updateLastReadMessageIfNewer(contact: String, messageUuid: Long, lastReadTimestamp: Long): Int
+
+    /**
+     * Atomically finds a packet by identity key (id + from + to) and updates its data, optionally stamping
+     * [routingError] when it is non-negative. Mirrors the existing [updateMessageStatus] / [updateMessageId] pattern.
+     */
+    @Transaction
+    suspend fun updatePacketByKey(data: DataPacket, routingError: Int) {
+        findPacketsWithId(data.id)
+            .find { it.data.id == data.id && it.data.from == data.from && it.data.to == data.to }
+            ?.let { existing ->
+                val updated =
+                    if (routingError >= 0) {
+                        existing.copy(data = data, routingError = routingError)
+                    } else {
+                        existing.copy(data = data)
+                    }
+                update(updated)
+            }
+    }
+
+    /**
+     * Atomically finds a reaction by [replacement]'s packetId + userId + emoji and updates it, borrowing
+     * [myNodeNum][ReactionEntity.myNodeNum] from the existing row. No-op if no match is found.
+     */
+    @Transaction
+    suspend fun updateReactionByKey(replacement: ReactionEntity) {
+        val existing =
+            findReactionsWithId(replacement.packetId).find {
+                it.userId == replacement.userId && it.emoji == replacement.emoji
+            } ?: return
+        // myNodeNum is part of the composite PK and must come from the existing row.
+        update(replacement.copy(myNodeNum = existing.myNodeNum))
+    }
+
+    /**
+     * Atomically applies an SFPP delivery-status transition to every packet and reaction matching [packetId] + address
+     * ([from]/[to]). Preserves the no-downgrade invariant: an item already
+     * [SFPP_CONFIRMED][MessageStatus.SFPP_CONFIRMED] is not regressed to [SFPP_ROUTING][MessageStatus.SFPP_ROUTING].
+     * All updates land in one transaction so a packet and its reactions cannot end up in inconsistent delivery states.
+     */
+    @Suppress("CyclomaticComplexMethod", "LongParameterList")
+    @Transaction
+    suspend fun applySFPPStatus(
+        packetId: Int,
+        from: Int,
+        to: Int,
+        hash: ByteString,
+        status: MessageStatus,
+        rxTime: Long,
+        myNodeNum: Int?,
+    ) {
+        val packets = findPacketsWithId(packetId)
+        val reactions = findReactionsWithId(packetId)
+        val fromId = NodeAddress.numToDefaultId(from)
+        val isFromLocalNode = myNodeNum != null && from == myNodeNum
+        val toId =
+            if (to == 0 || to == NodeAddress.NODENUM_BROADCAST) {
+                NodeAddress.ID_BROADCAST
+            } else {
+                NodeAddress.numToDefaultId(to)
+            }
+
+        packets.forEach { packet ->
+            val fromMatches =
+                packet.data.from == fromId || (isFromLocalNode && packet.data.from == NodeAddress.ID_LOCAL)
+            if (fromMatches && packet.data.to == toId) {
+                if (packet.data.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
+                    return@forEach
+                }
+                val newTime = if (rxTime > 0) rxTime * MILLIS_PER_SECOND else packet.received_time
+                val updatedData = packet.data.copy(status = status, sfppHash = hash, time = newTime)
+                update(packet.copy(data = updatedData, sfpp_hash = hash, received_time = newTime))
+            }
+        }
+
+        reactions.forEach { reaction ->
+            val fromMatches = reaction.userId == fromId || (isFromLocalNode && reaction.userId == NodeAddress.ID_LOCAL)
+            if (fromMatches && (reaction.to == null || reaction.to == toId)) {
+                if (reaction.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
+                    return@forEach
+                }
+                val newTime = if (rxTime > 0) rxTime * MILLIS_PER_SECOND else reaction.timestamp
+                update(reaction.copy(status = status, sfpp_hash = hash, timestamp = newTime))
+            }
+        }
+    }
+
+    /**
+     * Atomically applies an SFPP delivery-status transition to the single packet and single reaction matching [hash]
+     * (8-byte prefix). Same no-downgrade invariant as [applySFPPStatus]. Both updates land in one transaction.
+     */
+    @Transaction
+    suspend fun applySFPPStatusByHash(hash: ByteString, status: MessageStatus, rxTime: Long) {
+        findPacketBySfppHash(hash)?.let { packet ->
+            if (packet.data.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
+                return@let
+            }
+            val newTime = if (rxTime > 0) rxTime * MILLIS_PER_SECOND else packet.received_time
+            val updatedData = packet.data.copy(status = status, sfppHash = hash, time = newTime)
+            update(packet.copy(data = updatedData, sfpp_hash = hash, received_time = newTime))
+        }
+        findReactionBySfppHash(hash)?.let { reaction ->
+            if (reaction.status == MessageStatus.SFPP_CONFIRMED && status == MessageStatus.SFPP_ROUTING) {
+                return@let
+            }
+            val newTime = if (rxTime > 0) rxTime * MILLIS_PER_SECOND else reaction.timestamp
+            update(reaction.copy(status = status, sfpp_hash = hash, timestamp = newTime))
+        }
+    }
+
+    /**
+     * Atomically deletes all messages (and their reactions) for the given [uuidList], chunking internally to stay under
+     * SQLite's bind-parameter limit. The entire batch is all-or-nothing: a failure rolls back every chunk.
+     */
+    @Transaction
+    suspend fun deleteMessagesAtomic(uuidList: List<Long>) {
+        if (uuidList.isEmpty()) return
+        for (chunk in uuidList.chunked(SQLITE_MAX_BIND_PARAMETERS)) {
+            deleteMessages(chunk)
+        }
+    }
+
+    // endregion
+
+    companion object {
+        private const val MILLIS_PER_SECOND = 1000L
+    }
 
     // region ── FTS5 Search ──
 

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/TracerouteNodePositionDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/TracerouteNodePositionDao.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.database.dao
 
 import androidx.room3.Dao
 import androidx.room3.Query
+import androidx.room3.Transaction
 import androidx.room3.Upsert
 import kotlinx.coroutines.flow.Flow
 import org.meshtastic.core.database.entity.TracerouteNodePositionEntity
@@ -35,4 +36,17 @@ interface TracerouteNodePositionDao {
     suspend fun getAllSnapshot(): List<TracerouteNodePositionEntity>
 
     @Upsert suspend fun insertAll(entities: List<TracerouteNodePositionEntity>)
+
+    /**
+     * Atomically replaces all positions for [logUuid]: deletes the old snapshot and inserts [entities] in one
+     * transaction. If insertion fails, the old snapshot is preserved (rollback). Observers never see an empty
+     * intermediate state.
+     */
+    @Transaction
+    suspend fun replaceByLogUuid(logUuid: String, entities: List<TracerouteNodePositionEntity>) {
+        deleteByLogUuid(logUuid)
+        if (entities.isNotEmpty()) {
+            insertAll(entities)
+        }
+    }
 }

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerAssociationTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerAssociationTest.kt
@@ -1,0 +1,659 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.encodeUtf8
+import okio.FileSystem
+import okio.Path
+import org.meshtastic.core.database.entity.MyNodeEntity
+import org.meshtastic.core.di.CoroutineDispatchers
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Verifies the merge association state machine in [DatabaseManager]: writer-drain timeout restores the source DB so the
+ * merge retries on the next connect, cancellation during the drain is cleaned up without leaking waiters, and a
+ * successful merge persists all routing metadata (device claim, node claim, address alias) in one atomic DataStore
+ * edit.
+ *
+ * Uses [UnconfinedTestDispatcher] so background coroutines launched by [DatabaseManager] run eagerly, and
+ * [advanceTimeBy] to drive the [DatabaseManager.WRITER_DRAIN_TIMEOUT_MS] timeout deterministically.
+ */
+class DatabaseManagerAssociationTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var dataStoreScope: CoroutineScope
+
+    private lateinit var tmpDir: Path
+    private lateinit var armableDs: ArmableDataStore
+    private lateinit var dispatchers: CoroutineDispatchers
+    private lateinit var manager: TestDatabaseManager
+
+    @BeforeTest
+    fun setUp() {
+        tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "dbManagerAssocTest-${Uuid.random()}"
+        FileSystem.SYSTEM.createDirectories(tmpDir)
+        dataStoreScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        val realDatastore =
+            PreferenceDataStoreFactory.createWithPath(
+                scope = dataStoreScope,
+                produceFile = { tmpDir / "test.preferences_pb" },
+            )
+        armableDs = ArmableDataStore(realDatastore)
+        dispatchers = CoroutineDispatchers(testDispatcher, testDispatcher, testDispatcher)
+        manager = TestDatabaseManager(armableDs, dispatchers)
+    }
+
+    @AfterTest
+    fun tearDown() = runTest(testDispatcher) {
+        manager.close()
+        dataStoreScope.cancel()
+        runCurrent()
+        FileSystem.SYSTEM.deleteRecursively(tmpDir)
+    }
+
+    /**
+     * Overrides [buildDatabase] to create distinct in-memory DBs per [dbName]. Each call to
+     * [getInMemoryDatabaseBuilder] returns a new Room instance with its own connection, so
+     * [dbCache][DatabaseManager.dbCache] entries for different names are genuinely separate databases.
+     */
+    private class TestDatabaseManager(
+        datastore: DataStore<Preferences>,
+        private val testDispatchers: CoroutineDispatchers,
+    ) : DatabaseManager(datastore, testDispatchers) {
+        override fun buildDatabase(dbName: String): MeshtasticDatabase = getInMemoryDatabaseBuilder().build()
+
+        override val limitedIo: kotlinx.coroutines.CoroutineDispatcher
+            get() = testDispatchers.default
+
+        /**
+         * No-op: in-memory test databases have no filesystem directory, so LRU eviction, legacy-DB cleanup, and FTS
+         * search-index backfill would crash on Android host tests trying to access platform singletons.
+         */
+        override fun schedulePostSwitchMaintenance(dbName: String, db: MeshtasticDatabase) = Unit
+
+        /** When non-null, [mergeDatabases] throws this before the merge commits, simulating a pre-commit failure. */
+        var failMergeWith: Exception? = null
+
+        override suspend fun mergeDatabases(source: MeshtasticDatabase, dest: MeshtasticDatabase, sourceName: String) {
+            failMergeWith?.let { throw it }
+            super.mergeDatabases(source, dest, sourceName)
+        }
+    }
+
+    /** Builds a minimal [MyNodeEntity] carrying only [num] for association/merge write-leak checks. */
+    private fun myNode(num: Int) = MyNodeEntity(
+        myNodeNum = num,
+        model = null,
+        firmwareVersion = null,
+        couldUpdate = false,
+        shouldUpdate = false,
+        currentPacketId = 0L,
+        messageTimeoutMsec = 0,
+        minAppVersion = 0,
+        maxChannels = 0,
+        hasWifi = false,
+    )
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /** Hex-encoded [deviceId] as [deviceDbPrefKey] would produce it. */
+    private fun deviceKeyHex(deviceId: String): String = deviceId.encodeUtf8().hex()
+
+    /**
+     * Sets up two switched databases (addrA claimed as canonical, addrB active) and returns the two DB instances plus
+     * the claimed canonical DB name.
+     */
+    private suspend fun setupTwoDatabases(): Pair<MeshtasticDatabase, MeshtasticDatabase> {
+        manager.switchActiveDatabase("addrA")
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+        val dbA = manager.currentDb.value
+
+        manager.switchActiveDatabase("addrB")
+        val dbB = manager.currentDb.value
+
+        return dbA to dbB
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────────
+
+    /**
+     * 1 + 2 combined: A writer holding the source DB's withDb lane causes the drain to time out, aborting the merge and
+     * restoring the source. After releasing the writer, a retry succeeds — the merge commits, dest becomes canonical,
+     * and the active DB switches.
+     */
+    @Test
+    fun drainTimeoutRestoresSourceAndRetrySucceeds() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+        assertEquals(dbB, manager.currentDb.value, "addrB's DB should be active before association")
+
+        // Hold a withDb writer on addrB's DB so drainWriters can't complete.
+        val gate = CompletableDeferred<Unit>()
+        val writerJob = launch {
+            manager.withDb {
+                gate.await()
+                null
+            }
+        }
+
+        // associateDevice should reach the merge branch, publish dest, then time out on the drain.
+        val associateJob = launch { manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+
+        // Advance virtual time past WRITER_DRAIN_TIMEOUT_MS (5_000ms) to trigger the drain timeout.
+        advanceTimeBy(5_501)
+        assertTrue(associateJob.isCompleted, "associateDevice should complete after drain timeout")
+        assertEquals(dbB, manager.currentDb.value, "source (addrB) should be restored after drain timeout")
+
+        // Release the writer gate so the source DB quiesces.
+        gate.complete(Unit)
+        writerJob.join()
+
+        // Retry: with no writer in-flight, the drain succeeds and the merge commits.
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+
+        assertEquals(
+            dbA,
+            manager.currentDb.value,
+            "dest (addrA's canonical DB) should be active after successful merge",
+        )
+    }
+
+    /**
+     * 3: Cancelling [associateDevice] during the writer-drain wait propagates [CancellationException], restores the
+     * source DB, and does not leak the drain waiter — a subsequent retry succeeds.
+     */
+    @Test
+    fun cancellationDuringDrainRestoresSource() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        val gate = CompletableDeferred<Unit>()
+        val writerJob = launch {
+            manager.withDb {
+                gate.await()
+                null
+            }
+        }
+
+        val associateJob = launch { manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+
+        // Cancel while suspended in drainWriters (before the 5s timeout fires).
+        associateJob.cancelAndJoin()
+
+        assertTrue(associateJob.isCancelled, "associateDevice coroutine should be cancelled")
+        assertEquals(
+            dbB,
+            manager.currentDb.value,
+            "source should be restored after cancellation (NonCancellable publishActiveDb)",
+        )
+
+        // Release the writer and retry — if the drain waiter leaked, the retry would also stall.
+        gate.complete(Unit)
+        writerJob.join()
+
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+
+        assertEquals(
+            dbA,
+            manager.currentDb.value,
+            "retry should succeed after cancellation cleanup — dest is canonical",
+        )
+    }
+
+    /**
+     * 4: A successful association persists device, node, and address routing metadata in one atomic DataStore edit, all
+     * pointing to the same canonical DB.
+     */
+    @Test
+    fun atomicRoutingMetadataAllPointToCanonical() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+        manager.switchActiveDatabase("addrB")
+
+        // No writer is held, so the drain succeeds immediately and the merge commits.
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+
+        val prefs = armableDs.data.first()
+        val deviceClaim = prefs[stringPreferencesKey("device_db_for:${deviceKeyHex("deadbeefdeadbeef")}")]
+        val nodeClaim = prefs[stringPreferencesKey("node_db_for:123")]
+        val addrClaim = prefs[stringPreferencesKey("addr_db_for:ADDRB")]
+
+        assertNotNull(deviceClaim, "device-id claim should be persisted")
+        assertNotNull(nodeClaim, "node-num claim should be persisted")
+        assertNotNull(addrClaim, "address alias should be persisted")
+        assertEquals(deviceClaim, nodeClaim, "device and node claims point to the same DB")
+        assertEquals(deviceClaim, addrClaim, "address alias points to the same canonical DB")
+    }
+
+    // ── Post-merge cancellation and routing-recovery tests ─────────────────────
+
+    /**
+     * Armable DataStore wrapper that can inject faults deterministically.
+     *
+     * Modes:
+     * - [Mode.Normal]: delegates normally.
+     * - [Mode.FailBeforeCommit]: throws [exception] before delegating, then resets to Normal.
+     * - [Mode.FailAfterCommit]: delegates first (durably commits), then throws [exception], then resets to Normal.
+     *
+     * Each fault fires once; subsequent edits succeed normally. This avoids fragile edit-count assumptions.
+     */
+    private class ArmableDataStore(private val delegate: DataStore<Preferences>) : DataStore<Preferences> {
+        override val data
+            get() = delegate.data
+
+        sealed interface Mode {
+            data object Normal : Mode
+
+            data class FailBeforeCommit(val exception: Exception) : Mode
+
+            data class FailAfterCommit(val exception: Exception) : Mode
+        }
+
+        var mode: Mode = Mode.Normal
+        private var faultFired = false
+
+        @Suppress("TooGenericExceptionThrown")
+        override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+            when (val m = mode) {
+                is Mode.Normal -> delegate.updateData(transform)
+
+                is Mode.FailBeforeCommit -> {
+                    if (!faultFired) {
+                        faultFired = true
+                        mode = Mode.Normal
+                        throw m.exception
+                    }
+                    delegate.updateData(transform)
+                }
+
+                is Mode.FailAfterCommit -> {
+                    val result = delegate.updateData(transform)
+                    if (!faultFired) {
+                        faultFired = true
+                        mode = Mode.Normal
+                        throw m.exception
+                    }
+                    result
+                }
+            }
+
+        fun reset() {
+            mode = Mode.Normal
+            faultFired = false
+        }
+
+        fun armFailBeforeCommit(exception: Exception) {
+            mode = Mode.FailBeforeCommit(exception)
+            faultFired = false
+        }
+
+        fun armFailAfterCommit(exception: Exception) {
+            mode = Mode.FailAfterCommit(exception)
+            faultFired = false
+        }
+    }
+
+    /**
+     * Commit-then-cancel: the routing DataStore edit commits durably, then the wrapper throws CancellationException.
+     * Destination must remain active, all routing metadata must agree, and cancellation must propagate.
+     */
+    @Test
+    fun cancellationAfterMergeCommitKeepsDestination() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+        assertEquals(dbB, manager.currentDb.value, "addrB should be active before association")
+
+        armableDs.armFailAfterCommit(CancellationException("post-merge cancel"))
+
+        var caught: CancellationException? = null
+        try {
+            manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+        } catch (e: CancellationException) {
+            caught = e
+        }
+        assertNotNull(caught, "CancellationException should propagate after merge commit")
+        assertEquals(dbA, manager.currentDb.value, "destination must remain active — source is NOT restored")
+
+        // Routing metadata was durably committed before the wrapper threw. All claims must agree.
+        val prefs = armableDs.data.first()
+        val deviceClaim = prefs[stringPreferencesKey("device_db_for:${deviceKeyHex("deadbeefdeadbeef")}")]
+        val nodeClaim = prefs[stringPreferencesKey("node_db_for:123")]
+        val addrClaim = prefs[stringPreferencesKey("addr_db_for:ADDRB")]
+        assertNotNull(deviceClaim, "device claim committed")
+        assertNotNull(nodeClaim, "node claim committed")
+        assertNotNull(addrClaim, "address alias committed")
+        assertEquals(deviceClaim, nodeClaim, "device and node claims agree")
+        assertEquals(deviceClaim, addrClaim, "address alias agrees with claims")
+    }
+
+    /**
+     * DataStore failure after merge: routing edit never commits. Destination stays active (marker exists), source is
+     * not retired. Before retry, address alias is absent. After retry, all routing metadata agrees.
+     */
+    @Test
+    fun dataStoreFailureAfterMergeKeepsDestinationAndRepairsOnRetry() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        armableDs.armFailBeforeCommit(RuntimeException("simulated DataStore failure"))
+
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+        assertEquals(dbA, manager.currentDb.value, "dest must remain active — source is NOT restored")
+
+        // Before retry: routing metadata was NOT persisted (FailBeforeCommit prevented the edit).
+        val prefsBefore = armableDs.data.first()
+        assertNull(
+            prefsBefore[stringPreferencesKey("addr_db_for:ADDRB")],
+            "address alias must be absent before repair — routing edit failed",
+        )
+
+        // Retry repairs routing metadata via the already-unified branch.
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+
+        val prefsAfter = armableDs.data.first()
+        val deviceClaim = prefsAfter[stringPreferencesKey("device_db_for:${deviceKeyHex("deadbeefdeadbeef")}")]
+        val nodeClaim = prefsAfter[stringPreferencesKey("node_db_for:123")]
+        val addrClaim = prefsAfter[stringPreferencesKey("addr_db_for:ADDRB")]
+        assertNotNull(deviceClaim, "device claim repaired")
+        assertNotNull(nodeClaim, "node claim repaired")
+        assertNotNull(addrClaim, "address alias repaired")
+        assertEquals(deviceClaim, nodeClaim, "device and node claims agree after repair")
+        assertEquals(deviceClaim, addrClaim, "address alias agrees after repair")
+    }
+
+    /**
+     * After a post-merge routing failure, new writes land in destination (not source), proving source is never
+     * reactivated past the merge-commit boundary.
+     */
+    @Test
+    fun postMergeWriteLandsInDestination() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        armableDs.armFailBeforeCommit(RuntimeException("simulated DataStore failure"))
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+
+        val destDb = manager.currentDb.value
+        assertEquals(dbA, destDb, "destination is dbA (the canonical DB)")
+
+        manager.withDb {
+            it.nodeInfoDao()
+                .setMyNodeInfo(
+                    MyNodeEntity(
+                        myNodeNum = 999,
+                        model = null,
+                        firmwareVersion = null,
+                        couldUpdate = false,
+                        shouldUpdate = false,
+                        currentPacketId = 0L,
+                        messageTimeoutMsec = 0,
+                        minAppVersion = 0,
+                        maxChannels = 0,
+                        hasWifi = false,
+                    ),
+                )
+        }
+
+        // The write exists in destination.
+        val destMyNode = destDb.nodeInfoDao().getMyNodeInfo().first()
+        assertNotNull(destMyNode, "post-merge write landed in destination")
+        assertEquals(999, destMyNode?.myNodeNum, "write is durable in destination")
+
+        // The write does NOT exist in source.
+        val sourceMyNode = dbB.nodeInfoDao().getMyNodeInfo().first()
+        assertNull(sourceMyNode, "source must not have the post-merge write")
+    }
+
+    // ── Writer-admission gate tests ─────────────────────────────────────────────
+    //
+    // These exercise the admission barrier added so a new `withDb` writer that arrives during an association attempt
+    // never captures a DB that is being retired (source) or one that does not yet exist (dest). Source stays canonical
+    // until the merge commits; the gate blocks the writer and releases it onto `source` on abort or `dest` on commit.
+
+    /**
+     * A writer that arrives while the drain is in progress is blocked at the admission gate — its block has not run —
+     * and is released onto destination once the merge commits.
+     */
+    @Test
+    fun writerArrivingDuringDrainIsBlockedAndReleasedToDestOnCommit() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        // Hold a pre-existing source writer so the drain stays pending and a new writer can arrive into the gate.
+        val preGate = CompletableDeferred<Unit>()
+        val preWriter = launch {
+            manager.withDb {
+                preGate.await()
+                null
+            }
+        }
+        val associateJob = launch { manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+
+        val newWriterStarted = CompletableDeferred<Unit>()
+        val newWriterDb = CompletableDeferred<MeshtasticDatabase>()
+        val newWriterJob = launch {
+            manager.withDb { db ->
+                newWriterStarted.complete(Unit)
+                newWriterDb.complete(db)
+                null
+            }
+        }
+
+        // The new writer must be suspended at the admission gate, not running its block.
+        assertFalse(newWriterStarted.isCompleted, "new writer must block at the admission gate during the drain")
+        assertFalse(newWriterDb.isCompleted, "new writer must not have captured a DB yet")
+
+        // Release the pre-existing writer: drain completes, merge commits, gate releases onto dest.
+        preGate.complete(Unit)
+        newWriterJob.join()
+        associateJob.join()
+        preWriter.join()
+
+        assertTrue(newWriterStarted.isCompleted, "new writer must be released after the merge commits")
+        assertEquals(dbA, newWriterDb.getCompleted(), "new writer released onto destination after successful merge")
+        assertEquals(dbA, manager.currentDb.value, "destination is canonical after commit")
+    }
+
+    /** A successful merge releases the blocked writer onto destination (not source). */
+    @Test
+    fun successfulMergeReleasesBlockedWriterOntoDestination() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        val preGate = CompletableDeferred<Unit>()
+        val preWriter = launch {
+            manager.withDb {
+                preGate.await()
+                null
+            }
+        }
+        val associateJob = launch { manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+
+        val newWriterDb = CompletableDeferred<MeshtasticDatabase>()
+        val newWriterJob = launch {
+            manager.withDb { db ->
+                newWriterDb.complete(db)
+                null
+            }
+        }
+
+        assertFalse(newWriterDb.isCompleted, "new writer must block during the drain")
+        preGate.complete(Unit)
+        val usedDb = newWriterDb.await()
+        assertEquals(dbA, usedDb, "blocked writer released onto destination after successful merge")
+        assertEquals(dbA, manager.currentDb.value, "destination is canonical after commit")
+
+        associateJob.join()
+        preWriter.join()
+        newWriterJob.join()
+    }
+
+    /** A pre-commit merge failure releases the blocked writer onto source; the destination is never activated. */
+    @Test
+    fun preCommitMergeFailureReleasesBlockedWriterOntoSource() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        manager.failMergeWith = RuntimeException("simulated pre-commit merge failure")
+
+        val preGate = CompletableDeferred<Unit>()
+        val preWriter = launch {
+            manager.withDb {
+                preGate.await()
+                null
+            }
+        }
+        val associateJob = launch { manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+
+        val newWriterDb = CompletableDeferred<MeshtasticDatabase>()
+        val newWriterJob = launch {
+            manager.withDb { db ->
+                newWriterDb.complete(db)
+                null
+            }
+        }
+
+        preGate.complete(Unit)
+        val usedDb = newWriterDb.await()
+        assertEquals(dbB, usedDb, "blocked writer released onto source after pre-commit merge failure")
+        associateJob.join()
+        assertEquals(dbB, manager.currentDb.value, "source remains active after merge failure")
+
+        preWriter.join()
+        newWriterJob.join()
+    }
+
+    /**
+     * Cancelling the attempt while a writer is blocked at the gate releases the gate onto source and leaves no waiter
+     * leaked.
+     */
+    @Test
+    fun cancellationReleasesAdmissionGateOntoSource() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        val preGate = CompletableDeferred<Unit>()
+        val preWriter = launch {
+            manager.withDb {
+                preGate.await()
+                null
+            }
+        }
+        val associateJob = launch { manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+
+        val newWriterDb = CompletableDeferred<MeshtasticDatabase>()
+        val newWriterJob = launch {
+            manager.withDb { db ->
+                newWriterDb.complete(db)
+                null
+            }
+        }
+
+        associateJob.cancelAndJoin()
+        val usedDb = newWriterDb.await()
+        assertEquals(dbB, usedDb, "gate released onto source when the attempt is cancelled")
+        assertEquals(dbB, manager.currentDb.value, "source active after cancellation")
+
+        preGate.complete(Unit)
+        preWriter.join()
+        newWriterJob.join()
+    }
+
+    /**
+     * After a full association cycle with an admission-gated writer, the writer tracker holds no live writers and no
+     * pending drain waiters — counts and waiters are balanced.
+     */
+    @Test
+    fun writerCountsAndDrainWaitersRemainBalanced() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+
+        val preGate = CompletableDeferred<Unit>()
+        val preWriter = launch {
+            manager.withDb {
+                preGate.await()
+                null
+            }
+        }
+        val associateJob = launch { manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+        val newWriterJob = launch { manager.withDb { _ -> null } }
+
+        preGate.complete(Unit)
+        associateJob.join()
+        preWriter.join()
+        newWriterJob.join()
+
+        val (writers, waiters) = manager.debugWriterCounts()
+        assertEquals(0, writers, "no leaked writers after association")
+        assertEquals(0, waiters, "no pending drain waiters after association")
+    }
+
+    // ── Logical retirement regression ───────────────────────────────────────────
+
+    /**
+     * After a successful merge, the retired source database must remain open — app-wide consumers may still hold
+     * references to the published source Room instance. A direct DAO read through the retained source reference must
+     * succeed, proving the pool was not physically closed during the process. Destination must be canonical and
+     * writer/waiter counts must be balanced.
+     */
+    @Test
+    fun sourcePoolStaysOpenAfterLogicalRetirement() = runTest(testDispatcher) {
+        val (dbA, dbB) = setupTwoDatabases()
+        assertEquals(dbB, manager.currentDb.value, "addrB's DB should be active before association")
+        val sourceDb = manager.currentDb.value
+
+        // Successful merge logically retires the source but does not close its pool.
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+        assertEquals(dbA, manager.currentDb.value, "destination must be canonical after successful merge")
+
+        // Direct DAO read on the retained source reference — must succeed (pool still open).
+        val sourceMyNode = sourceDb.nodeInfoDao().getMyNodeInfo().first()
+        assertNull(sourceMyNode, "source read must succeed (pool open); source content is empty by default")
+
+        val (writers, waiters) = manager.debugWriterCounts()
+        assertEquals(0, writers, "no leaked writers after association")
+        assertEquals(0, waiters, "no pending drain waiters after association")
+    }
+
+    /**
+     * [DatabaseManager.close] must be idempotent after logical retirement: calling close twice must not throw. The
+     * first close physically cleans the logically-retired source; the second close is a safe no-op because the cache
+     * and retirement set are already empty.
+     */
+    @Test
+    fun closeIsIdempotentAndCleansRetiredSources() = runTest(testDispatcher) {
+        setupTwoDatabases()
+        manager.associateDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef")
+
+        manager.close()
+        manager.close()
+    }
+}

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/MeshLogDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/MeshLogDaoTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.dao
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.database.MeshtasticDatabase
+import org.meshtastic.core.database.entity.MeshLog
+import org.meshtastic.core.database.getInMemoryDatabaseBuilder
+import org.meshtastic.proto.PortNum
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MeshLogDaoTest {
+    private lateinit var database: MeshtasticDatabase
+    private lateinit var meshLogDao: MeshLogDao
+
+    private val testFromNum = 42
+
+    private fun logEntry(uuid: String, portNum: Int = PortNum.TELEMETRY_APP.value, time: Long) = MeshLog(
+        uuid = uuid,
+        message_type = "Packet",
+        received_date = time,
+        raw_message = "",
+        fromNum = testFromNum,
+        portNum = portNum,
+    )
+
+    @BeforeTest
+    fun setUp() {
+        database = getInMemoryDatabaseBuilder().build()
+        meshLogDao = database.meshLogDao()
+    }
+
+    @AfterTest
+    fun closeDb() {
+        database.close()
+    }
+
+    @Test
+    fun testDeleteLogsByUuidAtomicRemovesAll() = runTest {
+        meshLogDao.insert(logEntry("log-1", time = 100))
+        meshLogDao.insert(logEntry("log-2", time = 200))
+        meshLogDao.insert(logEntry("log-3", time = 300))
+
+        val uuids =
+            meshLogDao.getLogsFrom(testFromNum, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE).first().map { it.uuid }
+        assertEquals(3, uuids.size)
+
+        meshLogDao.deleteLogsByUuidAtomic(uuids)
+
+        val remaining = meshLogDao.getLogsFrom(testFromNum, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE).first()
+        assertTrue(remaining.isEmpty())
+    }
+
+    @Test
+    fun testDeleteLogsByUuidAtomicEmptyListIsNoOp() = runTest {
+        meshLogDao.insert(logEntry("log-1", time = 100))
+        meshLogDao.insert(logEntry("log-2", time = 200))
+
+        val before = meshLogDao.getLogsFrom(testFromNum, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE).first()
+        assertEquals(2, before.size)
+
+        meshLogDao.deleteLogsByUuidAtomic(emptyList())
+
+        val after = meshLogDao.getLogsFrom(testFromNum, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE).first()
+        assertEquals(2, after.size)
+    }
+
+    @Test
+    fun testDeleteLogsByUuidAtomicCrossesChunkBoundary() = runTest {
+        // 1200 UUIDs exceeds SQLITE_MAX_BIND_PARAMETERS (999), forcing at least 2 chunks inside the
+        // @Transaction. All must be deleted in one atomic batch; a partial commit would leave rows behind.
+        val total = 1200
+        for (i in 1..total) {
+            meshLogDao.insert(logEntry("bulk-$i", time = i.toLong()))
+        }
+        // Insert one log from a different fromNum that should survive the delete.
+        val survivor =
+            MeshLog(
+                uuid = "survivor",
+                message_type = "Packet",
+                received_date = 0L,
+                raw_message = "",
+                fromNum = 999,
+                portNum = PortNum.TELEMETRY_APP.value,
+            )
+        meshLogDao.insert(survivor)
+
+        val uuids =
+            meshLogDao.getLogsFrom(testFromNum, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE).first().map { it.uuid }
+        assertEquals(total, uuids.size, "all bulk logs should be queryable before delete")
+
+        meshLogDao.deleteLogsByUuidAtomic(uuids)
+
+        val remaining = meshLogDao.getLogsFrom(testFromNum, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE).first()
+        assertTrue(remaining.isEmpty(), "all selected logs should be deleted across the chunk boundary")
+
+        val survivorStillPresent = meshLogDao.getLogsFrom(999, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE).first()
+        assertEquals(1, survivorStillPresent.size, "unselected log from a different fromNum should remain")
+    }
+
+    @Test
+    fun testGetLogsSnapshotReturnsMatchingLogs() = runTest {
+        meshLogDao.insert(logEntry("log-1", portNum = PortNum.TELEMETRY_APP.value, time = 300))
+        meshLogDao.insert(logEntry("log-2", portNum = PortNum.TELEMETRY_APP.value, time = 100))
+        meshLogDao.insert(logEntry("log-3", portNum = PortNum.POSITION_APP.value, time = 200))
+
+        val snapshot = meshLogDao.getLogsSnapshot(testFromNum, PortNum.TELEMETRY_APP.value, Int.MAX_VALUE)
+        assertEquals(2, snapshot.size, "only telemetry logs should match")
+        assertEquals(listOf("log-1", "log-2"), snapshot.map { it.uuid }, "telemetry logs in DESC order")
+    }
+}

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/PacketDaoAtomicTransactionTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/PacketDaoAtomicTransactionTest.kt
@@ -1,0 +1,687 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.dao
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.database.MeshtasticDatabase
+import org.meshtastic.core.database.entity.ContactSettings
+import org.meshtastic.core.database.entity.MyNodeEntity
+import org.meshtastic.core.database.entity.Packet
+import org.meshtastic.core.database.entity.ReactionEntity
+import org.meshtastic.core.database.getInMemoryDatabaseBuilder
+import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.proto.PortNum
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the atomic read-modify-write transactions in [PacketDao]: [updateLastReadMessage], [updatePacketByKey],
+ * [updateReactionByKey], [applySFPPStatus], [applySFPPStatusByHash], and [deleteMessagesAtomic]. Each test exercises
+ * the transaction boundary — monotonic guards, identity-key matching, no-downgrade invariants, and chunk-boundary
+ * deletes — that a non-atomic implementation would race.
+ */
+class PacketDaoAtomicTransactionTest {
+    private lateinit var database: MeshtasticDatabase
+    private lateinit var packetDao: PacketDao
+
+    private val myNodeNum = 42424242
+
+    private val sfppHash: ByteString = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8).toByteString()
+    private val otherHash: ByteString = byteArrayOf(9, 10, 11, 12, 13, 14, 15, 16).toByteString()
+
+    private val myNodeEntity =
+        MyNodeEntity(
+            myNodeNum = myNodeNum,
+            model = null,
+            firmwareVersion = null,
+            couldUpdate = false,
+            shouldUpdate = false,
+            currentPacketId = 1L,
+            messageTimeoutMsec = 5 * 60 * 1000,
+            minAppVersion = 1,
+            maxChannels = 8,
+            hasWifi = false,
+        )
+
+    @BeforeTest
+    fun setUp() {
+        database = getInMemoryDatabaseBuilder().build()
+        packetDao = database.packetDao()
+    }
+
+    /** Seeds the MyNodeInfo row required by packet queries. Must be called inside each test's runTest block. */
+    private suspend fun seedMyNodeInfo() {
+        database.nodeInfoDao().setMyNodeInfo(myNodeEntity)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        database.close()
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private fun textPacket(
+        contact: String,
+        text: String,
+        time: Long,
+        packetId: Int = 0,
+        from: String? = NodeAddress.ID_LOCAL,
+        to: String? = NodeAddress.ID_BROADCAST,
+        status: MessageStatus = MessageStatus.UNKNOWN,
+        routingError: Int = -1,
+        sfppHash: ByteString? = null,
+    ) = Packet(
+        uuid = 0L,
+        myNodeNum = myNodeNum,
+        port_num = PortNum.TEXT_MESSAGE_APP.value,
+        contact_key = contact,
+        received_time = time,
+        read = true,
+        data =
+        DataPacket(
+            to = to,
+            bytes = text.encodeToByteArray().toByteString(),
+            dataType = PortNum.TEXT_MESSAGE_APP.value,
+            from = from,
+            id = packetId,
+            status = status,
+            sfppHash = sfppHash,
+        ),
+        packetId = packetId,
+        routingError = routingError,
+        sfpp_hash = sfppHash,
+        messageText = text,
+    )
+
+    private fun reaction(
+        replyId: Int,
+        userId: String,
+        emoji: String,
+        timestamp: Long,
+        packetId: Int = replyId,
+        to: String? = null,
+        status: MessageStatus = MessageStatus.UNKNOWN,
+        sfppHash: ByteString? = null,
+    ) = ReactionEntity(
+        myNodeNum = myNodeNum,
+        replyId = replyId,
+        userId = userId,
+        emoji = emoji,
+        timestamp = timestamp,
+        packetId = packetId,
+        to = to,
+        status = status,
+        sfpp_hash = sfppHash,
+    )
+
+    // ── updateLastReadMessage ────────────────────────────────────────────────────
+
+    @Test
+    fun updateLastReadMessageCreatesSettingsWhenAbsent() = runTest {
+        seedMyNodeInfo()
+        val contact = "0${NodeAddress.ID_BROADCAST}"
+        packetDao.updateLastReadMessage(contact, messageUuid = 42L, lastReadTimestamp = 1000L)
+
+        val settings = packetDao.getContactSettings(contact)
+        assertNotNull(settings)
+        assertEquals(42L, settings!!.lastReadMessageUuid)
+        assertEquals(1000L, settings.lastReadMessageTimestamp)
+    }
+
+    @Test
+    fun updateLastReadMessageAcceptsNewerTimestamp() = runTest {
+        seedMyNodeInfo()
+        val contact = "0${NodeAddress.ID_BROADCAST}"
+        packetDao.updateLastReadMessage(contact, messageUuid = 42L, lastReadTimestamp = 2000L)
+        packetDao.updateLastReadMessage(contact, messageUuid = 99L, lastReadTimestamp = 3000L)
+
+        val settings = packetDao.getContactSettings(contact)
+        assertNotNull(settings)
+        assertEquals(99L, settings!!.lastReadMessageUuid)
+        assertEquals(3000L, settings.lastReadMessageTimestamp)
+    }
+
+    @Test
+    fun updateLastReadMessageRejectsOlderTimestamp() = runTest {
+        seedMyNodeInfo()
+        val contact = "0${NodeAddress.ID_BROADCAST}"
+        packetDao.updateLastReadMessage(contact, messageUuid = 42L, lastReadTimestamp = 2000L)
+        packetDao.updateLastReadMessage(contact, messageUuid = 99L, lastReadTimestamp = 1000L)
+
+        val settings = packetDao.getContactSettings(contact)
+        assertNotNull(settings)
+        assertEquals(42L, settings!!.lastReadMessageUuid)
+        assertEquals(2000L, settings.lastReadMessageTimestamp)
+    }
+
+    /**
+     * Verifies that [PacketDao.updateLastReadMessage] preserves unrelated contact-settings columns (muteUntil,
+     * filteringDisabled) that were set before the last-read update. The INSERT-IGNORE + conditional-UPDATE pattern must
+     * never overwrite these fields with defaults.
+     */
+    @Test
+    fun updateLastReadMessagePreservesUnrelatedFields() = runTest {
+        seedMyNodeInfo()
+        val contact = "0${NodeAddress.ID_BROADCAST}"
+
+        // Seed with non-default muteUntil and filteringDisabled
+        packetDao.insertContactSettingsIgnore(
+            listOf(ContactSettings(contact_key = contact, muteUntil = 999_999_999L, filteringDisabled = true)),
+        )
+
+        // Perform the last-read update (newer timestamp)
+        packetDao.updateLastReadMessage(contact, messageUuid = 42L, lastReadTimestamp = 3000L)
+
+        val settings = packetDao.getContactSettings(contact)
+        assertNotNull(settings)
+        assertEquals(42L, settings!!.lastReadMessageUuid, "lastReadMessageUuid should be updated")
+        assertEquals(3000L, settings.lastReadMessageTimestamp, "lastReadMessageTimestamp should be updated")
+        assertEquals(999_999_999L, settings.muteUntil, "muteUntil must be preserved")
+        assertTrue(settings.filteringDisabled, "filteringDisabled must be preserved")
+    }
+
+    /** Verifies that updating contact A's last-read position does not alter contact B. */
+    @Test
+    fun updateLastReadMessageIsContactScoped() = runTest {
+        seedMyNodeInfo()
+        val contactA = "0${NodeAddress.ID_BROADCAST}"
+        val contactB = "0!abcdef01"
+
+        packetDao.updateLastReadMessage(contactA, messageUuid = 10L, lastReadTimestamp = 1000L)
+        packetDao.updateLastReadMessage(contactB, messageUuid = 20L, lastReadTimestamp = 2000L)
+        packetDao.updateLastReadMessage(contactA, messageUuid = 30L, lastReadTimestamp = 3000L)
+
+        val settingsA = packetDao.getContactSettings(contactA)
+        assertNotNull(settingsA)
+        assertEquals(30L, settingsA!!.lastReadMessageUuid, "contact A updated to 30")
+        assertEquals(3000L, settingsA.lastReadMessageTimestamp)
+
+        val settingsB = packetDao.getContactSettings(contactB)
+        assertNotNull(settingsB)
+        assertEquals(20L, settingsB!!.lastReadMessageUuid, "contact B unchanged at 20")
+        assertEquals(2000L, settingsB.lastReadMessageTimestamp)
+    }
+
+    @Test
+    fun updateLastReadMessageEqualTimestampIsNoOp() = runTest {
+        seedMyNodeInfo()
+        val contact = "0${NodeAddress.ID_BROADCAST}"
+        packetDao.updateLastReadMessage(contact, messageUuid = 42L, lastReadTimestamp = 2000L)
+        packetDao.updateLastReadMessage(contact, messageUuid = 99L, lastReadTimestamp = 2000L)
+
+        val settings = packetDao.getContactSettings(contact)
+        assertNotNull(settings)
+        assertEquals(42L, settings!!.lastReadMessageUuid)
+        assertEquals(2000L, settings.lastReadMessageTimestamp)
+    }
+
+    // ── updatePacketByKey ────────────────────────────────────────────────────────
+
+    @Test
+    fun updatePacketByKeyUpdatesOnlyMatchingIdentity() = runTest {
+        seedMyNodeInfo()
+        val matching = textPacket("contact", "match", time = 100, packetId = 50, from = "!aa", to = "^all")
+        val sameIdDiffFrom = textPacket("contact", "other", time = 200, packetId = 50, from = "!bb", to = "^all")
+        packetDao.insert(matching)
+        packetDao.insert(sameIdDiffFrom)
+
+        val newData = matching.data.copy(status = MessageStatus.DELIVERED)
+        packetDao.updatePacketByKey(newData, routingError = -1)
+
+        val packets = packetDao.findPacketsWithId(50)
+        val updated = packets.find { it.data.from == "!aa" }
+        val untouched = packets.find { it.data.from == "!bb" }
+        assertEquals(MessageStatus.DELIVERED, updated?.data?.status)
+        assertEquals(MessageStatus.UNKNOWN, untouched?.data?.status)
+    }
+
+    @Test
+    fun updatePacketByKeyAppliesRoutingErrorWhenNonNegative() = runTest {
+        seedMyNodeInfo()
+        val packet = textPacket("contact", "msg", time = 100, packetId = 60, from = "!aa", to = "^all")
+        packetDao.insert(packet)
+
+        packetDao.updatePacketByKey(packet.data, routingError = 7)
+
+        val updated = packetDao.findPacketsWithId(60).first()
+        assertEquals(7, updated.routingError)
+    }
+
+    @Test
+    fun updatePacketByKeyLeavesRoutingErrorUnchangedWhenMinusOne() = runTest {
+        seedMyNodeInfo()
+        val packet =
+            textPacket("contact", "msg", time = 100, packetId = 70, from = "!aa", to = "^all", routingError = 3)
+        packetDao.insert(packet)
+
+        val newData = packet.data.copy(status = MessageStatus.DELIVERED)
+        packetDao.updatePacketByKey(newData, routingError = -1)
+
+        val updated = packetDao.findPacketsWithId(70).first()
+        assertEquals(3, updated.routingError, "routingError should be preserved, not reset to -1")
+        assertEquals(MessageStatus.DELIVERED, updated.data.status)
+    }
+
+    // ── updateReactionByKey ──────────────────────────────────────────────────────
+
+    @Test
+    fun updateReactionByKeyUpdatesMatchingReaction() = runTest {
+        seedMyNodeInfo()
+        packetDao.insert(textPacket("contact", "msg", time = 100, packetId = 80))
+        packetDao.insert(reaction(replyId = 80, userId = "!u", emoji = "👍", timestamp = 1, packetId = 80))
+
+        val replacement =
+            reaction(
+                replyId = 80,
+                userId = "!u",
+                emoji = "👍",
+                timestamp = 999,
+                packetId = 80,
+                status = MessageStatus.SFPP_CONFIRMED,
+                sfppHash = sfppHash,
+            )
+                .copy(myNodeNum = 0) // placeholder — DAO must borrow from existing
+        packetDao.updateReactionByKey(replacement)
+
+        val updated = packetDao.findReactionsWithId(80).find { it.userId == "!u" && it.emoji == "👍" }
+        assertNotNull(updated)
+        assertEquals(999, updated!!.timestamp)
+        assertEquals(MessageStatus.SFPP_CONFIRMED, updated.status)
+        assertEquals(sfppHash, updated.sfpp_hash)
+    }
+
+    @Test
+    fun updateReactionByKeyPreservesExistingMyNodeNum() = runTest {
+        seedMyNodeInfo()
+        packetDao.insert(textPacket("contact", "msg", time = 100, packetId = 81))
+        packetDao.insert(reaction(replyId = 81, userId = "!u", emoji = "❤️", timestamp = 1, packetId = 81))
+
+        val replacement =
+            ReactionEntity(
+                myNodeNum = 0, // placeholder — DAO must overwrite with existing
+                replyId = 81,
+                userId = "!u",
+                emoji = "❤️",
+                timestamp = 555,
+                packetId = 81,
+            )
+        packetDao.updateReactionByKey(replacement)
+
+        val updated = packetDao.findReactionsWithId(81).find { it.userId == "!u" && it.emoji == "❤️" }
+        assertNotNull(updated)
+        assertEquals(myNodeNum, updated!!.myNodeNum, "myNodeNum must be borrowed from existing row, not 0")
+        assertEquals(555, updated.timestamp)
+    }
+
+    @Test
+    fun updateReactionByKeyLeavesNonMatchingEmojiUntouched() = runTest {
+        seedMyNodeInfo()
+        packetDao.insert(textPacket("contact", "msg", time = 100, packetId = 82))
+        packetDao.insert(reaction(replyId = 82, userId = "!u", emoji = "👍", timestamp = 1, packetId = 82))
+
+        val replacement =
+            ReactionEntity(
+                myNodeNum = myNodeNum,
+                replyId = 82,
+                userId = "!u",
+                emoji = "❤️", // different emoji — no match
+                timestamp = 999,
+                packetId = 82,
+            )
+        packetDao.updateReactionByKey(replacement)
+
+        val reactions = packetDao.findReactionsWithId(82)
+        assertEquals(1, reactions.size)
+        assertEquals("👍", reactions.first().emoji)
+        assertEquals(1, reactions.first().timestamp, "original reaction untouched")
+    }
+
+    @Test
+    fun updateReactionByKeyIsNoOpWhenNoMatch() = runTest {
+        seedMyNodeInfo()
+        packetDao.insert(reaction(replyId = 83, userId = "!u", emoji = "👍", timestamp = 1, packetId = 83))
+
+        val replacement =
+            ReactionEntity(
+                myNodeNum = myNodeNum,
+                replyId = 83,
+                userId = "!other", // different user — no match
+                emoji = "👍",
+                timestamp = 999,
+                packetId = 83,
+            )
+        packetDao.updateReactionByKey(replacement)
+
+        val reactions = packetDao.findReactionsWithId(83)
+        assertEquals(1, reactions.size)
+        assertEquals(1, reactions.first().timestamp, "no reaction updated")
+    }
+
+    // ── applySFPPStatus ──────────────────────────────────────────────────────────
+
+    @Test
+    fun applySFPPStatusUpdatesMatchingPacketAndReactionInOneTransaction() = runTest {
+        seedMyNodeInfo()
+        val packetId = 100
+        packetDao.insert(
+            textPacket(
+                "contact",
+                "msg",
+                time = 1000,
+                packetId = packetId,
+                from = NodeAddress.ID_LOCAL,
+                to = NodeAddress.ID_BROADCAST,
+            ),
+        )
+        packetDao.insert(
+            reaction(
+                replyId = packetId,
+                userId = NodeAddress.ID_LOCAL,
+                emoji = "👍",
+                timestamp = 1,
+                packetId = packetId,
+                to = NodeAddress.ID_BROADCAST,
+            ),
+        )
+
+        packetDao.applySFPPStatus(
+            packetId = packetId,
+            from = myNodeNum,
+            to = 0,
+            hash = sfppHash,
+            status = MessageStatus.SFPP_ROUTING,
+            rxTime = 5L,
+            myNodeNum = myNodeNum,
+        )
+
+        val packet = packetDao.findPacketsWithId(packetId).first()
+        assertEquals(MessageStatus.SFPP_ROUTING, packet.data.status)
+        assertEquals(sfppHash, packet.data.sfppHash)
+        assertEquals(sfppHash, packet.sfpp_hash)
+        assertEquals(5_000L, packet.data.time, "rxTime should be converted to millis")
+        assertEquals(5_000L, packet.received_time)
+
+        val reaction = packetDao.findReactionsWithId(packetId).first()
+        assertEquals(MessageStatus.SFPP_ROUTING, reaction.status)
+        assertEquals(sfppHash, reaction.sfpp_hash)
+    }
+
+    @Test
+    fun applySFPPStatusMatchesLocalNodeWithIdLocal() = runTest {
+        seedMyNodeInfo()
+        val packetId = 110
+        // Packet stored with from = "^local" — local node sends with ID_LOCAL.
+        packetDao.insert(
+            textPacket(
+                "contact",
+                "msg",
+                time = 1000,
+                packetId = packetId,
+                from = NodeAddress.ID_LOCAL,
+                to = NodeAddress.ID_BROADCAST,
+            ),
+        )
+
+        // from = myNodeNum triggers isFromLocalNode = true, which matches data.from == ID_LOCAL.
+        packetDao.applySFPPStatus(
+            packetId = packetId,
+            from = myNodeNum,
+            to = 0,
+            hash = sfppHash,
+            status = MessageStatus.SFPP_ROUTING,
+            rxTime = 0L,
+            myNodeNum = myNodeNum,
+        )
+
+        val packet = packetDao.findPacketsWithId(packetId).first()
+        assertEquals(MessageStatus.SFPP_ROUTING, packet.data.status)
+    }
+
+    @Test
+    fun applySFPPStatusBroadcastDestinationMatchesIdBroadcast() = runTest {
+        seedMyNodeInfo()
+        val packetId = 120
+        // to = 0 (broadcast) should match data.to == "^all" (ID_BROADCAST).
+        packetDao.insert(
+            textPacket(
+                "contact",
+                "msg",
+                time = 1000,
+                packetId = packetId,
+                from = NodeAddress.ID_LOCAL,
+                to = NodeAddress.ID_BROADCAST,
+            ),
+        )
+
+        packetDao.applySFPPStatus(
+            packetId = packetId,
+            from = myNodeNum,
+            to = 0,
+            hash = sfppHash,
+            status = MessageStatus.SFPP_ROUTING,
+            rxTime = 0L,
+            myNodeNum = myNodeNum,
+        )
+
+        val packet = packetDao.findPacketsWithId(packetId).first()
+        assertEquals(MessageStatus.SFPP_ROUTING, packet.data.status)
+    }
+
+    @Test
+    fun applySFPPStatusDoesNotDowngradeConfirmedToRouting() = runTest {
+        seedMyNodeInfo()
+        val packetId = 130
+        packetDao.insert(
+            textPacket(
+                "contact",
+                "msg",
+                time = 1000,
+                packetId = packetId,
+                from = NodeAddress.ID_LOCAL,
+                to = NodeAddress.ID_BROADCAST,
+                status = MessageStatus.SFPP_CONFIRMED,
+            ),
+        )
+        packetDao.insert(
+            reaction(
+                replyId = packetId,
+                userId = NodeAddress.ID_LOCAL,
+                emoji = "👍",
+                timestamp = 1,
+                packetId = packetId,
+                to = NodeAddress.ID_BROADCAST,
+                status = MessageStatus.SFPP_CONFIRMED,
+            ),
+        )
+
+        packetDao.applySFPPStatus(
+            packetId = packetId,
+            from = myNodeNum,
+            to = 0,
+            hash = sfppHash,
+            status = MessageStatus.SFPP_ROUTING,
+            rxTime = 5L,
+            myNodeNum = myNodeNum,
+        )
+
+        val packet = packetDao.findPacketsWithId(packetId).first()
+        assertEquals(MessageStatus.SFPP_CONFIRMED, packet.data.status, "packet must not be downgraded")
+
+        val reaction = packetDao.findReactionsWithId(packetId).first()
+        assertEquals(MessageStatus.SFPP_CONFIRMED, reaction.status, "reaction must not be downgraded")
+    }
+
+    @Test
+    fun applySFPPStatusLeavesNonMatchingAddressesUntouched() = runTest {
+        seedMyNodeInfo()
+        val packetId = 140
+        // Packet from node 123 (!0000007b), not from local node.
+        packetDao.insert(
+            textPacket(
+                "contact",
+                "msg",
+                time = 1000,
+                packetId = packetId,
+                from = "!0000007b",
+                to = NodeAddress.ID_BROADCAST,
+            ),
+        )
+
+        // Call with from = 456 (!000001c8) — should NOT match.
+        packetDao.applySFPPStatus(
+            packetId = packetId,
+            from = 456,
+            to = 0,
+            hash = sfppHash,
+            status = MessageStatus.SFPP_ROUTING,
+            rxTime = 0L,
+            myNodeNum = myNodeNum,
+        )
+
+        val packet = packetDao.findPacketsWithId(packetId).first()
+        assertEquals(MessageStatus.UNKNOWN, packet.data.status, "non-matching packet should be untouched")
+        assertNull(packet.sfpp_hash)
+    }
+
+    // ── applySFPPStatusByHash ────────────────────────────────────────────────────
+
+    @Test
+    fun applySFPPStatusByHashMatchesByHashPrefix() = runTest {
+        seedMyNodeInfo()
+        val packetId = 200
+        packetDao.insert(textPacket("contact", "msg", time = 1000, packetId = packetId, sfppHash = sfppHash))
+        packetDao.insert(
+            reaction(
+                replyId = packetId,
+                userId = "!u",
+                emoji = "👍",
+                timestamp = 1,
+                packetId = packetId,
+                sfppHash = sfppHash,
+            ),
+        )
+
+        packetDao.applySFPPStatusByHash(sfppHash, status = MessageStatus.SFPP_ROUTING, rxTime = 5L)
+
+        val packet = packetDao.findPacketBySfppHash(sfppHash)
+        assertNotNull(packet)
+        assertEquals(MessageStatus.SFPP_ROUTING, packet!!.data.status)
+
+        val reaction = packetDao.findReactionBySfppHash(sfppHash)
+        assertNotNull(reaction)
+        assertEquals(MessageStatus.SFPP_ROUTING, reaction!!.status)
+    }
+
+    @Test
+    fun applySFPPStatusByHashDoesNotDowngradeConfirmedToRouting() = runTest {
+        seedMyNodeInfo()
+        val packetId = 210
+        packetDao.insert(
+            textPacket(
+                "contact",
+                "msg",
+                time = 1000,
+                packetId = packetId,
+                status = MessageStatus.SFPP_CONFIRMED,
+                sfppHash = sfppHash,
+            ),
+        )
+
+        packetDao.applySFPPStatusByHash(sfppHash, status = MessageStatus.SFPP_ROUTING, rxTime = 5L)
+
+        val packet = packetDao.findPacketBySfppHash(sfppHash)
+        assertNotNull(packet)
+        assertEquals(MessageStatus.SFPP_CONFIRMED, packet!!.data.status, "confirmed packet must not be downgraded")
+    }
+
+    @Test
+    fun applySFPPStatusByHashLeavesUnrelatedHashUntouched() = runTest {
+        seedMyNodeInfo()
+        val packetId = 220
+        packetDao.insert(textPacket("contact", "msg", time = 1000, packetId = packetId, sfppHash = sfppHash))
+
+        // Apply with a completely different hash prefix — should not touch the packet.
+        packetDao.applySFPPStatusByHash(otherHash, status = MessageStatus.SFPP_ROUTING, rxTime = 5L)
+
+        val packet = packetDao.findPacketBySfppHash(sfppHash)
+        assertNotNull(packet)
+        assertEquals(MessageStatus.UNKNOWN, packet!!.data.status, "unrelated hash should be untouched")
+    }
+
+    // ── deleteMessagesAtomic ─────────────────────────────────────────────────────
+
+    @Test
+    fun deleteMessagesAtomicDeletesPacketsAndReactions() = runTest {
+        seedMyNodeInfo()
+        val packetId = 300
+        packetDao.insert(textPacket("contact", "msg", time = 100, packetId = packetId))
+        packetDao.insert(reaction(replyId = packetId, userId = "!u", emoji = "👍", timestamp = 1, packetId = packetId))
+
+        val uuids = packetDao.getMessagesFrom("contact").first().map { it.packet.uuid }
+        assertTrue(uuids.isNotEmpty())
+
+        packetDao.deleteMessagesAtomic(uuids)
+
+        assertEquals(0, packetDao.getMessageCount("contact"))
+        assertTrue(packetDao.findReactionsWithId(packetId).isEmpty(), "reactions should be deleted with their packets")
+    }
+
+    @Test
+    fun deleteMessagesAtomicEmptyListIsNoOp() = runTest {
+        seedMyNodeInfo()
+        val contact = "empty-test"
+        packetDao.insert(textPacket(contact, "msg", time = 100, packetId = 310))
+        val before = packetDao.getMessageCount(contact)
+
+        packetDao.deleteMessagesAtomic(emptyList())
+
+        assertEquals(before, packetDao.getMessageCount(contact))
+    }
+
+    @Test
+    fun deleteMessagesAtomicCrossesChunkBoundaryAndDeletesAll() = runTest {
+        seedMyNodeInfo()
+        // 1200 UUIDs exceeds SQLITE_MAX_BIND_PARAMETERS (999), forcing at least 2 chunks.
+        val total = 1200
+        val contact = "chunk-boundary"
+        for (i in 1..total) {
+            packetDao.insert(textPacket(contact, "msg-$i", time = 100L + i, packetId = i))
+        }
+        // Also insert a packet that should survive the delete.
+        val survivorContact = "survivor"
+        packetDao.insert(textPacket(survivorContact, "keep", time = 999_999, packetId = 9_999))
+
+        val insertedUuids = packetDao.getAllPacketsSnapshot().filter { it.contact_key == contact }.map { it.uuid }
+        assertEquals(total, insertedUuids.size, "all packets should have been inserted")
+
+        packetDao.deleteMessagesAtomic(insertedUuids)
+
+        assertEquals(0, packetDao.getMessageCount(contact), "all chunked packets deleted")
+        assertEquals(1, packetDao.getMessageCount(survivorContact), "non-selected packet untouched")
+    }
+}

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/TracerouteNodePositionDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/TracerouteNodePositionDaoTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.dao
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.database.MeshtasticDatabase
+import org.meshtastic.core.database.entity.MeshLog
+import org.meshtastic.core.database.entity.TracerouteNodePositionEntity
+import org.meshtastic.core.database.getInMemoryDatabaseBuilder
+import org.meshtastic.proto.Position
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TracerouteNodePositionDaoTest {
+
+    private lateinit var database: MeshtasticDatabase
+    private lateinit var tracerouteDao: TracerouteNodePositionDao
+    private lateinit var meshLogDao: MeshLogDao
+
+    private val logUuid = "traceroute-log-1"
+
+    @BeforeTest
+    fun setUp() {
+        database = getInMemoryDatabaseBuilder().build()
+        tracerouteDao = database.tracerouteNodePositionDao()
+        meshLogDao = database.meshLogDao()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        database.close()
+    }
+
+    private suspend fun seedParentLog() {
+        meshLogDao.insert(
+            MeshLog(
+                uuid = logUuid,
+                message_type = "Packet",
+                received_date = 1000L,
+                raw_message = "",
+                fromNum = 0,
+                portNum = 0,
+            ),
+        )
+    }
+
+    private fun position(nodeNum: Int) =
+        TracerouteNodePositionEntity(logUuid = logUuid, requestId = 1, nodeNum = nodeNum, position = Position())
+
+    @Test
+    fun testReplaceByLogUuidIsAtomic() = runTest {
+        seedParentLog()
+        tracerouteDao.insertAll(listOf(position(10), position(20)))
+
+        val before = tracerouteDao.getByLogUuid(logUuid).first()
+        assertEquals(2, before.size)
+
+        tracerouteDao.replaceByLogUuid(logUuid, listOf(position(30), position(40), position(50)))
+
+        val after = tracerouteDao.getByLogUuid(logUuid).first()
+        assertEquals(3, after.size)
+        assertEquals(setOf(30, 40, 50), after.map { it.nodeNum }.toSet())
+    }
+
+    @Test
+    fun testReplaceByLogUuidEmptyEntitiesDeletesAll() = runTest {
+        seedParentLog()
+        tracerouteDao.insertAll(listOf(position(10), position(20)))
+
+        val before = tracerouteDao.getByLogUuid(logUuid).first()
+        assertEquals(2, before.size)
+
+        tracerouteDao.replaceByLogUuid(logUuid, emptyList())
+
+        val after = tracerouteDao.getByLogUuid(logUuid).first()
+        assertTrue(after.isEmpty())
+    }
+
+    @Test
+    fun testReplaceByLogUuidRollbackOnInsertFailure() = runTest {
+        seedParentLog()
+        tracerouteDao.insertAll(listOf(position(10), position(20)))
+
+        val before = tracerouteDao.getByLogUuid(logUuid).first()
+        assertEquals(2, before.size)
+
+        // replaceByLogUuid deletes existing rows for logUuid, then inserts the new entities.
+        // The entity references "nonexistent-log" which has no parent MeshLog — the FK constraint
+        // on log_uuid should fire, aborting the transaction and rolling back the delete.
+        val badEntity =
+            TracerouteNodePositionEntity(
+                logUuid = "nonexistent-log",
+                requestId = 1,
+                nodeNum = 99,
+                position = Position(),
+            )
+        assertFailsWith<Exception> { tracerouteDao.replaceByLogUuid(logUuid, listOf(badEntity)) }
+
+        // The original 2 rows must still be present — the delete was rolled back.
+        val after = tracerouteDao.getByLogUuid(logUuid).first()
+        assertEquals(2, after.size, "original rows must survive the rolled-back transaction")
+        assertEquals(setOf(10, 20), after.map { it.nodeNum }.toSet())
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change moves several related database updates and deletions into atomic, transaction-scoped DAO operations, so multi-step repository logic no longer risks partial writes across SQLite limits. It also strengthens `DatabaseManager`’s device-association merge coordination with an explicit writer-admission gate, improves rollback behavior on merge failures/timeouts/cancellation, and adds in-memory DAO/manager tests to validate atomicity, chunking, and race safety.

## Key changes

### Features
- **`PacketDao` transactional write helpers**
  - Atomically update last-read message state (creates `contact_settings` when missing; updates only when newer).
  - Update packet and reaction rows by key using DAO-level conditional/atomic updates.
  - Apply SFPP delivery-status transitions atomically (by packet address/id matching or by SFPP hash prefix), including a **no-downgrade** rule.
  - Add `deleteMessagesAtomic(...)` to delete packets/reactions/messages in one transactional operation with safe chunking.
- **`MeshLogDao` read/modify/delete helpers**
  - Add one-shot **snapshot** query API (`getLogsSnapshot(...)`) for log UUID selection.
  - Add `deleteLogsByUuidAtomic(...)` to delete UUID-selected logs atomically.
- **`TracerouteNodePositionDao` atomic replacement**
  - Add `replaceByLogUuid(logUuid, entities)` that replaces positions for a log UUID in a single transaction (delete + insert inside one atomic operation).
- **Repository updates to use the new DAO primitives**
  - `MeshLogRepositoryImpl.deleteLocalStatsLogs(...)`: select candidate UUIDs via snapshot parsing, then delete them in one atomic DAO call.
  - `PacketRepositoryImpl`: switch packet/reaction/SFPP operations to DAO-level “apply/update” methods and use atomic message deletion instead of repository-side chunk loops and read/modify logic.
  - `TracerouteSnapshotRepositoryImpl.upsertSnapshotPositions(...)`: persist positions via DAO replacement (removes explicit delete/early-return sequencing).
- **`DatabaseManager` coordination hooks/refactoring**
  - Add overridable hooks for database construction and post-switch maintenance.
  - Refactor lifecycle so `close()` is now `suspend`, with coordinated job cancellation/joining and safe cached DB closure.

### Fixes
- **Avoid partial deletes across SQLite bind-parameter limits**
  - Centralize SQLite max bind parameter handling via `SQLITE_MAX_BIND_PARAMETERS` and enforce chunking inside transactional DAO methods.
- **SFPP state correctness**
  - Prevent regressions of SFPP status (e.g., confirmed not downgraded back to routing).
- **Last-read monotonicity**
  - Ensure last-read updates only apply when the incoming timestamp is newer.
- **Atomic traceroute position replacement**
  - Ensure observers don’t see an intermediate “empty” state during replacement (delete/insert happens atomically, with rollback on insert failure).
- **Stronger merge/association failure handling**
  - Implement a writer-drain phase with timeout/cancellation handling and an admission gate so blocked writers are released to the correct DB instance depending on merge outcome.
  - Improve rollback/commit behavior so the source DB isn’t incorrectly retired when merge commit/routing persistence partially fails.

### Refactors
- Reduce repository-side complexity by shifting conditional read/modify/write logic into transactional DAO methods.
- Remove repository constants related to chunking/timestamp conversion that are no longer needed after moving logic to DAOs.
- Improve `DatabaseManager` extensibility by refactoring DB build/maintenance into overridable methods and adjusting visibility for `limitedIo` and cached DB close.

## Breaking changes and migration

- **`DatabaseManager.close()` is now `suspend`**. Any call sites must now be coroutine-aware (the Android `onTerminate` path was updated accordingly).
- Added new DAO methods and new overridable `DatabaseManager` hooks (`buildDatabase`, `schedulePostSwitchMaintenance`, `closeCachedDatabase`, and the updated merge flow internals), which may require updating custom implementations if they subclass `DatabaseManager`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->