### PR TITLE
fix(node): reconcile stale identity replays after renumbering

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
@@ -20,6 +20,7 @@ import org.meshtastic.core.database.entity.MetadataEntity
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.NodeEntity
 
+@Suppress("TooManyFunctions")
 interface NodeInfoWriteDataSource {
     suspend fun upsert(node: NodeEntity)
 
@@ -33,6 +34,12 @@ interface NodeInfoWriteDataSource {
     suspend fun deleteNode(num: Int)
 
     suspend fun deleteNodes(nodeNums: List<Int>)
+
+    /**
+     * Atomically deletes [deleteNums] rows (node + metadata) then upserts [upsert] in one [withDb] transaction.
+     * Deletions execute first so the upsert cannot resurrect a just-deleted stale identity.
+     */
+    suspend fun reconcileIdentity(deleteNums: List<Int>, upsert: NodeEntity?)
 
     suspend fun deleteMetadata(num: Int)
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
@@ -24,6 +24,7 @@ import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.NodeEntity
 import org.meshtastic.core.di.CoroutineDispatchers
 
+@Suppress("TooManyFunctions")
 @Single
 class SwitchingNodeInfoWriteDataSource(
     private val dbManager: DatabaseProvider,
@@ -57,6 +58,10 @@ class SwitchingNodeInfoWriteDataSource(
 
     override suspend fun deleteNodes(nodeNums: List<Int>) {
         withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().deleteNodes(nodeNums) } }
+    }
+
+    override suspend fun reconcileIdentity(deleteNums: List<Int>, upsert: NodeEntity?) {
+        withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().reconcileIdentity(deleteNums, upsert) } }
     }
 
     override suspend fun deleteMetadata(num: Int) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
@@ -28,6 +28,7 @@ import okio.ByteString
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.clampTimestampToNow
+import org.meshtastic.core.common.util.crc32
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
@@ -50,6 +51,18 @@ import org.meshtastic.proto.User
 import org.meshtastic.proto.NodeInfo as ProtoNodeInfo
 import org.meshtastic.proto.Position as ProtoPosition
 
+/**
+ * Resolves a stable identity key from a raw [ByteString]. Returns null unless the key is exactly [Node.PUBLIC_KEY_SIZE]
+ * bytes and is not [Node.ERROR_BYTE_STRING]. Used by the reducer to centralize key validation so no branch repeats the
+ * size/error check inline.
+ */
+private fun resolveStableKey(key: ByteString?): ByteString? {
+    if (key == null || key.size != Node.PUBLIC_KEY_SIZE || key == Node.ERROR_BYTE_STRING) return null
+    return key
+}
+
+private val DEFAULT_NODE_NAME_REGEX = Regex("^Meshtastic [0-9a-fA-F]{4}$")
+
 /** Implementation of [NodeManager] that maintains an in-memory database of the mesh. */
 @Suppress("LongParameterList", "TooManyFunctions", "CyclomaticComplexMethod")
 @Single(binds = [NodeManager::class, NodeIdLookup::class])
