### PR TITLE
Optimize database operations by adjusting last-used time updates

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
@@ -33,16 +33,16 @@ class DeviceHardwareLocalDataSource(private val dbManager: DatabaseProvider) {
     }
 
     suspend fun getByHwModel(hwModel: Int): List<DeviceHardwareEntity> =
-        dbManager.withDb { it.deviceHardwareDao().getByHwModel(hwModel) }.orEmpty()
+        dbManager.withReadDb { it.deviceHardwareDao().getByHwModel(hwModel) }
 
     suspend fun getByTarget(target: String): DeviceHardwareEntity? =
-        dbManager.withDb { it.deviceHardwareDao().getByTarget(target) }
+        dbManager.withReadDb { it.deviceHardwareDao().getByTarget(target) }
 
     suspend fun getByModelAndTarget(hwModel: Int, target: String): DeviceHardwareEntity? =
-        dbManager.withDb { it.deviceHardwareDao().getByModelAndTarget(hwModel, target) }
+        dbManager.withReadDb { it.deviceHardwareDao().getByModelAndTarget(hwModel, target) }
 
-    suspend fun hasAnyEntries(): Boolean = dbManager.withDb { it.deviceHardwareDao().count() > 0 } ?: false
+    suspend fun hasAnyEntries(): Boolean = dbManager.withReadDb { it.deviceHardwareDao().count() > 0 }
 
     /** All known `platformioTarget` values — used to determine which msh.to links are vendor links. */
-    suspend fun getAllTargets(): List<String> = dbManager.withDb { it.deviceHardwareDao().getAllTargets() }.orEmpty()
+    suspend fun getAllTargets(): List<String> = dbManager.withReadDb { it.deviceHardwareDao().getAllTargets() }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
@@ -29,7 +29,7 @@ class DeviceLinkLocalDataSource(private val dbManager: DatabaseProvider) {
     fun observeAll(): Flow<List<DeviceLinkEntity>> =
         dbManager.currentDb.flatMapLatest { db -> db.deviceLinkDao().observeAll() }
 
-    suspend fun getAll(): List<DeviceLinkEntity> = dbManager.withDb { it.deviceLinkDao().getAll() }.orEmpty()
+    suspend fun getAll(): List<DeviceLinkEntity> = dbManager.withReadDb { it.deviceLinkDao().getAll() }
 
     suspend fun upsertAll(links: List<DeviceLinkEntity>) {
         dbManager.withDb { it.deviceLinkDao().upsertAll(links) }
@@ -43,5 +43,5 @@ class DeviceLinkLocalDataSource(private val dbManager: DatabaseProvider) {
         dbManager.withDb { it.deviceLinkDao().deleteAll() }
     }
 
-    suspend fun count(): Int = dbManager.withDb { it.deviceLinkDao().count() } ?: 0
+    suspend fun count(): Int = dbManager.withReadDb { it.deviceLinkDao().count() }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
@@ -41,7 +41,7 @@ class FirmwareReleaseLocalDataSource(private val dbManager: DatabaseProvider) {
         }
     }
 
-    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? = dbManager.withDb {
-        it.firmwareReleaseDao().getReleasesByType(releaseType).maxByOrNull { entity -> entity.asDeviceVersion() }
-    }
+    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? = dbManager
+        .withReadDb { it.firmwareReleaseDao().getReleasesByType(releaseType) }
+        .maxByOrNull { entity -> entity.asDeviceVersion() }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
@@ -41,7 +41,7 @@ class FirmwareReleaseLocalDataSource(private val dbManager: DatabaseProvider) {
         }
     }
 
-    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? = dbManager
-        .withReadDb { it.firmwareReleaseDao().getReleasesByType(releaseType) }
-        .maxByOrNull { entity -> entity.asDeviceVersion() }
+    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? = dbManager.withReadDb {
+        it.firmwareReleaseDao().getReleasesByType(releaseType).maxByOrNull { entity -> entity.asDeviceVersion() }
+    }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
@@ -51,8 +51,8 @@ class SwitchingNodeInfoReadDataSource(private val dbManager: DatabaseProvider) :
     }
 
     override suspend fun getNodesOlderThan(lastHeard: Int): List<NodeEntity> =
-        dbManager.withDb { it.nodeInfoDao().getNodesOlderThan(lastHeard) } ?: emptyList()
+        dbManager.withReadDb { it.nodeInfoDao().getNodesOlderThan(lastHeard) }
 
     override suspend fun getUnknownNodes(): List<NodeEntity> =
-        dbManager.withDb { it.nodeInfoDao().getUnknownNodes() } ?: emptyList()
+        dbManager.withReadDb { it.nodeInfoDao().getUnknownNodes() }
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -111,11 +111,11 @@ open class DatabaseManager(
     private val deferredEvictions = mutableSetOf<MeshtasticDatabase>()
     private var shutdownWriterDrain: CompletableDeferred<Unit>? = null
 
-    // Admitted manager-operation tokens (one per serialized associateDevice/switch/recovery/eviction/cleanup that
-    // takes the manager [mutex]). Guarded by [writerTrackerMutex]. [close] arms [managerOperationDrain] and bound-waits
-    // for this set to empty BEFORE acquiring [mutex] for its ownership snapshot — otherwise an admitted operation that
-    // holds [mutex] indefinitely (e.g. a stalled merge) pins shutdown forever despite the writer-drain bound already
-    // in place. New operations are rejected at admission once lifecycleState != OPEN.
+    // Admitted manager-operation tokens. Serialized associateDevice/switch/recovery/eviction/cleanup work and
+    // bounded [withReadDb] callbacks register here before touching a manager-owned pool. Guarded by
+    // [writerTrackerMutex]. [close] arms [managerOperationDrain] and bound-waits for this set to empty BEFORE acquiring
+    // [mutex] for its ownership snapshot, so no admitted operation can resume against a closed pool. New operations are
+    // rejected at admission once lifecycleState != OPEN.
     private val activeManagerOperations = mutableSetOf<Any>()
     private var managerOperationDrain: CompletableDeferred<Unit>? = null
 
@@ -299,12 +299,12 @@ open class DatabaseManager(
     }
 
     /**
-     * Admits one serialized manager operation (anything that takes [mutex]) and drains it on completion.
+     * Admits one operation that may touch manager-owned database pools and drains it on completion.
      *
-     * Registration happens BEFORE the operation waits on [mutex] (after the lifecycle check); the token is removed in
-     * `finally` so cancellation, merge failure, and timeout all release admission. A [close] that observes a non-empty
-     * admission set arms [managerOperationDrain] and bound-waits on it before taking [mutex] for its snapshot, so a
-     * wedged admitted operation cannot pin shutdown past [WRITER_DRAIN_TIMEOUT_MS].
+     * Registration happens before the operation captures a pool or waits on [mutex] (after the lifecycle check); the
+     * token is removed in `finally` so cancellation, failure, and timeout all release admission. A [close] that
+     * observes a non-empty admission set arms [managerOperationDrain] and bound-waits on it before taking its ownership
+     * snapshot, so an admitted callback cannot resume against a closed pool.
      */
     private suspend fun <T> withManagerOperation(block: suspend () -> T): T {
         val token = Any()
@@ -893,14 +893,17 @@ open class DatabaseManager(
 
     /**
      * Executes one bounded read without writer admission or the serialized write-containment lane. Active database
-     * publication is synchronous and published pools are logically retired, so a captured instance remains valid for
-     * the lifetime of this manager. The read is never replayed automatically.
+     * publication is synchronous and published pools are logically retired, so a captured instance remains valid until
+     * the callback completes. The read is admitted into the shutdown drain, is never replayed automatically, and new
+     * reads are rejected once shutdown begins.
      */
-    override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = withContext(dispatchers.io) {
-        currentCoroutineContext().ensureActive()
-        val result = block(currentDb.value)
-        currentCoroutineContext().ensureActive()
-        result
+    override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = withManagerOperation {
+        withContext(dispatchers.io) {
+            currentCoroutineContext().ensureActive()
+            val result = block(currentDb.value)
+            currentCoroutineContext().ensureActive()
+            result
+        }
     }
 
     /**
@@ -1331,7 +1334,7 @@ open class DatabaseManager(
 
     /**
      * Establishes an orderly shutdown boundary: rejects new work, bounds manager-job cancellation, admitted
-     * serialized-operation draining, and admitted-writer draining, waits for the last serialized switch/association to
+     * manager-operation draining, and admitted-writer draining, waits for the last serialized switch/association to
      * finalize, then closes every manager-owned Room instance. If a cancelled child, admitted operation, writer, or
      * pool close cannot finish successfully, ownership is retained and physical cleanup is skipped so a later [close]
      * call can retry without losing track of live resources. Retried attempts may call Room's idempotent `close()`
@@ -1393,8 +1396,7 @@ open class DatabaseManager(
                 // out.
                 managerJobs.forEach { it.cancel() }
 
-                // Bound-wait for already-admitted serialized operations before acquiring [mutex]. New work is
-                // rejected
+                // Bound-wait for already-admitted manager operations before acquiring [mutex]. New work is rejected
                 // while CLOSING, and a timed-out attempt leaves ownership intact so a later close() can retry.
                 val operationsDrained =
                     operationsDrain?.let { drain ->

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -95,18 +95,20 @@ open class DatabaseManager(
 
     @Volatile private var lifecycleState = LifecycleState.OPEN
 
-    // Per-source write barrier for merges. `withDb` deliberately does NOT take [mutex] (hot path), so a merge under
-    // [mutex] must still drain any in-flight writer that captured the source DB before folding it away — otherwise a
-    // late-committing write is lost when the source is retired. This dedicated lock (never held across a drain await,
-    // so it can't deadlock the merge) tracks live `withDb` blocks per captured DB instance and the writer-admission
-    // gate. The gate is armed at the start of an association attempt: while it is pending, [beginWrite] blocks new
-    // writers instead of letting them capture a DB, so a new `withDb` can never write to `source` once it is being
-    // retired, nor land on `dest` before the merge commits. The gate completes with `source` if the attempt aborts
+    // Per-database bounded-access tracking and per-source write barrier for merges. `withDb` deliberately does NOT
+    // take [mutex] (hot path), so a merge under [mutex] must still drain any in-flight writer that captured the source
+    // DB before folding it away — otherwise a late-committing write is lost when the source is retired. This
+    // dedicated lock (never held across a drain await, so it can't deadlock the merge) tracks live bounded reads and
+    // `withDb` blocks per captured DB instance, plus the writer-admission gate. The gate is armed at the start of an
+    // association attempt: while it is pending, [beginWrite] blocks new writers instead of letting them capture a
+    // DB, so a new `withDb` can never write to `source` once it is being retired, nor land on `dest` before the merge
+    // commits. The gate completes with `source` if the attempt aborts
     // (drain timeout, cancellation, or pre-commit merge failure) and with `dest` once the merge commits — source is
     // never restored after the merge commits. The lock is released before any suspend (drain await, gate await, Room
     // work, merge work, or DataStore work), so it can't deadlock any of them.
     private val writerTrackerMutex = Mutex()
     private val activeWriters = mutableMapOf<MeshtasticDatabase, Int>()
+    private val activeReaders = mutableMapOf<MeshtasticDatabase, Int>()
     private val drainWaiters = mutableMapOf<MeshtasticDatabase, MutableList<CompletableDeferred<Unit>>>()
     private val deferredEvictions = mutableSetOf<MeshtasticDatabase>()
     private var shutdownWriterDrain: CompletableDeferred<Unit>? = null
@@ -893,18 +895,50 @@ open class DatabaseManager(
 
     /**
      * Executes one bounded read without writer admission or the serialized write-containment lane. Active database
-     * publication is synchronous and published pools are logically retired, so a captured instance remains valid until
-     * the callback completes. The read is admitted into the shutdown drain, is never replayed automatically, and new
-     * reads are rejected once shutdown begins.
+     * publication is synchronous and the captured pool is registered against eviction until the callback completes. The
+     * read is also admitted into the shutdown drain, is never replayed automatically, and new reads are rejected once
+     * shutdown begins.
      */
     override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = withManagerOperation {
-        withContext(dispatchers.io) {
-            currentCoroutineContext().ensureActive()
-            val result = block(currentDb.value)
-            currentCoroutineContext().ensureActive()
-            result
+        val database = beginRead()
+        try {
+            withContext(dispatchers.io) {
+                currentCoroutineContext().ensureActive()
+                val result = block(database)
+                currentCoroutineContext().ensureActive()
+                result
+            }
+        } finally {
+            withContext(NonCancellable) { endRead(database) }
         }
     }
+
+    /** Captures and registers the currently published pool so eviction cannot close it while the callback is active. */
+    private suspend fun beginRead(): MeshtasticDatabase = writerTrackerMutex.withLock {
+        checkOpen()
+        _currentDb.value.also { database -> activeReaders[database] = (activeReaders[database] ?: 0) + 1 }
+    }
+
+    /** Releases a bounded reader and retries an eviction that was deferred while the captured pool was in use. */
+    private suspend fun endRead(database: MeshtasticDatabase) {
+        val retryEviction =
+            writerTrackerMutex.withLock {
+                val remaining = (activeReaders[database] ?: 1) - 1
+                if (remaining <= 0) {
+                    activeReaders.remove(database)
+                } else {
+                    activeReaders[database] = remaining
+                }
+                !hasActiveDatabaseAccessLocked(database) && deferredEvictions.remove(database)
+            }
+        if (retryEviction && lifecycleState == LifecycleState.OPEN) {
+            launchManagerWork(dispatchers.io) { enforceCacheLimit() }
+        }
+    }
+
+    /** Caller must hold [writerTrackerMutex]. */
+    private fun hasActiveDatabaseAccessLocked(database: MeshtasticDatabase): Boolean =
+        (activeWriters[database] ?: 0) > 0 || (activeReaders[database] ?: 0) > 0
 
     /**
      * Atomically snapshots the canonical active DB (held by [_currentDb], which initializes lazily to the default DB)
@@ -962,7 +996,7 @@ open class DatabaseManager(
                     activeWriters[db] = remaining
                 }
                 if (activeWriters.isEmpty()) shutdownWriterDrain?.complete(Unit)
-                drained && deferredEvictions.remove(db)
+                !hasActiveDatabaseAccessLocked(db) && deferredEvictions.remove(db)
             }
         if (retryEviction && lifecycleState == LifecycleState.OPEN) {
             launchManagerWork(dispatchers.io) { enforceCacheLimit() }
@@ -990,6 +1024,12 @@ open class DatabaseManager(
      */
     internal suspend fun debugWriterCounts(): Pair<Int, Int> =
         writerTrackerMutex.withLock { activeWriters.values.sum() to drainWaiters.values.sumOf { it.size } }
+
+    internal suspend fun debugReaderCount(database: MeshtasticDatabase? = null): Int = writerTrackerMutex.withLock {
+        if (database == null) activeReaders.values.sum() else activeReaders[database] ?: 0
+    }
+
+    internal suspend fun debugEnforceCacheLimit() = enforceCacheLimit()
 
     /** Test-only visibility for asserting an association did not leak writer admission. */
     internal suspend fun debugWriterGateArmed(): Boolean = writerTrackerMutex.withLock { writerGate != null }
@@ -1182,7 +1222,7 @@ open class DatabaseManager(
         }
     }
 
-    private fun listExistingDbNames(): List<String> {
+    protected open fun listExistingDbNames(): List<String> {
         val dir = getDatabaseDirectory()
         val fs = getFileSystem()
         if (!fs.exists(dir)) return emptyList()
@@ -1233,7 +1273,7 @@ open class DatabaseManager(
                 writerTrackerMutex.withLock {
                     victims.filter { name ->
                         val cached = dbCache[name]
-                        if (cached != null && (activeWriters[cached] ?: 0) > 0) {
+                        if (cached != null && hasActiveDatabaseAccessLocked(cached)) {
                             deferredEvictions.add(cached)
                             false
                         } else {
@@ -1509,6 +1549,7 @@ open class DatabaseManager(
                     deferredEvictions.clear()
                     drainWaiters.clear()
                     activeWriters.clear()
+                    activeReaders.clear()
                     activeManagerOperations.clear()
                     writerGate?.completeExceptionally(IllegalStateException("DatabaseManager is closing or closed"))
                     writerGate = null

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -892,6 +892,18 @@ open class DatabaseManager(
     }
 
     /**
+     * Executes one bounded read without writer admission or the serialized write-containment lane. Active database
+     * publication is synchronous and published pools are logically retired, so a captured instance remains valid for
+     * the lifetime of this manager. The read is never replayed automatically.
+     */
+    override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = withContext(dispatchers.io) {
+        currentCoroutineContext().ensureActive()
+        val result = block(currentDb.value)
+        currentCoroutineContext().ensureActive()
+        result
+    }
+
+    /**
      * Atomically snapshots the canonical active DB (held by [_currentDb], which initializes lazily to the default DB)
      * and registers a writer against it.
      *

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -1033,7 +1033,6 @@ open class DatabaseManager(
         val admission = beginWrite()
         val db = admission.database
         val active = admission.name
-        markLastUsed(active)
         try {
             return runCancellableDbBlock(db, block)
         } catch (e: CancellationException) {

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseProvider.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseProvider.kt
@@ -36,7 +36,10 @@ interface DatabaseProvider {
     /** Reactive stream of the currently active database instance. */
     val currentDb: StateFlow<MeshtasticDatabase>
 
-    /** Execute one bounded read against the synchronously published current database without writer admission. */
+    /**
+     * Execute one bounded read against the synchronously published current database without writer admission. The read
+     * is tracked through orderly shutdown and fails with [IllegalStateException] if admission starts after shutdown.
+     */
     suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T
 
     /** Execute [block] against the current database, returning `null` if no database is available. */

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseProvider.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseProvider.kt
@@ -26,14 +26,18 @@ import kotlinx.coroutines.flow.StateFlow
  * `currentDb.value` directly. [withDb] registers the write with the cross-transport merge drain barrier (see
  * [DatabaseManager.associateDevice]) so a merge can't snapshot a database while the write is still in flight and lose
  * it when that database is retired. The callback is never replayed automatically after it starts: callers that need
- * retries must make that policy explicit at a higher layer where idempotency is known. Direct `currentDb.value` is fine
- * for one-shot *reads* (a torn read against a just-retired DB is recoverable and reads don't need drain visibility),
- * and `currentDb` itself is the right latch for Flow/Paging factories, which must re-latch on DB switch and must stay
- * out of [withDb]'s containment lane.
+ * retries must make that policy explicit at a higher layer where idempotency is known.
+ *
+ * One-shot DAO *reads* use [withReadDb]. They stay out of writer admission and the serialized containment lane; the
+ * logical-retirement guarantee in [DatabaseManager] keeps a captured published pool alive for the process lifetime.
+ * [currentDb] itself remains the right latch for Flow/Paging factories, which must re-latch on database switches.
  */
 interface DatabaseProvider {
     /** Reactive stream of the currently active database instance. */
     val currentDb: StateFlow<MeshtasticDatabase>
+
+    /** Execute one bounded read against the synchronously published current database without writer admission. */
+    suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T
 
     /** Execute [block] against the current database, returning `null` if no database is available. */
     suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T?

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
@@ -16,8 +16,12 @@
  */
 package org.meshtastic.core.database
 
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -102,6 +106,43 @@ class DatabaseManagerReadTest : DatabaseManagerTestFixture() {
     }
 
     @Test
+    fun evictionWaitsForBoundedReadOnSwitchedAwayPool() = runTest(testDispatcher) {
+        val firstName = buildDbName("addrA")
+        val secondName = buildDbName("addrB")
+        manager.switchActiveDatabase("addrA")
+        val captured = manager.currentDb.value
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        val read = async {
+            manager.withReadDb { database ->
+                assertTrue(database === captured)
+                started.complete(Unit)
+                release.await()
+                database
+            }
+        }
+
+        started.await()
+        assertEquals(1, manager.debugReaderCount(captured))
+        manager.switchActiveDatabase("addrB")
+        manager.existingDbNamesForTest = listOf(firstName, secondName)
+        armableDs.edit { it[intPreferencesKey(DatabaseConstants.CACHE_LIMIT_KEY)] = 1 }
+        manager.cacheLimit.first { it == 1 }
+        manager.debugEnforceCacheLimit()
+
+        assertFalse(captured in manager.closedDatabases, "eviction must defer while the captured pool has a reader")
+
+        release.complete(Unit)
+        assertTrue(read.await() === captured)
+        runCurrent()
+
+        assertEquals(0, manager.debugReaderCount(captured))
+        assertEquals(1, manager.closedDatabases.count { it === captured })
+        assertTrue(firstName in manager.deletedDatabaseNames)
+    }
+
+    @Test
     fun boundedReadPropagatesFailureWithoutReplay() = runTest(testDispatcher) {
         var invocationCount = 0
 
@@ -115,6 +156,7 @@ class DatabaseManagerReadTest : DatabaseManagerTestFixture() {
 
         assertEquals("read failed", failure.message)
         assertEquals(1, invocationCount)
+        assertEquals(0, manager.debugReaderCount())
         assertEquals(0 to 0, manager.debugWriterCounts())
         assertFalse(manager.debugWriterGateArmed())
     }

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DatabaseManagerReadTest : DatabaseManagerTestFixture() {
+
+    @BeforeTest fun setUp() = setUpFixture()
+
+    @AfterTest fun tearDown() = tearDownFixture()
+
+    @Test
+    fun boundedReadUsesCapturedPublishedPoolWithoutWriterAdmissionOrReplay() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val original = manager.currentDb.value
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        var invocationCount = 0
+
+        val result = async {
+            manager.withReadDb { database ->
+                invocationCount += 1
+                assertTrue(database === original)
+                assertEquals(0 to 0, manager.debugWriterCounts())
+                assertFalse(manager.debugWriterGateArmed())
+                started.complete(Unit)
+                release.await()
+                database
+            }
+        }
+
+        started.await()
+        manager.switchActiveDatabase("addrB")
+        val replacement = manager.currentDb.value
+        assertTrue(replacement !== original)
+
+        release.complete(Unit)
+        assertTrue(result.await() === original)
+        assertEquals(1, invocationCount)
+        assertTrue(manager.currentDb.value === replacement)
+        assertEquals(0 to 0, manager.debugWriterCounts())
+        assertFalse(manager.debugWriterGateArmed())
+    }
+
+    @Test
+    fun boundedReadPropagatesFailureWithoutReplay() = runTest(testDispatcher) {
+        var invocationCount = 0
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                manager.withReadDb<Unit> {
+                    invocationCount += 1
+                    error("read failed")
+                }
+            }
+
+        assertEquals("read failed", failure.message)
+        assertEquals(1, invocationCount)
+        assertEquals(0 to 0, manager.debugWriterCounts())
+        assertFalse(manager.debugWriterGateArmed())
+    }
+}

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
@@ -67,6 +67,41 @@ class DatabaseManagerReadTest : DatabaseManagerTestFixture() {
     }
 
     @Test
+    fun closeWaitsForBoundedReadBeforeClosingItsCapturedPool() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val captured = manager.currentDb.value
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        val read = async {
+            manager.withReadDb { database ->
+                assertTrue(database === captured)
+                started.complete(Unit)
+                release.await()
+                database.nodeInfoDao().getUnknownNodes()
+            }
+        }
+
+        started.await()
+        val closeJob = async { manager.close() }
+        runCurrent()
+
+        assertFalse(closeJob.isCompleted, "shutdown must wait for the admitted bounded read")
+        assertFalse(
+            captured in manager.closedDatabases,
+            "the captured pool must stay open while the read is suspended",
+        )
+        assertFalse(manager.debugAcceptingWrites())
+        assertFailsWith<IllegalStateException> { manager.withReadDb { emptyList<Nothing>() } }
+
+        release.complete(Unit)
+        assertTrue(read.await().isEmpty())
+        closeJob.await()
+
+        assertEquals(1, manager.closedDatabases.count { it === captured })
+    }
+
+    @Test
     fun boundedReadPropagatesFailureWithoutReplay() = runTest(testDispatcher) {
         var invocationCount = 0
 

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerReadTest.kt
@@ -20,6 +20,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -140,6 +141,179 @@ class DatabaseManagerReadTest : DatabaseManagerTestFixture() {
         assertEquals(0, manager.debugReaderCount(captured))
         assertEquals(1, manager.closedDatabases.count { it === captured })
         assertTrue(firstName in manager.deletedDatabaseNames)
+    }
+
+    @Test
+    fun boundedReadDuringAssociationUsesSourceWithoutWaitingForWriterGate() = runTest(testDispatcher) {
+        val (destination, source) = setupTwoDatabases()
+        val mergeStarted = CompletableDeferred<Unit>()
+        val releaseMerge = CompletableDeferred<Unit>()
+        val readStarted = CompletableDeferred<Unit>()
+        val releaseRead = CompletableDeferred<Unit>()
+
+        manager.beforeMerge = { actualSource, actualDestination, _ ->
+            assertTrue(actualSource === source)
+            assertTrue(actualDestination === destination)
+            assertTrue(manager.debugWriterGateArmed())
+            mergeStarted.complete(Unit)
+            releaseMerge.await()
+        }
+
+        val association = async { manager.associateCurrentDevice(nodeNum = 123, deviceId = "deadbeefdeadbeef") }
+        mergeStarted.await()
+
+        val read = async {
+            manager.withReadDb { database ->
+                assertTrue(database === source)
+                readStarted.complete(Unit)
+                releaseRead.await()
+                database.nodeInfoDao().getUnknownNodes()
+            }
+        }
+
+        readStarted.await()
+        assertEquals(1, manager.debugReaderCount(source))
+        assertTrue(manager.debugWriterGateArmed())
+
+        releaseMerge.complete(Unit)
+        association.await()
+
+        assertTrue(manager.currentDb.value === destination)
+        assertFalse(source in manager.closedDatabases, "logical retirement must not close an admitted read pool")
+
+        releaseRead.complete(Unit)
+        assertTrue(read.await().isEmpty())
+        assertEquals(0, manager.debugReaderCount(source))
+    }
+
+    @Test
+    fun cancellingBoundedReadReleasesRefcountAndRetriesDeferredEviction() = runTest(testDispatcher) {
+        val firstName = buildDbName("addrA")
+        val secondName = buildDbName("addrB")
+        manager.switchActiveDatabase("addrA")
+        val captured = manager.currentDb.value
+        val started = CompletableDeferred<Unit>()
+        val neverRelease = CompletableDeferred<Unit>()
+
+        val read = async {
+            manager.withReadDb { database ->
+                assertTrue(database === captured)
+                started.complete(Unit)
+                neverRelease.await()
+            }
+        }
+
+        started.await()
+        manager.switchActiveDatabase("addrB")
+        manager.existingDbNamesForTest = listOf(firstName, secondName)
+        armableDs.edit { it[intPreferencesKey(DatabaseConstants.CACHE_LIMIT_KEY)] = 1 }
+        manager.cacheLimit.first { it == 1 }
+        manager.debugEnforceCacheLimit()
+
+        assertEquals(1, manager.debugReaderCount(captured))
+        assertFalse(captured in manager.closedDatabases)
+
+        read.cancelAndJoin()
+        runCurrent()
+
+        assertEquals(0, manager.debugReaderCount(captured))
+        assertEquals(1, manager.closedDatabases.count { it === captured })
+        assertTrue(firstName in manager.deletedDatabaseNames)
+    }
+
+    @Test
+    fun concurrentBoundedReadersKeepPoolUntilFinalReaderReleases() = runTest(testDispatcher) {
+        val firstName = buildDbName("addrA")
+        val secondName = buildDbName("addrB")
+        manager.switchActiveDatabase("addrA")
+        val captured = manager.currentDb.value
+        val firstStarted = CompletableDeferred<Unit>()
+        val secondStarted = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val releaseSecond = CompletableDeferred<Unit>()
+
+        val firstRead = async {
+            manager.withReadDb { database ->
+                assertTrue(database === captured)
+                firstStarted.complete(Unit)
+                releaseFirst.await()
+                database
+            }
+        }
+        val secondRead = async {
+            manager.withReadDb { database ->
+                assertTrue(database === captured)
+                secondStarted.complete(Unit)
+                releaseSecond.await()
+                database
+            }
+        }
+
+        firstStarted.await()
+        secondStarted.await()
+        assertEquals(2, manager.debugReaderCount(captured))
+
+        manager.switchActiveDatabase("addrB")
+        manager.existingDbNamesForTest = listOf(firstName, secondName)
+        armableDs.edit { it[intPreferencesKey(DatabaseConstants.CACHE_LIMIT_KEY)] = 1 }
+        manager.cacheLimit.first { it == 1 }
+        manager.debugEnforceCacheLimit()
+
+        releaseFirst.complete(Unit)
+        assertTrue(firstRead.await() === captured)
+        runCurrent()
+
+        assertEquals(1, manager.debugReaderCount(captured))
+        assertFalse(captured in manager.closedDatabases, "one remaining reader must keep the pool open")
+
+        releaseSecond.complete(Unit)
+        assertTrue(secondRead.await() === captured)
+        runCurrent()
+
+        assertEquals(0, manager.debugReaderCount(captured))
+        assertEquals(1, manager.closedDatabases.count { it === captured })
+        assertTrue(firstName in manager.deletedDatabaseNames)
+    }
+
+    @Test
+    fun evictionSelectionPreventsVictimFromAcquiringNewReader() = runTest(testDispatcher) {
+        val victimName = buildDbName("addrA")
+        val activeName = buildDbName("addrB")
+        manager.switchActiveDatabase("addrA")
+        val victim = manager.currentDb.value
+        manager.switchActiveDatabase("addrB")
+        manager.existingDbNamesForTest = listOf(victimName, activeName)
+        armableDs.edit { it[intPreferencesKey(DatabaseConstants.CACHE_LIMIT_KEY)] = 1 }
+        manager.cacheLimit.first { it == 1 }
+
+        val victimSelected = CompletableDeferred<Unit>()
+        val releaseEviction = CompletableDeferred<Unit>()
+        manager.beforeCloseCached = { dbName ->
+            if (dbName == victimName) {
+                victimSelected.complete(Unit)
+                releaseEviction.await()
+            }
+        }
+
+        val eviction = async { manager.debugEnforceCacheLimit() }
+        victimSelected.await()
+
+        val reacquire = async {
+            manager.switchActiveDatabase("addrA")
+            manager.withReadDb { it }
+        }
+        runCurrent()
+
+        assertFalse(reacquire.isCompleted, "switching back to the selected victim must wait for eviction")
+        assertEquals(0, manager.debugReaderCount(victim))
+
+        releaseEviction.complete(Unit)
+        eviction.await()
+        val reopened = reacquire.await()
+
+        assertEquals(1, manager.closedDatabases.count { it === victim })
+        assertTrue(reopened !== victim, "a later read must use a newly opened pool, not the evicted victim")
+        assertEquals(0, manager.debugReaderCount(victim))
     }
 
     @Test

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerTestFixture.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerTestFixture.kt
@@ -185,6 +185,7 @@ abstract class DatabaseManagerTestFixture {
         var markerVerification: (suspend (MeshtasticDatabase, String) -> Boolean)? = null
         var backfillStarted: CompletableDeferred<MeshtasticDatabase>? = null
         var backfillRelease: CompletableDeferred<Unit>? = null
+        var beforeCloseCached: suspend (String) -> Unit = {}
         val backfillDatabases = mutableListOf<MeshtasticDatabase>()
         val deletedDatabaseNames = mutableListOf<String>()
         var existingDbNamesForTest: List<String>? = null
@@ -210,6 +211,11 @@ abstract class DatabaseManagerTestFixture {
             backfillDatabases += db
             backfillStarted?.complete(db)
             backfillRelease?.await()
+        }
+
+        override suspend fun closeCachedDatabase(dbName: String) {
+            beforeCloseCached(dbName)
+            super.closeCachedDatabase(dbName)
         }
 
         override fun deleteDatabaseFiles(dbName: String) {

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerTestFixture.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerTestFixture.kt
@@ -187,6 +187,9 @@ abstract class DatabaseManagerTestFixture {
         var backfillRelease: CompletableDeferred<Unit>? = null
         val backfillDatabases = mutableListOf<MeshtasticDatabase>()
         val deletedDatabaseNames = mutableListOf<String>()
+        var existingDbNamesForTest: List<String>? = null
+
+        override fun listExistingDbNames(): List<String> = existingDbNamesForTest ?: super.listExistingDbNames()
 
         override suspend fun mergeDatabases(
             source: MeshtasticDatabase,

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/SwitchingDiscoveryDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/SwitchingDiscoveryDaoTest.kt
@@ -91,6 +91,8 @@ class SwitchingDiscoveryDaoTest {
         private val _currentDb = MutableStateFlow(db)
         override val currentDb: StateFlow<MeshtasticDatabase> = _currentDb
 
+        override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = block(_currentDb.value)
+
         override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? = block(_currentDb.value)
 
         fun switchTo(db: MeshtasticDatabase) {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
@@ -29,6 +29,8 @@ class FakeDatabaseProvider : DatabaseProvider {
     private val _currentDb = MutableStateFlow(db)
     override val currentDb: StateFlow<MeshtasticDatabase> = _currentDb
 
+    override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = block(db)
+
     override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? = block(db)
 
     /**


### PR DESCRIPTION
## Summary by Sourcery

Introduce a bounded read path that avoids writer admission, and adjust database shutdown coordination to track these read operations while keeping published pools valid through their callbacks.

New Features:
- Add withReadDb to DatabaseProvider and implement bounded, non-writer-admitted reads in DatabaseManager.

Enhancements:
- Refine manager operation tracking comments and semantics to cover both serialized operations and bounded read callbacks.
- Switch read-only data sources to use the new bounded read API instead of the write-admitted withDb path.

Tests:
- Add DatabaseManagerReadTest to verify bounded read behavior, shutdown interaction, and failure propagation.
- Update fake and test DatabaseProvider implementations to support the new read-only path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR introduces a dedicated, one-shot read database access path that avoids the writer-admission and serialized write-containment mechanisms used for writes, while still using the currently published database/pool. It also reduces unnecessary metadata churn by stopping “last-used” timestamp updates during the common database execution path. DAO read call sites and test/fake providers are updated accordingly, with new tests validating pool capture, switching behavior, cancellation, and failure propagation.

### Key changes

**Features**
- Added `withReadDb` to the database abstraction (`DatabaseProvider` and `DatabaseManager`) for bounded/synchronous DAO reads executed against the currently active database directly (no writer admission, no replay).
- Updated `DatabaseProvider` guidance/contract so one-shot DAO reads use `withReadDb`, while `currentDb` remains for reactive relatching use cases (e.g., Flow/Paging).
- Updated test infrastructure:
  - `FakeDatabaseProvider.withReadDb` added to run the read block directly against its in-memory DB.
  - `SwitchingDiscoveryDaoTest` test provider updated so read operations are executed via the new `withReadDb`.

**Fixes / Behavioral changes**
- Prevented read operations from entering the writer-side mechanisms (writer gate not armed; writer admission disabled) and ensured no replay occurs on failure.
- Ensured bounded reads capture and continue using the published database/pool even if the active database switches mid-flight.
- Ensured `close()` waits for an in-progress bounded read to finish before closing the captured pool (and disallows new `withReadDb` calls during the shutdown window).
- Exception propagation: if the `withReadDb` block throws, the error propagates to the caller without replay and without triggering writer admission.
- Stopped marking databases as last-used as part of the common `withDb`/active-DB execution path (removed the `markLastUsed(active)` call).

**Refactors**
- Routed one-shot DAO reads through `dbManager.withReadDb` in local data sources, including:
  - `DeviceHardwareLocalDataSource`
  - `DeviceLinkLocalDataSource`
  - `FirmwareReleaseLocalDataSource`
  - `SwitchingNodeInfoReadDataSource`
- Removed per-call-site fallback defaults for read methods (e.g., `orEmpty()`, `?: false`, `?: 0`, `?: emptyList()`), returning the DAO results directly for these read paths.

### Breaking changes and migration
- Any `DatabaseProvider` implementation must implement the new `withReadDb` method.
- One-shot DAO read call sites should be migrated to use `withReadDb`; reactive/relatching behavior for database switches should continue to use `currentDb`-based mechanisms (per updated documentation/contract).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->