@@ -59,41 +72,108 @@ class NodeManagerImpl(
     @Named("ServiceScope") private val scope: CoroutineScope,
 ) : NodeManager {
 
+    /**
+     * Resolves the stable identity key from a stored [Node], preferring [Node.publicKey] and falling back to
+     * [User.public_key] only when the primary field is not itself a valid stable key.
+     */
+    internal fun resolveNodeStableKey(node: Node): ByteString? =
+        resolveStableKey(node.publicKey) ?: resolveStableKey(node.user.public_key)
+
     // Two indices over the same node set: byNum is the canonical store (mesh-level identifier), byId is a secondary
-    // O(1) lookup for the user-facing hex string. Both are held in a single atomic ref so updates are observed
-    // consistently — concurrent readers never see an entry present in one index but not the other.
-    private data class NodeIndex(
+    // index for O(1) user-ID lookup. Both are held in a single atomic ref so updates are observed consistently.
+    internal data class NodeIndex(
         val byNum: PersistentMap<Int, Node> = persistentMapOf(),
         val byId: PersistentMap<String, Node> = persistentMapOf(),
     ) {
-        fun put(num: Int, node: Node): NodeIndex {
+        fun put(num: Int, node: Node, preferredNum: Int? = null): NodeIndex {
             val previous = byNum[num]
+            val nextByNum = byNum.putting(num, node)
             var nextById = byId
-            // If the user.id changed (e.g. firmware reassigned the hex id) drop the stale id entry.
-            if (previous != null && previous.user.id.isNotEmpty() && previous.user.id != node.user.id) {
-                nextById = nextById.removing(previous.user.id)
+            val affectedIds = setOfNotNull(previous?.user?.id, node.user.id).filter { it.isNotEmpty() }
+            for (id in affectedIds) {
+                val candidates = nextByNum.entries.filter { it.value.user.id == id }
+                val representative = chooseRepresentative(candidates, preferredNum)
+                nextById =
+                    if (representative == null) {
+                        nextById.removing(id)
+                    } else {
+                        nextById.putting(id, representative.value)
+                    }
             }
-            if (node.user.id.isNotEmpty()) {
-                nextById = nextById.putting(node.user.id, node)
-            }
-            return NodeIndex(byNum = byNum.putting(num, node), byId = nextById)
+            return NodeIndex(byNum = nextByNum, byId = nextById)
         }
 
-        fun remove(num: Int): NodeIndex {
+        /**
+         * Removes [num] from both indices. When the removed node's user ID was the [byId] representative and another
+         * surviving node shares that ID, [preferredNum] wins when present; otherwise the stable fallback selects the
+         * replacement.
+         */
+        fun remove(num: Int, preferredNum: Int? = null): NodeIndex {
             val previous = byNum[num] ?: return this
-            return NodeIndex(
-                byNum = byNum.removing(num),
-                byId = if (previous.user.id.isNotEmpty()) byId.removing(previous.user.id) else byId,
-            )
+            val newByNum = byNum.removing(num)
+            var newById = byId
+            if (previous.user.id.isNotEmpty() && (byId[previous.user.id]?.num == num || preferredNum != null)) {
+                val survivors = newByNum.entries.filter { it.value.user.id == previous.user.id }
+                val survivor = chooseRepresentative(survivors, preferredNum)
+                newById =
+                    if (survivor != null) {
+                        newById.putting(previous.user.id, survivor.value)
+                    } else {
+                        newById.removing(previous.user.id)
+                    }
+            }
+            return NodeIndex(byNum = newByNum, byId = newById)
         }
 
         companion object {
+            /**
+             * Determines whether a [Node] is a generated placeholder (default identity with no established identity).
+             * Used by both the representative selector and the stale-packet reducer to ensure consistent
+             * classification.
+             */
+            internal fun isGeneratedPlaceholder(node: Node): Boolean {
+                val nodeKey = resolveStableKey(node.publicKey) ?: resolveStableKey(node.user.public_key)
+                return nodeKey == null &&
+                    node.user.hw_model == HardwareModel.UNSET &&
+                    node.user.id == NodeAddress.numToDefaultId(node.num) &&
+                    node.user.long_name.matches(DEFAULT_NODE_NAME_REGEX)
+            }
+
+            private val representativeComparator =
+                compareByDescending<Map.Entry<Int, Node>> {
+                    resolveStableKey(it.value.publicKey) != null ||
+                        resolveStableKey(it.value.user.public_key) != null ||
+                        it.value.user.hw_model != HardwareModel.UNSET
+                }
+                    .thenBy { it.key }
+
+            /**
+             * Selects a deterministic representative from [candidates] sharing the same user ID. If [preferredNum] is
+             * provided and present in candidates, it is selected (used for stale replay and local reconciliation).
+             * Otherwise, prefer an established key or hardware identity, then the lower node number.
+             */
+            internal fun chooseRepresentative(
+                candidates: List<Map.Entry<Int, Node>>,
+                preferredNum: Int?,
+            ): Map.Entry<Int, Node>? = preferredNum?.let { preferred -> candidates.firstOrNull { it.key == preferred } }
+                ?: candidates.minWithOrNull(representativeComparator)
+
             fun fromByNum(nodes: Map<Int, Node>): NodeIndex {
                 var byNum = persistentMapOf<Int, Node>()
+                for ((n, node) in nodes) {
+                    byNum = byNum.putting(n, node)
+                }
+                // Build byId deterministically: for duplicate user IDs, choose representative by stable tie-break.
+                val byIdEntries =
+                    byNum.entries
+                        .groupBy { it.value.user.id }
+                        .filterKeys { it.isNotEmpty() }
+                        .mapValues { (_, entries) ->
+                            chooseRepresentative(entries.toList(), preferredNum = null)!!.value
+                        }
                 var byId = persistentMapOf<String, Node>()
-                for ((num, node) in nodes) {
-                    byNum = byNum.putting(num, node)
-                    if (node.user.id.isNotEmpty()) byId = byId.putting(node.user.id, node)
+                for ((id, node) in byIdEntries) {
+                    byId = byId.putting(id, node)
                 }
                 return NodeIndex(byNum, byId)
             }
@@ -138,6 +218,7 @@ class NodeManagerImpl(
 
     companion object {
         private const val TIME_MS_TO_S = 1000L
+        private const val GENERATED_NODE_NAME_SUFFIX_LENGTH = 4
     }
 
     override fun loadCachedNodeDB() {
@@ -189,19 +270,8 @@ class NodeManagerImpl(
         nodeIndex.update { it.remove(nodeNum) }
     }
 
-    internal fun getOrCreateNode(n: Int, channel: Int = 0): Node = nodeIndex.value.byNum[n]
-        ?: run {
-            val userId = NodeAddress.numToDefaultId(n)
-            val defaultUser =
-                User(
-                    id = userId,
-                    long_name = "Meshtastic ${userId.takeLast(n = 4)}",
-                    short_name = userId.takeLast(n = 4),
-                    hw_model = HardwareModel.UNSET,
-                )
-
-            Node(num = n, user = defaultUser, channel = channel)
-        }
+    internal fun getOrCreateNode(n: Int, channel: Int = 0): Node =
+        nodeIndex.value.byNum[n] ?: createDefaultNode(n, channel)
 
     override fun updateNode(nodeNum: Int, channel: Int, transform: (Node) -> Node) {
         // Perform read + transform inside update{} to ensure atomicity.
@@ -222,40 +292,17 @@ class NodeManagerImpl(
     }
 
     override fun handleReceivedUser(fromNum: Int, p: User, channel: Int, manuallyVerified: Boolean) {
-        updateNode(fromNum) { node ->
-            val newNode = (node.isUnknownUser && p.hw_model != HardwareModel.UNSET)
-            val shouldPreserve = shouldPreserveExistingUser(node.user, p)
-
-            val next =
-                if (shouldPreserve) {
-                    node.copy(channel = channel, manuallyVerified = manuallyVerified)
-                } else {
-                    val keyMatch = !node.hasPKC || node.user.public_key == p.public_key
-                    val newUser = if (keyMatch) p else p.copy(public_key = ByteString.EMPTY)
-                    node.copy(
-                        user = newUser,
-                        publicKey = newUser.public_key,
-                        channel = channel,
-                        manuallyVerified = manuallyVerified,
-                    )
-                }
-            if (newNode && !shouldPreserve) {
-                scope.handledLaunch {
-                    notificationManager.dispatch(
-                        Notification(
-                            title = getStringSuspend(Res.string.new_node_seen, next.user.short_name),
-                            message = next.user.long_name,
-                            category = Notification.Category.NodeEvent,
-                            id = next.num,
-                            // Path format must stay in sync with DEEP_LINK_BASE_URI + DeepLinkRouter
-                            // in core/navigation (avoided as a Gradle dep here to keep core/data free
-                            // of Compose Navigation libs).
-                            deepLinkUri = "meshtastic://meshtastic/nodes/${next.num}",
-                        ),
-                    )
-                }
+        while (true) {
+            val before = nodeIndex.value
+            val myNum = myNodeNum.value // Read fresh on each retry
+            val transition = reduceReceivedUser(before, fromNum, p, channel, manuallyVerified, myNum)
+            // Guard against myNodeNum changing between the reduction and the CAS — a handshake renumber
+            // could reclassify a local packet as remote or vice versa.
+            if (myNodeNum.value != myNum) continue
+            if (nodeIndex.compareAndSet(before, transition.after)) {
+                applyReceivedUserEffects(transition)
+                return
             }
-            next
         }
     }
 
@@ -356,10 +403,235 @@ class NodeManagerImpl(
     }
 
     private fun shouldPreserveExistingUser(existing: User, incoming: User): Boolean {
-        val isDefaultName = (incoming.long_name).matches(Regex("^Meshtastic [0-9a-fA-F]{4}$"))
+        val isDefaultName = incoming.long_name.matches(DEFAULT_NODE_NAME_REGEX)
         val isDefaultHwModel = incoming.hw_model == HardwareModel.UNSET
-        val hasExistingUser = (existing.id).isNotEmpty() && existing.hw_model != HardwareModel.UNSET
+        val hasCustomIdentity =
+            existing.id != incoming.id ||
+                existing.long_name != incoming.long_name ||
+                existing.short_name != incoming.short_name
+        val hasExistingUser =
+            existing.id.isNotEmpty() && (existing.hw_model != HardwareModel.UNSET || hasCustomIdentity)
         return hasExistingUser && isDefaultName && isDefaultHwModel
+    }
+
+    /**
+     * Ordered persistence plan produced by [reduceReceivedUser]. Deletions execute before upsert: stale rows are
+     * removed before the canonical node is validated/inserted, so the DAO's normal mesh-time upsert cannot resurrect a
+     * deleted stale identity from a `same_key, different_num` collision.
+     */
+    private data class PersistencePlan(val deleteNums: List<Int> = emptyList(), val upsert: Node? = null)
+
+    /**
+     * Result of classifying one [User] packet against an in-memory [NodeIndex] snapshot. The reducer is pure: it only
+     * reads [before] and the packet fields, and produces the next index plus the side effects to apply once the CAS
+     * commits. Safe to re-evaluate on every retry.
+     */
+    private data class ReceivedUserTransition(
+        val after: NodeIndex,
+        /** Ordered persistence plan to apply once the CAS commits (see [PersistencePlan]). */
+        val persistence: PersistencePlan,
+        /** Node to fire a "new node seen" notification for (null if not a genuine new node). */
+        val notifyNode: Node?,
+    )
+
+    /**
+     * Pure reducer that classifies an incoming [User] packet against the [before] snapshot and returns the next index
+     * plus queued side effects. No logging, no DB calls, no coroutine launches — deterministic and safe to re-run on
+     * CAS retry.
+     *
+     * Classification:
+     * 1. [fromNum] == [myNum] → local-link authoritative: remove ALL other same-key entries, update local, no notify.
+     * 2. [p.public_key] is null/empty/ERROR → NoMatch: normal update.
+     * 3. Otherwise the resolved key's canonical firmware-2.8 num (`crc32(public_key).toInt()`) decides direction:
+     *     - Multiple other same-key candidates → ambiguous: preserve all, ignore packet.
+     *     - Exactly one other same-key candidate:
+     *         - Incoming at the canonical num, other not canonical → remove the other noncanonical entry, accept/
+     *           transform/upsert the incoming packet, prefer [fromNum], no notification.
+     *         - Other at the canonical num, incoming not canonical → remove the incoming stale entry (placeholder or
+     *           same-key), prefer the other num, no persistence, no notification.
+     *         - Neither num canonical → direction unknown: preserve both, ignore packet.
+     *         - Either slot carrying a different established valid key → conflict: preserve both, ignore packet.
+     *     - No other same-key candidate → NoMatch: normal update.
+     */
+    @Suppress("CyclomaticComplexMethod", "ReturnCount", "LongMethod")
+    private fun reduceReceivedUser(
+        before: NodeIndex,
+        fromNum: Int,
+        p: User,
+        channel: Int,
+        manuallyVerified: Boolean,
+        myNum: Int?,
+    ): ReceivedUserTransition {
+        val resolvedKey = resolveStableKey(p.public_key)
+
+        if (fromNum == myNum) {
+            // Local-link data is authoritative. Remove ALL other same-key entries in-memory, then update the local
+            // node. Durable renumbering is handled by the config-install migration — no repository delete calls.
+            val otherSameKeyNums =
+                if (resolvedKey == null) {
+                    emptyList()
+                } else {
+                    before.byNum.entries
+                        .filter { (otherNum, otherNode) ->
+                            otherNum != fromNum && resolveNodeStableKey(otherNode) == resolvedKey
+                        }
+                        .map { it.key }
+                }
+            val afterRemovals = otherSameKeyNums.fold(before) { idx, num -> idx.remove(num) }
+            val localNode = afterRemovals.byNum[fromNum] ?: createDefaultNode(fromNum, channel)
+            val transformed = transformUserNode(localNode, p, channel, manuallyVerified)
+            return ReceivedUserTransition(
+                after = afterRemovals.put(fromNum, transformed, preferredNum = fromNum),
+                persistence = PersistencePlan(deleteNums = otherSameKeyNums, upsert = transformed),
+                notifyNode = null,
+            )
+        }
+
+        // Non-local: identity matching against other nodes in the snapshot. Direction is decided by the firmware-2.8
+        // canonical node num (crc32 of the resolved public key) — the slot whose num matches the key is the canonical
+        // home; the other same-key sighting is a stale replay that must yield.
+        if (resolvedKey != null) {
+            val canonicalNum = resolvedKey.crc32().toInt()
+            val matches =
+                before.byNum.entries.filter { (otherNum, otherNode) ->
+                    otherNum != fromNum && resolveNodeStableKey(otherNode) == resolvedKey
+                }
+
+            if (matches.size > 1) {
+                // Ambiguous: multiple other candidates carry the same key. Don't pick arbitrarily.
+                return ReceivedUserTransition(before, PersistencePlan(), null)
+            }
+
+            if (matches.size == 1) {
+                val other = matches.single()
+                val otherIsCanonical = other.key == canonicalNum
+                val incomingIsCanonical = fromNum == canonicalNum
+                val existing = before.byNum[fromNum]
+                val existingKey = existing?.let { resolveNodeStableKey(it) }
+                val isGeneratedPlaceholder = existing != null && NodeIndex.isGeneratedPlaceholder(existing)
+                // The incoming slot is open for canonical-direction reconciliation when absent, a generated
+                // placeholder, or already carrying the same key. A different established valid key is a conflict.
+                val incomingSlotIsOpen = existing == null || isGeneratedPlaceholder || existingKey == resolvedKey
+
+                if (incomingIsCanonical && !otherIsCanonical) {
+                    // Packet arrived at the canonical num; the other same-key entry is a stale noncanonical sighting.
+                    if (!incomingSlotIsOpen) {
+                        // Different established identity at the canonical num → conflict, preserve both.
+                        return ReceivedUserTransition(before, PersistencePlan(), null)
+                    }
+                    // Delete the noncanonical same-key row durably, then upsert canonical.
+                    val afterRemoval = before.remove(other.key)
+                    val baseNode = afterRemoval.byNum[fromNum] ?: createDefaultNode(fromNum, channel)
+                    val transformed = transformUserNode(baseNode, p, channel, manuallyVerified)
+                    return ReceivedUserTransition(
+                        after = afterRemoval.put(fromNum, transformed, preferredNum = fromNum),
+                        persistence = PersistencePlan(deleteNums = listOf(other.key), upsert = transformed),
+                        notifyNode = null,
+                    )
+                }
+
+                if (otherIsCanonical && !incomingIsCanonical) {
+                    // Other entry sits at the canonical num; the incoming packet at fromNum is a stale noncanonical
+                    // replay. Delete the stale row durably so it cannot return after process restart.
+                    if (!incomingSlotIsOpen) {
+                        return ReceivedUserTransition(before, PersistencePlan(), null)
+                    }
+                    return ReceivedUserTransition(
+                        after = before.remove(fromNum, preferredNum = other.key),
+                        persistence = PersistencePlan(deleteNums = listOf(fromNum)),
+                        notifyNode = null,
+                    )
+                }
+
+                // Neither num is canonical (both-canonical is impossible since other.key != fromNum): direction
+                // unknown. Preserve both, no persistence, no notification.
+                return ReceivedUserTransition(before, PersistencePlan(), null)
+            }
+        }
+
+        // NoMatch: normal update path.
+        val existing = before.byNum[fromNum] ?: createDefaultNode(fromNum, channel)
+        val isNewNode = existing.isUnknownUser && p.hw_model != HardwareModel.UNSET
+        val shouldPreserve = shouldPreserveExistingUser(existing.user, p)
+        val transformed = transformUserNode(existing, p, channel, manuallyVerified)
+        val notify = if (isNewNode && !shouldPreserve) transformed else null
+        return ReceivedUserTransition(
+            after = before.put(fromNum, transformed),
+            persistence = PersistencePlan(upsert = transformed),
+            notifyNode = notify,
+        )
+    }
+
+    /** Pure factory for a placeholder [Node] at [num]. Kept side-effect-free so the reducer can call it safely. */
+    private fun createDefaultNode(num: Int, channel: Int): Node {
+        val userId = NodeAddress.numToDefaultId(num)
+        return Node(
+            num = num,
+            user =
+            User(
+                id = userId,
+                long_name = "Meshtastic ${userId.takeLast(GENERATED_NODE_NAME_SUFFIX_LENGTH)}",
+                short_name = userId.takeLast(GENERATED_NODE_NAME_SUFFIX_LENGTH),
+                hw_model = HardwareModel.UNSET,
+            ),
+            channel = channel,
+        )
+    }
+
+    /**
+     * Pure transform of an existing [node] under an incoming [User] packet (extracted from the legacy updateNode path).
+     */
+    private fun transformUserNode(node: Node, p: User, channel: Int, manuallyVerified: Boolean): Node {
+        val shouldPreserve = shouldPreserveExistingUser(node.user, p)
+        return if (shouldPreserve) {
+            node.copy(channel = channel, manuallyVerified = manuallyVerified)
+        } else {
+            val sanitizedUser = if (resolveStableKey(p.public_key) == null) p.copy(public_key = ByteString.EMPTY) else p
+            val keyMatch = !node.hasPKC || node.user.public_key == sanitizedUser.public_key
+            val newUser = if (keyMatch) sanitizedUser else sanitizedUser.copy(public_key = ByteString.EMPTY)
+            node.copy(
+                user = newUser,
+                publicKey = newUser.public_key,
+                channel = channel,
+                manuallyVerified = manuallyVerified,
+            )
+        }
+    }
+
+    /**
+     * Applies the side effects queued by [reduceReceivedUser] exactly once after the CAS commits, dispatching on the
+     * ordered [PersistencePlan]. The plan deletes stale rows before the upsert so the DAO's normal mesh-time upsert
+     * (which deliberately maps a `same_key, different_num` node back to the existing identity) cannot resurrect a
+     * deleted stale entry.
+     */
+    private fun applyReceivedUserEffects(transition: ReceivedUserTransition) {
+        val plan = transition.persistence
+        if (plan.deleteNums.isNotEmpty() || plan.upsert != null) {
+            if (isNodeDbReady.value) {
+                scope.handledLaunch { nodeRepository.reconcileIdentity(plan.deleteNums, plan.upsert) }
+            }
+        }
+        transition.notifyNode?.let { node ->
+            scope.handledLaunch {
+                notificationManager.dispatch(
+                    Notification(
+                        title = notificationTitleFormatter(node.user.short_name),
+                        message = node.user.long_name,
+                        category = Notification.Category.NodeEvent,
+                        id = node.num,
+                        deepLinkUri = "meshtastic://meshtastic/nodes/${node.num}",
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * Test seam over the notification title; production resolves compose-resources lazily inside the dispatch
+     * coroutine.
+     */
+    internal var notificationTitleFormatter: suspend (String) -> String = { shortName ->
+        getStringSuspend(Res.string.new_node_seen, shortName)
     }
 
     override fun toNodeID(nodeNum: Int): String = if (nodeNum == NodeAddress.NODENUM_BROADCAST) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
@@ -221,6 +221,10 @@ class NodeRepositoryImpl(
         nodeNums.forEach { nodeInfoWriteDataSource.deleteMetadata(it) }
     }
 
+    /** Atomically deletes stale rows then upserts the canonical node in one [withDb] transaction. */
+    override suspend fun reconcileIdentity(deleteNums: List<Int>, upsert: Node?) =
+        withContext(dispatchers.io) { nodeInfoWriteDataSource.reconcileIdentity(deleteNums, upsert?.toEntity()) }
+
     override suspend fun getNodesOlderThan(lastHeard: Int): List<Node> =
         withContext(dispatchers.io) { nodeInfoReadDataSource.getNodesOlderThan(lastHeard).map { it.toModel() } }
 

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
@@ -19,15 +19,24 @@ package org.meshtastic.core.data.manager
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.capture.capture
 import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.common.util.crc32
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.proto.DeviceMetrics
 import org.meshtastic.proto.EnvironmentMetrics
@@ -54,6 +63,10 @@ class NodeManagerImplTest {
     @BeforeTest
     fun setUp() {
         nodeManager = NodeManagerImpl(nodeRepository, notificationManager, testScope)
+        // Override the compose-resources formatter so notification dispatch is deterministic in the
+        // plain-JVM test env (getStringSuspend does not resolve here). Tests that assert "no dispatch"
+        // still hold: the override only changes the title, not whether dispatch fires.
+        nodeManager.notificationTitleFormatter = { shortName -> "New node seen: $shortName" }
     }
 
     @Test
@@ -439,4 +452,1053 @@ class NodeManagerImplTest {
         val result = nodeManager.getMyId()
         assertEquals("!mynode42", result)
     }
+
+    // ---------- Atomic identity reconciliation ----------
+    //
+    // Covers the CAS-loop reducer that replaced the legacy read-then-mutate sequence. Each test asserts typed
+    // in-memory state AND the observable side effects (upsert / conditional delete / notification dispatch).
+
+    private val validPk = ByteArray(32) { (it + 1).toByte() }.toByteString()
+
+    private fun ByteString.canonicalNum(): Int = crc32().toInt()
+
+    private fun makeKnownNode(num: Int, pk: ByteString, name: String = "Known"): Node = Node(
+        num = num,
+        user =
+        User(
+            id = "!${num.toString(16)}",
+            long_name = name,
+            short_name = name.take(3),
+            hw_model = HardwareModel.TLORA_V2,
+            public_key = pk,
+        ),
+        publicKey = pk,
+    )
+
+    private fun enableDbWrites() {
+        nodeManager.setNodeDbReady(true)
+        nodeManager.setAllowNodeDbWrites(true)
+    }
+
+    // 1. Established same-key duplicate
+
+    @Test
+    fun `established same-key duplicate deletes stale row preserves canonical without upsert`() {
+        val oldNum = 1000
+        val newNum = validPk.canonicalNum()
+        nodeManager.updateNode(newNum) { makeKnownNode(newNum, validPk, "Migrated") }
+        nodeManager.updateNode(oldNum) { makeKnownNode(oldNum, validPk, "Stale Established") }
+        enableDbWrites()
+
+        val staleUser =
+            User(
+                id = "!old",
+                long_name = "Stale",
+                short_name = "STL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(oldNum, staleUser)
+        testScope.advanceUntilIdle()
+
+        assertNull(nodeManager.nodeDBbyNodeNum[oldNum])
+        val canonical = nodeManager.nodeDBbyNodeNum[newNum]
+        assertNotNull(canonical)
+        assertEquals("Migrated", canonical!!.user.long_name)
+        assertEquals(validPk, canonical.publicKey)
+        verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.reconcileIdentity(listOf(oldNum), null) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 2. Placeholder duplicate
+
+    @Test
+    fun `placeholder duplicate removes placeholder in memory preserves canonical`() {
+        val oldNum = 1000
+        val newNum = validPk.canonicalNum()
+        nodeManager.updateNode(newNum) { makeKnownNode(newNum, validPk, "Migrated") }
+        val placeholderKey = ByteString.EMPTY
+        val defaultId = NodeAddress.numToDefaultId(oldNum)
+        nodeManager.updateNode(oldNum) {
+            Node(
+                num = oldNum,
+                user =
+                User(
+                    id = defaultId,
+                    long_name = "Meshtastic ${defaultId.takeLast(4)}",
+                    short_name = defaultId.takeLast(4),
+                    hw_model = HardwareModel.UNSET,
+                    public_key = placeholderKey,
+                ),
+                publicKey = placeholderKey,
+            )
+        }
+        enableDbWrites()
+
+        val staleUser =
+            User(
+                id = "!old",
+                long_name = "Stale",
+                short_name = "STL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(oldNum, staleUser)
+        testScope.advanceUntilIdle()
+
+        assertNull(nodeManager.nodeDBbyNodeNum[oldNum])
+        val canonical = nodeManager.nodeDBbyNodeNum[newNum]
+        assertNotNull(canonical)
+        assertEquals("Migrated", canonical!!.user.long_name)
+    }
+
+    // 3. Different-key conflict
+
+    @Test
+    fun `different-key conflict preserves both nodes and emits no side effects`() {
+        val fromNum = 1000
+        val otherNum = 2000
+        val differentPk = ByteArray(32) { (it + 50).toByte() }.toByteString()
+        nodeManager.updateNode(otherNum) { makeKnownNode(otherNum, validPk, "Other") }
+        nodeManager.updateNode(fromNum) { makeKnownNode(fromNum, differentPk, "Established") }
+        enableDbWrites()
+
+        val incomingUser =
+            User(
+                id = "!stale",
+                long_name = "Stale",
+                short_name = "STL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(fromNum, incomingUser)
+        testScope.advanceUntilIdle()
+
+        val fromNode = nodeManager.nodeDBbyNodeNum[fromNum]
+        assertNotNull(fromNode)
+        assertEquals("Established", fromNode!!.user.long_name)
+        assertEquals(differentPk, fromNode.publicKey)
+        val otherNode = nodeManager.nodeDBbyNodeNum[otherNum]
+        assertNotNull(otherNode)
+        assertEquals("Other", otherNode!!.user.long_name)
+        verifySuspend(mode = VerifyMode.not) { nodeRepository.reconcileIdentity(any(), any()) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 4. Multiple same-key matches
+
+    @Test
+    fun `multiple same-key matches leaves all entries untouched`() {
+        val nodeA = 1000
+        val nodeB = 2000
+        val fromNum = 3000
+        nodeManager.updateNode(nodeA) { makeKnownNode(nodeA, validPk, "Alpha") }
+        nodeManager.updateNode(nodeB) { makeKnownNode(nodeB, validPk, "Bravo") }
+        enableDbWrites()
+
+        val incomingUser =
+            User(
+                id = "!incoming",
+                long_name = "Incoming",
+                short_name = "INC",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(fromNum, incomingUser)
+        testScope.advanceUntilIdle()
+
+        // Nothing removed, nothing inserted at fromNum.
+        assertNotNull(nodeManager.nodeDBbyNodeNum[nodeA])
+        assertNotNull(nodeManager.nodeDBbyNodeNum[nodeB])
+        assertNull(nodeManager.nodeDBbyNodeNum[fromNum])
+        verifySuspend(mode = VerifyMode.not) { nodeRepository.reconcileIdentity(any(), any()) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 5. Local authoritative renumber
+
+    @Test
+    fun `local authoritative renumber removes old same-key entries in memory upserts local no notification`() {
+        val localNum = 5000
+        val otherNum = 6000
+        nodeManager.setMyNodeNum(localNum)
+        nodeManager.updateNode(otherNum) { makeKnownNode(otherNum, validPk, "Old Same-Key") }
+        enableDbWrites()
+
+        val localUser =
+            User(
+                id = "!local",
+                long_name = "Local Node",
+                short_name = "LCL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(localNum, localUser)
+        testScope.advanceUntilIdle()
+
+        assertNull(nodeManager.nodeDBbyNodeNum[otherNum])
+        val localNode = nodeManager.nodeDBbyNodeNum[localNum]
+        assertNotNull(localNode)
+        assertEquals("Local Node", localNode!!.user.long_name)
+        assertEquals(validPk, localNode.publicKey)
+        verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.reconcileIdentity(any(), any()) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 6. Genuine new node
+
+    @Test
+    fun `genuine new node fires exactly one upsert and exactly one notification`() {
+        val newNodeNum = 3000
+        val newPk = ByteArray(32) { (it + 100).toByte() }.toByteString()
+        val newUser =
+            User(
+                id = "!newnode",
+                long_name = "New Node",
+                short_name = "NEW",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = newPk,
+            )
+        enableDbWrites()
+
+        val captured = mutableListOf<Notification>()
+        every { notificationManager.dispatch(capture(captured)) } returns Unit
+
+        nodeManager.handleReceivedUser(newNodeNum, newUser)
+        testScope.advanceUntilIdle()
+
+        val result = nodeManager.nodeDBbyNodeNum[newNodeNum]
+        assertNotNull(result)
+        assertEquals("New Node", result!!.user.long_name)
+        assertEquals(newPk, result.publicKey)
+        verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.reconcileIdentity(any(), any()) }
+        // Strengthen: capture the dispatched Notification and verify payload + routing fields, not just the call count.
+        assertEquals(1, captured.size)
+        val n = captured.first()
+        assertEquals(newNodeNum, n.id)
+        assertEquals("New Node", n.message)
+        assertEquals(Notification.Category.NodeEvent, n.category)
+        assertEquals("meshtastic://meshtastic/nodes/$newNodeNum", n.deepLinkUri)
+    }
+
+    // 7. Invalid / malformed keys (null, empty, ERROR) are treated as NoMatch
+
+    @Test
+    fun `invalid public keys skip identity matching and update normally`() {
+        val existingNum = 7000
+        val existingPk = ByteArray(32) { (it + 1).toByte() }.toByteString()
+        nodeManager.updateNode(existingNum) { makeKnownNode(existingNum, existingPk, "Canonical") }
+        enableDbWrites()
+
+        // Three packets at a different number with keys that cannot identify a stable identity.
+        // None of them should match the canonical node at 7000 or trigger stale cleanup.
+        val targetNum = 8000
+
+        // (a) null key
+        nodeManager.handleReceivedUser(
+            targetNum,
+            User(id = "!a", long_name = "A", short_name = "A", hw_model = HardwareModel.TLORA_V2),
+        )
+        testScope.advanceUntilIdle()
+
+        // (b) empty key
+        nodeManager.handleReceivedUser(
+            targetNum,
+            User(
+                id = "!b",
+                long_name = "B",
+                short_name = "B",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = ByteString.EMPTY,
+            ),
+        )
+        testScope.advanceUntilIdle()
+
+        // (c) ERROR key
+        nodeManager.handleReceivedUser(
+            targetNum,
+            User(
+                id = "!c",
+                long_name = "C",
+                short_name = "C",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = Node.ERROR_BYTE_STRING,
+            ),
+        )
+        testScope.advanceUntilIdle()
+
+        // Canonical node untouched (no stale cleanup).
+        assertNotNull(nodeManager.nodeDBbyNodeNum[existingNum])
+    }
+
+    // 8. Same number same key is a normal update, not a cross-number stale
+
+    @Test
+    fun `same number same key updates normally without stale classification`() {
+        val nodeNum = 9000
+        nodeManager.updateNode(nodeNum) { makeKnownNode(nodeNum, validPk, "Original") }
+        enableDbWrites()
+
+        val updatedUser =
+            User(
+                id = "!${nodeNum.toString(16)}",
+                long_name = "Updated",
+                short_name = "UPD",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(nodeNum, updatedUser)
+        testScope.advanceUntilIdle()
+
+        val result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertNotNull(result)
+        assertEquals("Updated", result!!.user.long_name)
+        assertEquals(validPk, result.publicKey)
+    }
+
+    // 9. Stale duplicate now issues a durable delete so the row cannot return after restart.
+
+    @Test
+    fun `stale duplicate triggers reconcileIdentity with delete for stale number`() {
+        val oldNum = 1000
+        val newNum = validPk.canonicalNum()
+        nodeManager.updateNode(newNum) { makeKnownNode(newNum, validPk, "Canonical") }
+        nodeManager.updateNode(oldNum) { makeKnownNode(oldNum, validPk, "Stale Dup") }
+        enableDbWrites()
+
+        val staleUser =
+            User(
+                id = "!old",
+                long_name = "Stale Packet",
+                short_name = "STL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(oldNum, staleUser)
+        testScope.advanceUntilIdle()
+
+        assertNull(nodeManager.nodeDBbyNodeNum[oldNum])
+        // Durable delete reached the repository for the stale packet.
+        verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.reconcileIdentity(any(), any()) }
+    }
+
+    // 10. No notification for stale / conflict / local outcomes
+
+    @Test
+    fun `notification never fires for stale conflict or local outcomes`() {
+        // Stale: stale packet at old number with established canonical elsewhere.
+        val staleOld = 1000
+        val staleCanonical = validPk.canonicalNum()
+        nodeManager.updateNode(staleCanonical) { makeKnownNode(staleCanonical, validPk, "Canonical") }
+        nodeManager.updateNode(staleOld) { makeKnownNode(staleOld, validPk, "Old") }
+        nodeManager.handleReceivedUser(
+            staleOld,
+            User(id = "!s", long_name = "S", short_name = "S", hw_model = HardwareModel.TLORA_V2, public_key = validPk),
+        )
+
+        // Conflict: different established identity at fromNum.
+        val conflictFrom = 3000
+        val conflictOther = 4000
+        val conflictPk = ByteArray(32) { (it + 50).toByte() }.toByteString()
+        nodeManager.updateNode(conflictOther) { makeKnownNode(conflictOther, validPk, "Other") }
+        nodeManager.updateNode(conflictFrom) { makeKnownNode(conflictFrom, conflictPk, "Established") }
+        nodeManager.handleReceivedUser(
+            conflictFrom,
+            User(id = "!c", long_name = "C", short_name = "C", hw_model = HardwareModel.TLORA_V2, public_key = validPk),
+        )
+
+        // Local: fromNum == myNodeNum, local-link authoritative update.
+        val localNum = 5000
+        val localGhost = 6000
+        nodeManager.setMyNodeNum(localNum)
+        nodeManager.updateNode(localGhost) { makeKnownNode(localGhost, validPk, "Ghost") }
+        nodeManager.handleReceivedUser(
+            localNum,
+            User(id = "!l", long_name = "L", short_name = "L", hw_model = HardwareModel.TLORA_V2, public_key = validPk),
+        )
+
+        testScope.advanceUntilIdle()
+
+        // No notification fired for any of the three outcomes.
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 11. byId consistency after stale removal — when stale and canonical share a user ID,
+    // removing the stale node must not orphan the canonical node in the byId index.
+
+    @Test
+    fun `byId index points to canonical survivor after stale removal shares user id`() {
+        val oldNum = 1000
+        val newNum = validPk.canonicalNum()
+        val sharedUserId = "!shared"
+        nodeManager.updateNode(newNum) {
+            Node(
+                num = newNum,
+                user =
+                User(
+                    id = sharedUserId,
+                    long_name = "Canonical",
+                    short_name = "CAN",
+                    hw_model = HardwareModel.TLORA_V2,
+                    public_key = validPk,
+                ),
+                publicKey = validPk,
+            )
+        }
+        nodeManager.updateNode(oldNum) {
+            Node(
+                num = oldNum,
+                user =
+                User(
+                    id = sharedUserId,
+                    long_name = "Stale",
+                    short_name = "STL",
+                    hw_model = HardwareModel.TLORA_V2,
+                    public_key = validPk,
+                ),
+                publicKey = validPk,
+            )
+        }
+        enableDbWrites()
+
+        val staleUser =
+            User(
+                id = sharedUserId,
+                long_name = "Stale",
+                short_name = "STL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validPk,
+            )
+        nodeManager.handleReceivedUser(oldNum, staleUser)
+        testScope.advanceUntilIdle()
+
+        assertNull(nodeManager.nodeDBbyNodeNum[oldNum])
+        val survivor = nodeManager.getNodeById(sharedUserId)
+        assertNotNull(survivor)
+        assertEquals(newNum, survivor!!.num)
+    }
+
+    // ── Additional identity reconciliation tests ────────────────────────────────
+
+    // 12. Malformed key lengths (1, 31, 33) are rejected
+
+    @Test
+    fun `malformed key lengths 1 31 33 are rejected and skip identity matching`() {
+        val nodeNum = 1234
+        val shortKey = ByteArray(1) { 1 }.toByteString()
+        val almostKey = ByteArray(31) { 2 }.toByteString()
+        val longKey = ByteArray(33) { 3 }.toByteString()
+
+        // All malformed keys should be treated as no-key (normal update path).
+        nodeManager.handleReceivedUser(
+            nodeNum,
+            User(
+                id = "!short",
+                long_name = "S",
+                short_name = "S",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = shortKey,
+            ),
+        )
+        var result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertEquals(ByteString.EMPTY, result!!.publicKey)
+
+        nodeManager.handleReceivedUser(
+            nodeNum,
+            User(
+                id = "!almost",
+                long_name = "A",
+                short_name = "A",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = almostKey,
+            ),
+        )
+        result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertEquals(ByteString.EMPTY, result!!.publicKey)
+
+        nodeManager.handleReceivedUser(
+            nodeNum,
+            User(
+                id = "!long",
+                long_name = "L",
+                short_name = "L",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = longKey,
+            ),
+        )
+        result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertEquals(ByteString.EMPTY, result!!.publicKey)
+    }
+
+    // 13. Invalid Node.publicKey falls back to valid User.public_key
+
+    @Test
+    fun `invalid Node publicKey falls back to valid User public_key`() {
+        val nodeNum = 1234
+        val validUserKey = ByteArray(32) { 42 }.toByteString()
+        val invalidNodeKey = ByteArray(16) { 1 }.toByteString() // Wrong size
+
+        nodeManager.handleReceivedUser(
+            nodeNum,
+            User(
+                id = "!test",
+                long_name = "Test",
+                short_name = "T",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = validUserKey,
+            ),
+        )
+        // Manually set an invalid Node.publicKey
+        nodeManager.updateNode(nodeNum) { it.copy(publicKey = invalidNodeKey) }
+
+        // resolveNodeStableKey should fall back to User.public_key
+        val node = nodeManager.nodeDBbyNodeNum[nodeNum]
+        val resolvedKey = nodeManager.resolveNodeStableKey(node!!)
+        assertEquals(validUserKey, resolvedKey)
+    }
+
+    // 14. UNSET hardware with a different valid key is preserved (conflict)
+
+    @Test
+    fun `UNSET hardware with different valid key is preserved as conflict`() {
+        val canonicalNum = 1000
+        val conflictNum = 2000
+        val canonicalKey = ByteArray(32) { 10 }.toByteString()
+        val conflictKey = ByteArray(32) { 20 }.toByteString()
+
+        // Canonical node with established identity
+        nodeManager.updateNode(canonicalNum) { makeKnownNode(canonicalNum, canonicalKey, "Canonical") }
+
+        // Conflict node with UNSET hardware but different valid key
+        nodeManager.updateNode(conflictNum) {
+            Node(
+                num = conflictNum,
+                user =
+                User(
+                    id = "!conflict",
+                    long_name = "Conflict",
+                    short_name = "CON",
+                    hw_model = HardwareModel.UNSET,
+                    public_key = conflictKey,
+                ),
+                publicKey = conflictKey,
+            )
+        }
+
+        // Packet at conflictNum with canonicalKey should be treated as conflict (preserve both)
+        nodeManager.handleReceivedUser(
+            conflictNum,
+            User(
+                id = "!c",
+                long_name = "C",
+                short_name = "C",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = canonicalKey,
+            ),
+        )
+
+        // Both nodes should still exist
+        assertNotNull(nodeManager.nodeDBbyNodeNum[canonicalNum])
+        assertNotNull(nodeManager.nodeDBbyNodeNum[conflictNum])
+        assertEquals(canonicalKey, nodeManager.nodeDBbyNodeNum[canonicalNum]!!.publicKey)
+        assertEquals(conflictKey, nodeManager.nodeDBbyNodeNum[conflictNum]!!.publicKey)
+    }
+
+    // 15. Custom incomplete identity is preserved
+
+    @Test
+    fun `custom incomplete identity is preserved over default incoming`() {
+        val nodeNum = 1234
+        val customUser =
+            User(
+                id = "!custom",
+                long_name = "My Custom Name",
+                short_name = "MCN",
+                hw_model = HardwareModel.UNSET, // Incomplete hardware
+            )
+        nodeManager.updateNode(nodeNum) { it.copy(user = customUser) }
+
+        // Incoming default user should not overwrite custom identity
+        val defaultUser =
+            User(
+                id = NodeAddress.numToDefaultId(nodeNum),
+                long_name = "Meshtastic ${nodeNum.toHex().takeLast(4)}",
+                short_name = nodeNum.toHex().takeLast(4),
+                hw_model = HardwareModel.UNSET,
+            )
+        nodeManager.handleReceivedUser(nodeNum, defaultUser)
+
+        val result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertEquals("My Custom Name", result!!.user.long_name)
+        assertEquals("MCN", result.user.short_name)
+    }
+
+    // 16. Three nodes sharing one user ID
+
+    @Test
+    fun `three nodes sharing one user ID selects deterministic representative`() {
+        val userId = "!shared"
+        val node1 = 1000
+        val node2 = 2000
+        val node3 = 3000
+
+        // All three have the same user ID but different node numbers
+        nodeManager.updateNode(node1) {
+            Node(
+                num = node1,
+                user = User(id = userId, long_name = "N1", short_name = "N1", hw_model = HardwareModel.UNSET),
+            )
+        }
+        nodeManager.updateNode(node2) {
+            Node(
+                num = node2,
+                user = User(id = userId, long_name = "N2", short_name = "N2", hw_model = HardwareModel.TLORA_V2),
+            )
+        }
+        nodeManager.updateNode(node3) {
+            Node(
+                num = node3,
+                user = User(id = userId, long_name = "N3", short_name = "N3", hw_model = HardwareModel.UNSET),
+            )
+        }
+
+        // byId should point to node2 (non-placeholder, lowest among non-placeholders)
+        val representative = nodeManager.getNodeById(userId)
+        assertNotNull(representative)
+        assertEquals(node2, representative!!.num)
+    }
+
+    // 17. Old-ID survivor restoration after put
+
+    @Test
+    fun `old ID survivor restored after put changes user ID`() {
+        val nodeNum = 1234
+        val oldUserId = "!old"
+        val newUserId = "!new"
+        val survivorNum = 5678
+
+        // Two nodes with old user ID
+        nodeManager.updateNode(nodeNum) {
+            Node(
+                num = nodeNum,
+                user = User(id = oldUserId, long_name = "Old", short_name = "OLD", hw_model = HardwareModel.TLORA_V2),
+            )
+        }
+        nodeManager.updateNode(survivorNum) {
+            Node(
+                num = survivorNum,
+                user =
+                User(id = oldUserId, long_name = "Survivor", short_name = "SUR", hw_model = HardwareModel.TLORA_V2),
+            )
+        }
+
+        // Change nodeNum's user ID
+        nodeManager.updateNode(nodeNum) {
+            it.copy(user = it.user.copy(id = newUserId, long_name = "New", short_name = "NEW"))
+        }
+
+        // byId for oldUserId should now point to survivorNum
+        val survivor = nodeManager.getNodeById(oldUserId)
+        assertNotNull(survivor)
+        assertEquals(survivorNum, survivor!!.num)
+
+        // byId for newUserId should point to nodeNum
+        val newNode = nodeManager.getNodeById(newUserId)
+        assertNotNull(newNode)
+        assertEquals(nodeNum, newNode!!.num)
+    }
+
+    // 18. fromByNum insertion-order independence
+
+    @Test
+    fun `fromByNum is independent of insertion order`() {
+        val userId = "!shared"
+        val node1 = 1000
+        val node2 = 2000
+
+        val nodes12 =
+            mapOf(
+                node1 to
+                    Node(
+                        num = node1,
+                        user = User(id = userId, long_name = "N1", short_name = "N1", hw_model = HardwareModel.UNSET),
+                    ),
+                node2 to
+                    Node(
+                        num = node2,
+                        user = User(
+                            id = userId,
+                            long_name = "N2",
+                            short_name = "N2",
+                            hw_model = HardwareModel.TLORA_V2,
+                        ),
+                    ),
+            )
+        val nodes21 =
+            mapOf(
+                node2 to
+                    Node(
+                        num = node2,
+                        user = User(
+                            id = userId,
+                            long_name = "N2",
+                            short_name = "N2",
+                            hw_model = HardwareModel.TLORA_V2,
+                        ),
+                    ),
+                node1 to
+                    Node(
+                        num = node1,
+                        user = User(id = userId, long_name = "N1", short_name = "N1", hw_model = HardwareModel.UNSET),
+                    ),
+            )
+
+        val index12 = NodeManagerImpl.NodeIndex.fromByNum(nodes12)
+        val index21 = NodeManagerImpl.NodeIndex.fromByNum(nodes21)
+
+        // Both should produce the same byId representative (node2, non-placeholder)
+        assertEquals(index12.byId[userId]!!.num, index21.byId[userId]!!.num)
+        assertEquals(node2, index12.byId[userId]!!.num)
+    }
+
+    // 19. Preferred canonical mapping after stale removal
+
+    @Test
+    fun `preferred canonical remains mapped after stale removal`() {
+        val userId = "!shared"
+        val canonicalKey = ByteArray(32) { 41 }.toByteString()
+        val competingKey = ByteArray(32) { 42 }.toByteString()
+        val preferredNum = canonicalKey.canonicalNum()
+        val competingNum = 500
+        val staleNum = 1000
+
+        nodeManager.updateNode(competingNum) {
+            Node(
+                num = competingNum,
+                user =
+                User(
+                    id = userId,
+                    long_name = "Fallback Winner",
+                    short_name = "FBK",
+                    hw_model = HardwareModel.TLORA_V2,
+                    public_key = competingKey,
+                ),
+                publicKey = competingKey,
+            )
+        }
+        nodeManager.updateNode(preferredNum) {
+            Node(
+                num = preferredNum,
+                user =
+                User(
+                    id = userId,
+                    long_name = "Preferred",
+                    short_name = "PRE",
+                    hw_model = HardwareModel.TLORA_V2,
+                    public_key = canonicalKey,
+                ),
+                publicKey = canonicalKey,
+            )
+        }
+        nodeManager.updateNode(staleNum) {
+            Node(
+                num = staleNum,
+                user =
+                User(
+                    id = userId,
+                    long_name = "Stale",
+                    short_name = "STL",
+                    hw_model = HardwareModel.TLORA_V2,
+                    public_key = canonicalKey,
+                ),
+                publicKey = canonicalKey,
+            )
+        }
+
+        nodeManager.handleReceivedUser(
+            staleNum,
+            User(
+                id = userId,
+                long_name = "Stale Replay",
+                short_name = "STL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = canonicalKey,
+            ),
+        )
+
+        assertNull(nodeManager.nodeDBbyNodeNum[staleNum])
+        assertNotNull(nodeManager.nodeDBbyNodeNum[competingNum])
+        assertNotNull(nodeManager.nodeDBbyNodeNum[preferredNum])
+        val representative = nodeManager.getNodeById(userId)
+        assertNotNull(representative)
+        assertEquals(preferredNum, representative!!.num)
+    }
+
+    // 20. Accepted local node remains the byId representative
+
+    @Test
+    fun `accepted local node remains byId representative`() {
+        val userId = "!shared"
+        val remoteNum = 1000
+        val localNum = 2000
+
+        nodeManager.setMyNodeNum(localNum)
+        nodeManager.updateNode(localNum) {
+            Node(
+                num = localNum,
+                user = User(id = userId, long_name = "Local", short_name = "LOC", hw_model = HardwareModel.TLORA_V2),
+            )
+        }
+        nodeManager.updateNode(remoteNum) {
+            Node(
+                num = remoteNum,
+                user = User(id = userId, long_name = "Remote", short_name = "REM", hw_model = HardwareModel.TLORA_V2),
+            )
+        }
+
+        assertEquals(remoteNum, nodeManager.getNodeById(userId)!!.num)
+        nodeManager.handleReceivedUser(
+            localNum,
+            User(id = userId, long_name = "Local Updated", short_name = "LOC", hw_model = HardwareModel.TLORA_V2),
+        )
+
+        assertNotNull(nodeManager.nodeDBbyNodeNum[remoteNum])
+        val representative = nodeManager.getNodeById(userId)
+        assertNotNull(representative)
+        assertEquals(localNum, representative!!.num)
+    }
+
+    // 21. Exact notification title, message, ID, category, and deep link
+
+    @Test
+    fun `notification has exact title message ID category and deep link`() {
+        enableDbWrites()
+        val nodeNum = 1234
+        val user = User(id = "!test", long_name = "Test User", short_name = "TST", hw_model = HardwareModel.TLORA_V2)
+
+        nodeManager.handleReceivedUser(nodeNum, user)
+        testScope.advanceUntilIdle()
+
+        verify {
+            notificationManager.dispatch(
+                Notification(
+                    title = "New node seen: TST",
+                    message = "Test User",
+                    category = Notification.Category.NodeEvent,
+                    id = nodeNum,
+                    deepLinkUri = "meshtastic://meshtastic/nodes/$nodeNum",
+                ),
+            )
+        }
+    }
+
+    // 22. Incoming at the canonical num removes the noncanonical same-key entry and upserts incoming (no notify).
+
+    @Test
+    fun `incoming canonical removes noncanonical same-key entry and upserts incoming no notify`() {
+        val canonicalKey = ByteArray(32) { (it + 7).toByte() }.toByteString()
+        val canonicalNum = canonicalKey.canonicalNum()
+        val staleNum = 7777 // arbitrary noncanonical num distinct from canonicalNum
+        // Pre-existing entry at the noncanonical num carries the same key.
+        nodeManager.updateNode(staleNum) { makeKnownNode(staleNum, canonicalKey, "Ghost") }
+        // Placeholder at the canonical num so the incoming slot is "open" for reconciliation.
+        val placeholderId = NodeAddress.numToDefaultId(canonicalNum)
+        nodeManager.updateNode(canonicalNum) {
+            Node(
+                num = canonicalNum,
+                user =
+                User(
+                    id = placeholderId,
+                    long_name = "Meshtastic ${placeholderId.takeLast(4)}",
+                    short_name = placeholderId.takeLast(4),
+                    hw_model = HardwareModel.UNSET,
+                ),
+                publicKey = ByteString.EMPTY,
+            )
+        }
+        enableDbWrites()
+
+        nodeManager.handleReceivedUser(
+            canonicalNum,
+            User(
+                id = "!canonical",
+                long_name = "Canonical",
+                short_name = "CAN",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = canonicalKey,
+            ),
+        )
+        testScope.advanceUntilIdle()
+
+        assertNull(nodeManager.nodeDBbyNodeNum[staleNum])
+        val canonical = nodeManager.nodeDBbyNodeNum[canonicalNum]
+        assertNotNull(canonical)
+        assertEquals("Canonical", canonical!!.user.long_name)
+        assertEquals(canonicalKey, canonical.publicKey)
+        verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.reconcileIdentity(any(), any()) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 23. Incoming canonical absent from index entirely creates from packet, removes noncanonical, no notify.
+
+    @Test
+    fun `incoming canonical absent from index creates from packet removes noncanonical no notify`() {
+        val canonicalKey = ByteArray(32) { (it + 17).toByte() }.toByteString()
+        val canonicalNum = canonicalKey.canonicalNum()
+        val staleNum = 8888 // arbitrary noncanonical num
+        nodeManager.updateNode(staleNum) { makeKnownNode(staleNum, canonicalKey, "Stale Noncanonical") }
+        enableDbWrites()
+
+        nodeManager.handleReceivedUser(
+            canonicalNum,
+            User(
+                id = "!fresh",
+                long_name = "Fresh Canonical",
+                short_name = "FRS",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = canonicalKey,
+            ),
+        )
+        testScope.advanceUntilIdle()
+
+        assertNull(nodeManager.nodeDBbyNodeNum[staleNum])
+        val canonical = nodeManager.nodeDBbyNodeNum[canonicalNum]
+        assertNotNull(canonical)
+        assertEquals("Fresh Canonical", canonical!!.user.long_name)
+        assertEquals(canonicalKey, canonical.publicKey)
+        verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.reconcileIdentity(any(), any()) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 24. Neither num canonical preserves both with no side effects.
+
+    @Test
+    fun `neither num canonical preserves both no persistence no notification`() {
+        val key = ByteArray(32) { (it + 23).toByte() }.toByteString()
+        // Pick two nums guaranteed distinct from the canonical num and from each other.
+        val canonicalNum = key.canonicalNum()
+        val a = if (canonicalNum != 1111) 1111 else 1112
+        val b = if (canonicalNum != 2222) 2222 else 2223
+
+        nodeManager.updateNode(a) { makeKnownNode(a, key, "Alpha") }
+        nodeManager.updateNode(b) { makeKnownNode(b, key, "Bravo") }
+        enableDbWrites()
+
+        nodeManager.handleReceivedUser(
+            a,
+            User(
+                id = "!a",
+                long_name = "Alpha Packet",
+                short_name = "ALA",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = key,
+            ),
+        )
+        testScope.advanceUntilIdle()
+
+        // Both preserved with their original names; no persistence, no notification.
+        val alpha = nodeManager.nodeDBbyNodeNum[a]
+        val bravo = nodeManager.nodeDBbyNodeNum[b]
+        assertNotNull(alpha)
+        assertNotNull(bravo)
+        assertEquals("Alpha", alpha!!.user.long_name)
+        assertEquals("Bravo", bravo!!.user.long_name)
+        verifySuspend(mode = VerifyMode.not) { nodeRepository.reconcileIdentity(any(), any()) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 25. Different established valid key at the canonical num is preserved as a conflict.
+
+    @Test
+    fun `different established key at canonical num preserved as conflict`() {
+        val canonicalKey = ByteArray(32) { (it + 31).toByte() }.toByteString()
+        val establishedKey = ByteArray(32) { (it + 32).toByte() }.toByteString()
+        val canonicalNum = canonicalKey.canonicalNum()
+        val noncanonicalNum = 3333 // arbitrary; bears canonicalKey
+        nodeManager.updateNode(noncanonicalNum) { makeKnownNode(noncanonicalNum, canonicalKey, "Noncanonical Holder") }
+        // Canonical num is occupied by a node with a DIFFERENT valid key.
+        nodeManager.updateNode(canonicalNum) { makeKnownNode(canonicalNum, establishedKey, "Established") }
+        enableDbWrites()
+
+        nodeManager.handleReceivedUser(
+            canonicalNum,
+            User(
+                id = "!c",
+                long_name = "Claimant",
+                short_name = "CLM",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = canonicalKey,
+            ),
+        )
+        testScope.advanceUntilIdle()
+
+        // Conflict: both preserved with their original keys; no persistence, no notification.
+        val atCanonical = nodeManager.nodeDBbyNodeNum[canonicalNum]
+        val atNoncanonical = nodeManager.nodeDBbyNodeNum[noncanonicalNum]
+        assertNotNull(atCanonical)
+        assertNotNull(atNoncanonical)
+        assertEquals(establishedKey, atCanonical!!.publicKey)
+        assertEquals("Established", atCanonical.user.long_name)
+        assertEquals(canonicalKey, atNoncanonical!!.publicKey)
+        verifySuspend(mode = VerifyMode.not) { nodeRepository.reconcileIdentity(any(), any()) }
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    // 26. Durable stale-row deletion prevents stale identity from returning after process restart.
+
+    @Test
+    fun `durable delete of stale identity prevents return after process restart`() {
+        val key = ByteArray(32) { (it + 37).toByte() }.toByteString()
+        val canonicalNum = key.canonicalNum()
+        val staleNum = 9999 // arbitrary noncanonical num
+
+        // Seed canonical and stale persisted rows via the in-memory index.
+        nodeManager.updateNode(canonicalNum) { makeKnownNode(canonicalNum, key, "Canonical") }
+        nodeManager.updateNode(staleNum) {
+            Node(
+                num = staleNum,
+                user =
+                User(
+                    id = NodeAddress.numToDefaultId(staleNum),
+                    long_name = "Meshtastic ${NodeAddress.numToDefaultId(staleNum).takeLast(4)}",
+                    short_name = NodeAddress.numToDefaultId(staleNum).takeLast(4),
+                    hw_model = HardwareModel.UNSET,
+                ),
+                publicKey = ByteString.EMPTY,
+            )
+        }
+        enableDbWrites()
+
+        // Process the stale replay — incoming packet at staleNum with the key that belongs to canonicalNum.
+        val capturedDeleteNums = mutableListOf<List<Int>>()
+        val capturedUpsert = mutableListOf<Node?>()
+
+        everySuspend { nodeRepository.reconcileIdentity(capture(capturedDeleteNums), capture(capturedUpsert)) } returns
+            Unit
+
+        nodeManager.handleReceivedUser(
+            staleNum,
+            User(
+                id = "!stale9999",
+                long_name = "Stale Replay",
+                short_name = "STL",
+                hw_model = HardwareModel.TLORA_V2,
+                public_key = key,
+            ),
+        )
+        testScope.advanceUntilIdle()
+
+        // The stale number is removed from the in-memory index.
+        assertNull(nodeManager.nodeDBbyNodeNum[staleNum])
+        assertNotNull(nodeManager.nodeDBbyNodeNum[canonicalNum])
+
+        // reconcileIdentity was called exactly once with the stale number to delete, no upsert.
+        verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.reconcileIdentity(any(), any()) }
+        assertEquals(listOf(staleNum), capturedDeleteNums.first())
+        assertNull(capturedUpsert.first())
+        // No notification for a stale reconciliation.
+        verify(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
+    }
+
+    private fun Int.toHex(): String = this.toString(16).padStart(8, '0')
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -333,6 +333,25 @@ interface NodeInfoDao {
     @Query("DELETE FROM nodes WHERE num IN (:nodeNums)")
     suspend fun deleteNodes(nodeNums: List<Int>)
 
+    /**
+     * Atomically deletes stale node rows (and their metadata) before upserting the canonical node. Ordered
+     * deletes-then-upsert so the verified upsert path — which maps a `same_key, different_num` collision back to the
+     * existing identity — cannot resurrect a just-deleted stale entry.
+     *
+     * Runs in one Room transaction: if the upsert verification or write fails, the deletes roll back.
+     */
+    @Transaction
+    suspend fun reconcileIdentity(deleteNums: List<Int>, upsert: NodeEntity?) {
+        for (num in deleteNums) {
+            deleteMetadata(num)
+        }
+        deleteNodes(deleteNums)
+        if (upsert != null) {
+            val verified = getVerifiedNodeForUpsert(upsert)
+            doUpsert(verified)
+        }
+    }
+
     @Query("SELECT * FROM nodes WHERE last_heard < :lastHeard")
     suspend fun getNodesOlderThan(lastHeard: Int): List<NodeEntity>
 

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Node.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Node.kt
@@ -189,7 +189,10 @@ data class Node(
         private const val DEFAULT_ID_SUFFIX_LENGTH = 4
         private const val RELAY_NODE_SUFFIX_MASK = 0xFF
 
-        val ERROR_BYTE_STRING: ByteString = ByteArray(32) { 0 }.toByteString()
+        /** Size (in bytes) of a Curve25519 public key as used by meshtastic firmware. */
+        const val PUBLIC_KEY_SIZE: Int = 32
+
+        val ERROR_BYTE_STRING: ByteString = ByteArray(PUBLIC_KEY_SIZE) { 0 }.toByteString()
 
         fun getRelayNode(relayNodeId: Int, nodes: List<Node>, ourNodeNum: Int?): Node? {
             val relayNodeIdSuffix = relayNodeId and RELAY_NODE_SUFFIX_MASK

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRepository.kt
@@ -146,6 +146,16 @@ interface NodeRepository {
     suspend fun deleteNodes(nodeNums: List<Int>)
 
     /**
+     * Atomically deletes stale node rows then upserts the canonical node in a single [withDb] transaction. Deletions
+     * execute first so the upsert's normal mesh-time verification (which deliberately maps a `same_key, different_num`
+     * collision back to the existing identity) cannot resurrect a just-deleted stale row.
+     *
+     * @param deleteNums Node numbers to delete before the upsert (empty list is a no-op).
+     * @param upsert Node to upsert after deletions (null skips the upsert).
+     */
+    suspend fun reconcileIdentity(deleteNums: List<Int>, upsert: Node?)
+
+    /**
      * Updates the personal notes for a node.
      *
      * @param num The node number.

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -318,6 +318,8 @@ class TAKMeshIntegrationTest {
 
         override suspend fun deleteNodes(nodeNums: List<Int>) {}
 
+        override suspend fun reconcileIdentity(deleteNums: List<Int>, upsert: Node?) {}
+
         override suspend fun setNodeNotes(num: Int, notes: String) {}
 
         override suspend fun upsert(node: Node) {}

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
@@ -151,6 +151,13 @@ class FakeNodeRepository :
         _nodeDBbyNum.value = _nodeDBbyNum.value - nodeNums.toSet()
     }
 
+    override suspend fun reconcileIdentity(deleteNums: List<Int>, upsert: Node?) {
+        _nodeDBbyNum.value = _nodeDBbyNum.value - deleteNums.toSet()
+        if (upsert != null) {
+            _nodeDBbyNum.value = _nodeDBbyNum.value + (upsert.num to upsert)
+        }
+    }
+
     override suspend fun setNodeNotes(num: Int, notes: String) {
         val node = _nodeDBbyNum.value[num] ?: return
         _nodeDBbyNum.value = _nodeDBbyNum.value + (num to node.copy(notes = notes))


### PR DESCRIPTION
## Overview

This PR makes node-identity reconciliation deterministic and durable after firmware 2.8 node renumbering.

Firmware 2.8 derives the canonical node number from the public key. During migration, a radio or replayed node database can still present the same identity under an older node number. Those stale entries could compete with the canonical node, leave inconsistent in-memory indexes, return after a service or process restart, or be treated as newly discovered nodes.

This change classifies received identity packets through a pure reducer, atomically commits the resulting in-memory state, and then applies an ordered persistence plan. Stale database rows and metadata are deleted before the canonical node is validated and upserted, preventing removed identities from being resurrected.

## Key Changes

* Added stable public-key validation and canonical node-number resolution.
* Added deterministic reconciliation for canonical, stale, conflicting, ambiguous, placeholder, and locally authoritative identities.
* Applied in-memory state changes through an atomic compare-and-set retry loop.
* Kept node-number and user-ID indexes consistent during replacement and removal.
* Added an atomic repository and DAO operation that deletes stale node and metadata rows before an optional canonical upsert.
* Prevented stale, conflicting, ambiguous, and local-reconciliation outcomes from generating new-node notifications.
* Limited notification dispatch to genuine first sightings with complete notification metadata.
* Added the required repository and test-fake implementations for the new reconciliation operation.

## Testing

Added coverage for:

* stale firmware 2.7 identity replay against a firmware 2.8 canonical identity;
* canonical and noncanonical node-number direction;
* placeholder replacement and cleanup;
* locally authoritative renumbering;
* malformed, missing, and error public keys;
* conflicting and ambiguous identities;
* deterministic shared-ID representative selection;
* ordered stale-row deletion before canonical upsert;
* delete-only reconciliation when the canonical row already exists;
* persistence across service or process reload;
* new-node notification dispatch and suppression.

CI passed on the isolated node branch.

Combined hardware validation connected to a firmware 2.8 radio over TCP and then switched to a firmware 2.7 radio over BLE in the same process. Both configuration downloads completed, stale identity migration ran without a repeated new-node notification, and no database-pool failure, duplicate-node loop, reconnect loop, or process restart occurred.
