### PR TITLE
fix(ble): stop retrying writes from retired sessions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,110 +1,16 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: en-US
-
+early_access: true
 reviews:
-  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
-  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
-  profile: chill
+  profile: assertive
+  request_changes_workflow: false
   high_level_summary: true
-  poem: false
-  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
-  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
-    ignore_usernames:
-      - renovate
-      - renovate[bot]
-      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
-      # translation bumps) — machine-generated content, nothing to review.
-      - github-actions
-      - github-actions[bot]
-    ignore_title_keywords:
-      - "chore: Scheduled updates"
-  # Stop reviewing once a PR is closed.
-  abort_on_close: true
-
-  path_filters:
-    # Generated / huge / non-source — don't review, just noise + token burn.
-    - "!**/build/**"
-    - "!**/*.png"
-    - "!**/*.webp"
-    - "!**/firmware_releases.json"
-    - "!**/emoji-data.json"
-    - "!**/flatpak-sources.json"
-    # Crowdin-managed translations — owned upstream, not hand-edited here.
-    - "!**/values-*/strings.xml"
-    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
-    - "!.specify/**"
-
-  path_instructions:
-    - path: "**/commonMain/**"
-      instructions: >
-        KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
-    - path: "**/*.kt"
-      instructions: >
-        Flag leftover // ... existing code ... placeholders, and any logging of PII, location, or cryptographic keys.
-    - path: "**/src/**/strings.xml"
-      instructions: >
-        New string resources must be alphabetically sorted (scripts/sort-strings.py). Flag out-of-order additions.
-    - path: baselineprofile/
-      instructions: Keep baseline profile generation tied to the `google` flavor and connected devices/emulators, and commit the generated profile output to `androidApp/src/google/generated/baselineProfiles/baseline-prof.txt`.
-    - path: docs/
-      instructions: Treat non-English locale folders as Crowdin-managed output; edit the English sources under `docs/en/` and register new pages through `feature/docs/` instead of hand-editing translated locale directories.
-    - path: screenshot-tests/
-      instructions: When updating docs screenshots, keep `docs-screenshots-manifest.txt` and `docs-screenshot-aliases.properties` in sync with the generated files, and rerun `copyDocsScreenshots` after regenerating screenshots.
-    - path: docs-screenshots/
-      instructions: Keep this module generate-only for documentation screenshots; do not add it to the CI validation gate that is reserved for `screenshot-tests`.
-    - path: desktopApp/
-      instructions: Keep desktop release ProGuard rules aligned with `androidApp/proguard-rules.pro`, and preserve the desktop-specific runtime wiring needed for `Dispatchers.Main` on JVM.
-    - path: androidApp/
-      instructions: Keep the Android app’s `MeshService` declaration and manifest wiring in sync with the implementation that lives in `core:service`.
-    - path: core/service/
-      instructions: Keep `RadioControllerImpl` composed from its sub-controllers via interface delegation; admin sends are fire-and-forget, and any config mutation must go through `editSettings { }` transactions.
-    - path: feature/docs/
-      instructions: Treat the Compose resources under `src/commonMain/composeResources/files/` as generated output from `/docs/en/**` and translated docs sync tasks; do not hand-edit those copied files.
-    - path: feature/map/
-      instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
-    - path: feature/car/
-      instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
-
-  # CI is the source of truth for detekt + spotless (Zero Lint Tolerance gate),
-  # so disable detekt here to avoid duplicate comments. Keep the security/CI/shell
-  # scanners CI doesn't run inline.
-  tools:
-    detekt:
-      enabled: false
-    gitleaks:
-      enabled: true
-    shellcheck:
-      enabled: true
-    actionlint:
-      enabled: true
-
-  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
-  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
-  finishing_touches:
-    docstrings:
-      enabled: false
-    unit_tests:
-      enabled: false
-
-  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR.
-  pre_merge_checks:
-    docstrings:
-      mode: "off"
-
-knowledge_base:
-  # Feed CodeRabbit the same guidance human/AI contributors follow, including
-  # the repo-specific .skills/ modules and Copilot path instructions it
-  # wouldn't pick up by default.
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - ".skills/**/SKILL.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/*.instructions.md"
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,7 +15,6 @@ concurrency:
 jobs:
   # 1. CHANGE DETECTION: Prevents unnecessary builds
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -54,7 +54,6 @@ jobs:
 
   # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
   verify-check-changes-filter:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ build-scan-*.scan
 
 # Agent session handoff log — local-only scratch, not version-controlled
 .agent_memory/
+.omo/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ See [GitHub Releases](https://github.com/meshtastic/Meshtastic-Android/releases)
 
 #### 🏗️ Features
 * feat(settings): add packet authenticity policy by @RCGV1 in https://github.com/meshtastic/Meshtastic-Android/pull/6178
+* feat(messaging): redesign message bubbles toward the M3 conversation pattern by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6368
+* feat(notifications): align message notifications with Android best practices by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6371
 #### 🖥️ Desktop
 * fix(database): make DB updates atomic across device switches by @jeremiah-k in https://github.com/meshtastic/Meshtastic-Android/pull/6256
 #### 🛠️ Fixes
@@ -18,6 +20,15 @@ See [GitHub Releases](https://github.com/meshtastic/Meshtastic-Android/releases)
 * fix(waypoint): reject non-owner modification of a stored locked waypoint by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6348
 * fix(nodes): refresh distance when display units change by @CatSu-OSM in https://github.com/meshtastic/Meshtastic-Android/pull/6351
 * fix(map): retain camera across tab navigation by @CatSu-OSM in https://github.com/meshtastic/Meshtastic-Android/pull/6352
+* fix(database): reduce write-lane pressure from one-shot reads by @jeremiah-k in https://github.com/meshtastic/Meshtastic-Android/pull/6255
+* fix(nav): register /wifi-provision and /discovery as https App Links by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6365
+* fix(node): stop metric-card trailing values crushing to one-char-per-line by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6374
+* fix(node-metrics): apply full typography style instead of fontSize-only by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6375
+* fix(node): respect display units for position ground speed by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6376
+* fix(node): reconcile stale identity replays after renumbering by @jeremiah-k in https://github.com/meshtastic/Meshtastic-Android/pull/6259
+* fix(ui): add horizontal padding for position flags list item by @dzmpr in https://github.com/meshtastic/Meshtastic-Android/pull/6369
+#### 📝 Other Changes
+* refactor(ui): remove StatusSurface scrim behind status-colored chips by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/6367
 
 ### Internal (v2.8.0-internal.30)
 Changes since [`v2.8.0-closed.9`](https://github.com/meshtastic/Meshtastic-Android/releases/tag/v2.8.0-closed.9):
@@ -211,6 +222,7 @@ Changes since [`v2.7.14`](https://github.com/meshtastic/Meshtastic-Android/relea
 * @joeyleake made their first contribution in https://github.com/meshtastic/Meshtastic-Android/pull/6218
 * @sashko made their first contribution in https://github.com/meshtastic/Meshtastic-Android/pull/6315
 * @CatSu-OSM made their first contribution in https://github.com/meshtastic/Meshtastic-Android/pull/6351
+* @dzmpr made their first contribution in https://github.com/meshtastic/Meshtastic-Android/pull/6369
 <!-- UNRELEASED_END -->
 
 <!-- RELEASED_START -->

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleRetry.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleRetry.kt
@@ -38,24 +38,32 @@ private const val BACKOFF_FACTOR = 2.0
  * @param count Total attempt count (default 3).
  * @param delayMs Initial delay before the first retry. Subsequent delays grow exponentially.
  * @param tag Tag for log prefixes.
+ * @param retryWhile Checked after a failed attempt and again before each retry. Returning false rethrows the latest
+ *   failure immediately without logging or waiting, which lets callers revoke retries when the operation's session is
+ *   no longer current. The initial attempt always runs.
  * @param block The operation to perform.
  * @return The result of the operation.
  * @throws Exception If the operation fails after all attempts. [CancellationException] is always re-thrown immediately.
  */
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "ThrowsCount")
 suspend fun <T> retryBleOperation(
     count: Int = 3,
     delayMs: Long = 250L,
     tag: String = "BLE",
+    retryWhile: () -> Boolean = { true },
     block: suspend () -> T,
 ): T {
     var currentAttempt = 0
+    var lastFailure: Exception? = null
     while (true) {
+        lastFailure?.let { if (!retryWhile()) throw it }
         try {
             return block()
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            lastFailure = e
+            if (!retryWhile()) throw e
             currentAttempt++
             if (currentAttempt >= count) {
                 Logger.w(e) { "[$tag] BLE operation failed after $count attempts, giving up" }

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleRetryTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleRetryTest.kt
@@ -18,11 +18,14 @@ package org.meshtastic.core.ble
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
+import kotlin.test.assertSame
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BleRetryTest {
@@ -65,9 +68,50 @@ class BleRetryTest {
                 }
             }
 
-        assertTrue(ex is RuntimeException)
         assertEquals("Persistent error", ex.message)
         assertEquals(3, attempts)
+    }
+
+    @Test
+    fun retryBleOperation_stops_after_failure_when_retry_authority_is_revoked() = runTest {
+        val expected = IllegalStateException("session replaced")
+        var retryActive = true
+        var attempts = 0
+
+        val actual =
+            assertFailsWith<IllegalStateException> {
+                retryBleOperation(count = 3, delayMs = 10L, retryWhile = { retryActive }) {
+                    attempts++
+                    retryActive = false
+                    throw expected
+                }
+            }
+
+        assertSame(expected, actual)
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun retryBleOperation_rechecks_authority_after_backoff_before_retrying() = runTest {
+        val expected = IllegalStateException("session replaced during backoff")
+        var retryActive = true
+        var attempts = 0
+        val result = async {
+            runCatching {
+                retryBleOperation(count = 3, delayMs = 10L, retryWhile = { retryActive }) {
+                    attempts++
+                    throw expected
+                }
+            }
+        }
+
+        runCurrent()
+        assertEquals(1, attempts)
+        retryActive = false
+        advanceUntilIdle()
+
+        assertSame(expected, result.await().exceptionOrNull())
+        assertEquals(1, attempts)
     }
 
     @Test

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -79,16 +79,15 @@ private val CONNECTION_TIMEOUT = 15.seconds
  */
 private val HEARTBEAT_DRAIN_DELAY = 200.milliseconds
 
-internal val TARGETED_SCAN_TIMEOUT = 2.seconds
-
 /**
  * Bounded scan duration used by both discovery paths in [findDevice]:
- * - Bonded escalation: after the 2s [TARGETED_SCAN_TIMEOUT] misses the low-duty advertisement window, this is the
- *   single bounded retry before falling back to the bonded handle.
- * - Non-bonded retry: each of the [SCAN_RETRY_COUNT] attempts uses this duration.
+ * - Bonded devices get one address-filtered scan before falling back to the bonded handle.
+ * - Non-bonded retries each use this duration.
  *
- * 5s covers multiple advertising intervals for typical BLE power-save slots (~1–2s each). If the bounded bonded scan
- * window still misses, [findDevice] falls back to the bonded handle and [attemptConnection] keeps that patient
+ * Keeping the bonded path to one scanner registration is important on Android, which throttles applications that start
+ * BLE scans too frequently. A single 5s window still covers multiple advertising intervals for typical power-save slots
+ * (~1–2s each), resolves immediately when the target advertises, and avoids consuming two scan starts per reconnect. If
+ * the scan misses, [findDevice] falls back to the bonded handle and [attemptConnection] keeps that patient
  * `autoConnect` path bounded through [CONNECTION_TIMEOUT].
  */
 internal val SCAN_TIMEOUT = 5.seconds
@@ -242,23 +241,16 @@ class BleRadioTransport(
             bluetoothRepository.state.value.bondedDevices.firstOrNull { it.address.equals(address, ignoreCase = true) }
 
         if (bondedDevice != null) {
-            // Fast path: 2s targeted scan catches active advertising.
-            Logger.i {
-                "[${address.anonymize()}] Bonded device found; attempting short targeted scan for fresh advertisement"
-            }
-            scanForFreshDevice(TARGETED_SCAN_TIMEOUT)?.let {
+            // Use one bounded, address-filtered scan. Splitting this into a short scan plus an escalated scan consumed
+            // two Android scanner registrations per reconnect and could hit SCAN_FAILED_SCANNING_TOO_FREQUENTLY when a
+            // user switched devices while the reconnect policy and the Connections screen were also scanning.
+            Logger.i { "[${address.anonymize()}] Bonded device found; scanning once for a fresh advertisement" }
+            scanForFreshDevice(SCAN_TIMEOUT)?.let {
                 Logger.i { "[${address.anonymize()}] Fresh advertisement found; using scanned device" }
                 return it
             }
 
-            // Escalation: radio may be in a low-duty advertising slot. Try one bounded SCAN_TIMEOUT scan.
-            Logger.i { "[${address.anonymize()}] Targeted scan missed; escalating to bounded scan before fallback" }
-            scanForFreshDevice(SCAN_TIMEOUT)?.let {
-                Logger.i { "[${address.anonymize()}] Fresh advertisement found during escalated scan" }
-                return it
-            }
-
-            // If both scans miss, fall back to the bonded handle. Bonded-only devices have no fresh advertisement, so
+            // If the scan misses, fall back to the bonded handle. Bonded-only devices have no fresh advertisement, so
             // Kable uses autoConnect=true and Android can patiently wait for the device to advertise again.
             // This remains bounded by CONNECTION_TIMEOUT in connectAndAwait(), after which BleReconnectPolicy owns
             // retry/backoff.
@@ -288,7 +280,7 @@ class BleRadioTransport(
      *
      * One scan attempt only — no retry, no backoff. Both bonded and non-bonded paths in [findDevice] share this
      * primitive so retry policy stays centralized:
-     * - Bonded: escalated from [TARGETED_SCAN_TIMEOUT] to [SCAN_TIMEOUT] before [findDevice] returns the bonded handle.
+     * - Bonded: one address-filtered [SCAN_TIMEOUT] attempt before [findDevice] returns the bonded handle.
      * - Non-bonded: [SCAN_RETRY_COUNT] attempts at [SCAN_TIMEOUT] with [SCAN_RETRY_DELAY] between attempts.
      *
      * The outer [withTimeoutOrNull] is binding: the scanner receives [timeout] as a hint, but this coroutine resumes on

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -707,7 +707,9 @@ class BleRadioTransport(
                             return@withLock
                         }
                 try {
-                    retryBleOperation(tag = address) { currentService.sendToRadio(p) }
+                    retryBleOperation(tag = address, retryWhile = { currentService === radioService }) {
+                        currentService.sendToRadio(p)
+                    }
                     val sent = packetsSent.incrementAndGet()
                     val txBytes = bytesSent.addAndGet(p.size.toLong())
                     Logger.v {
@@ -726,7 +728,7 @@ class BleRadioTransport(
                         }
                         handleFailure(e)
                     } else {
-                        Logger.w(e) { "[$address] Stale write failure ignored (session was replaced)" }
+                        Logger.d(e) { "[$address] Stale write failure ignored because the session was replaced" }
                     }
                 }
             }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -60,12 +60,10 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration
 
 private const val BONDED_FALLBACK_CONNECT_BUFFER_MILLIS = 1_000L
-private val targetedScanTimeoutMillis = TARGETED_SCAN_TIMEOUT.inWholeMilliseconds
-private val escalatedScanTimeoutMillis = SCAN_TIMEOUT.inWholeMilliseconds
+private val bondedScanTimeoutMillis = SCAN_TIMEOUT.inWholeMilliseconds
 private val bondedReconnectWindowMillis =
     BleReconnectPolicy.DEFAULT_SETTLE_DELAY.inWholeMilliseconds +
-        targetedScanTimeoutMillis +
-        escalatedScanTimeoutMillis +
+        bondedScanTimeoutMillis +
         BONDED_FALLBACK_CONNECT_BUFFER_MILLIS
 
 /**
@@ -1081,24 +1079,17 @@ class BleRadioTransportReconnectCrashTest {
     // ─── Bonded fresh-advertisement discovery ─────────────────────────────────────────────────────
 
     /**
-     * Regression: bonded auto-reconnect must NOT reuse the stale bonded handle when the targeted scan misses the
-     * advertising window. The escalation path (TARGETED_SCAN_TIMEOUT → SCAN_TIMEOUT) must surface a freshly-scanned
-     * device.
-     *
-     * Sequenced scanner: call 0 (targeted) returns empty; call 1 (escalated) emits a fresh `FakeBleDevice` for the
-     * bonded address. The transport must connect using the fresh scanned device, never the stale bonded handle.
+     * Regression: bonded reconnect uses one bounded scanner registration and still prefers a fresh advertisement over
+     * the stale bonded handle. Starting a short scan and then a second escalated scan consumed two Android scan starts
+     * per reconnect, which could trigger SCAN_FAILED_SCANNING_TOO_FREQUENTLY during rapid device switching.
      */
     @Test
-    fun `bonded device missed by targeted scan is found by escalated scan`() = runTest {
+    fun `bonded reconnect uses one bounded scan and prefers its fresh device`() = runTest {
         val bondedDevice = FakeBleDevice(address = address, name = "Bonded Handle")
         bluetoothRepository.bond(bondedDevice)
 
         val freshDevice = FakeBleDevice(address = address, name = "Fresh Scan Result")
-        val sequencedScanner =
-            SequencedBleScanner().apply {
-                responses += { flow { awaitCancellation() } } // call 0: targeted scan misses
-                responses += { flow { emit(freshDevice) } } // call 1: escalated scan emits fresh device
-            }
+        val sequencedScanner = SequencedBleScanner().apply { responses += { flow { emit(freshDevice) } } }
 
         // Profile setup needs FROMNUM/FROMRADIO so the transport reaches a stable Connected state
         // rather than tearing down before we can inspect which device was connected.
@@ -1119,24 +1110,14 @@ class BleRadioTransportReconnectCrashTest {
 
             advanceTimeBy(bondedReconnectWindowMillis)
 
-            assertTrue(
-                sequencedScanner.callCount >= 2,
-                "Expected at least 2 scan calls (targeted + escalated); got ${sequencedScanner.callCount}",
-            )
+            assertEquals(1, sequencedScanner.callCount, "Bonded reconnect must consume one scan registration")
             assertEquals(
-                targetedScanTimeoutMillis,
-                sequencedScanner.calls[0].timeout.inWholeMilliseconds,
-                "First scan must use TARGETED_SCAN_TIMEOUT",
+                bondedScanTimeoutMillis,
+                sequencedScanner.calls.single().timeout.inWholeMilliseconds,
+                "The single bonded scan must use SCAN_TIMEOUT",
             )
-            assertEquals(
-                escalatedScanTimeoutMillis,
-                sequencedScanner.calls[1].timeout.inWholeMilliseconds,
-                "Second scan must use SCAN_TIMEOUT",
-            )
-            assertEquals(SERVICE_UUID, sequencedScanner.calls[0].serviceUuid, "First scan must include service UUID")
-            assertEquals(address, sequencedScanner.calls[0].address, "First scan must target selected address")
-            assertEquals(SERVICE_UUID, sequencedScanner.calls[1].serviceUuid, "Second scan must include service UUID")
-            assertEquals(address, sequencedScanner.calls[1].address, "Second scan must target selected address")
+            assertEquals(SERVICE_UUID, sequencedScanner.calls.single().serviceUuid, "Scan must include service UUID")
+            assertEquals(address, sequencedScanner.calls.single().address, "Scan must target selected address")
             assertEquals(1, connection.connectAndAwaitCalls, "Must connect exactly once with the fresh scanned device")
             assertTrue(
                 connection.device === freshDevice,
@@ -1151,22 +1132,15 @@ class BleRadioTransportReconnectCrashTest {
     }
 
     /**
-     * Regression: when the bonded device misses both fresh scan windows, [findDevice] must fall back to the bonded
-     * handle so Android's autoConnect path can patiently wait for the radio to advertise again.
-     *
-     * The fallback remains bounded by [CONNECTION_TIMEOUT] in `connectAndAwait`, after which the reconnect policy owns
-     * the next retry/backoff iteration.
+     * Regression: when the bonded device misses the bounded fresh-advertisement scan, [findDevice] must fall back to
+     * the bonded handle so Android's autoConnect path can patiently wait for the radio to advertise again.
      */
     @Test
-    fun `bonded device never advertising falls back to bounded autoConnect`() = runTest {
+    fun `bonded device never advertising falls back after one bounded scan`() = runTest {
         val bondedDevice = FakeBleDevice(address = address, name = "Bonded Handle")
         bluetoothRepository.bond(bondedDevice)
 
-        val sequencedScanner =
-            SequencedBleScanner().apply {
-                responses += { flow { awaitCancellation() } } // call 0: targeted scan misses
-                responses += { flow { awaitCancellation() } } // call 1: escalated scan misses
-            }
+        val sequencedScanner = SequencedBleScanner().apply { responses += { flow { awaitCancellation() } } }
 
         // Keep profile setup stable so the test can inspect the connected device.
         connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
@@ -1186,24 +1160,16 @@ class BleRadioTransportReconnectCrashTest {
 
             advanceTimeBy(bondedReconnectWindowMillis)
 
-            assertTrue(
-                sequencedScanner.callCount >= 2,
-                "Expected at least 2 scan calls (targeted + escalated); got ${sequencedScanner.callCount}",
-            )
+            assertEquals(1, sequencedScanner.callCount, "Bonded fallback must consume one scan registration")
             assertEquals(
-                targetedScanTimeoutMillis,
-                sequencedScanner.calls[0].timeout.inWholeMilliseconds,
-                "First scan must use TARGETED_SCAN_TIMEOUT",
-            )
-            assertEquals(
-                escalatedScanTimeoutMillis,
-                sequencedScanner.calls[1].timeout.inWholeMilliseconds,
-                "Second scan must use SCAN_TIMEOUT",
+                bondedScanTimeoutMillis,
+                sequencedScanner.calls.single().timeout.inWholeMilliseconds,
+                "The single bonded scan must use SCAN_TIMEOUT",
             )
             assertEquals(1, connection.connectAndAwaitCalls, "Must connect once through the bounded bonded fallback")
             assertTrue(
                 connection.device === bondedDevice,
-                "Must use the bonded handle after fresh scans miss (got: ${connection.device?.name})",
+                "Must use the bonded handle after the fresh scan misses (got: ${connection.device?.name})",
             )
 
             bleTransport.close()

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -419,6 +419,45 @@ class BleRadioTransportReconnectCrashTest {
     }
 
     @Test
+    fun `write retry stops when remote disconnect retires the captured session`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+        scanner.emitDevice(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
+
+            val attemptsBefore = connection.service.writeAttempts
+            connection.service.writeException = NotConnectedException("session closed")
+            bleTransport.handleSendToRadio(byteArrayOf(1))
+            testScheduler.runCurrent()
+            assertEquals(attemptsBefore + 1, connection.service.writeAttempts)
+
+            connection.simulateRemoteDisconnect()
+            testScheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                attemptsBefore + 1,
+                connection.service.writeAttempts,
+                "A write captured from a retired session must not consume more retry attempts",
+            )
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
     fun `repeated writes after session failure do not spam onDisconnect`() = runTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -118,7 +118,7 @@ class BleRadioTransportTest {
     fun `onDisconnect is called after DEFAULT_FAILURE_THRESHOLD consecutive failures`() = runTest {
         val device = FakeBleDevice(address = address, name = "Test Device")
         bluetoothRepository.bond(device)
-        scanner.emitDevice(device) // targeted scan resolves immediately; this test covers reconnect timing
+        scanner.emitDevice(device) // bounded scan resolves immediately; this test covers reconnect timing
 
         // Make every connectAndAwait call throw so each iteration counts as one failure.
         connection.connectException = RadioNotConnectedException("simulated failure")
@@ -234,8 +234,8 @@ class BleRadioTransportTest {
             )
         bleTransport.start()
         try {
-            // 3s settle + 2s targeted + 5s escalated scan = 10s before bonded fallback.
-            advanceTimeBy(11_000)
+            // 3s settle + one 5s bounded scan before bonded fallback.
+            advanceTimeBy(9_000)
 
             assertEquals(1, connection.connectAndAwaitCalls, "Must use bounded bonded fallback after fresh scans miss")
             assertEquals("Bonded Device", connection.device?.name)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -216,6 +216,10 @@ class FakeBleService : BleService {
 
     val writes = mutableListOf<FakeBleWrite>()
 
+    /** Counts every write invocation, including attempts that fail before they can be recorded in [writes]. */
+    var writeAttempts: Int = 0
+        private set
+
     /** When non-null, [write] throws this exception on every call until explicitly cleared. */
     var writeException: Exception? = null
 
@@ -298,6 +302,7 @@ class FakeBleService : BleService {
     override fun preferredWriteType(characteristic: BleCharacteristic): BleWriteType = BleWriteType.WITH_RESPONSE
 
     override suspend fun write(characteristic: BleCharacteristic, data: ByteArray, writeType: BleWriteType) {
+        writeAttempts++
         writeException?.let { ex -> throw ex }
         availableCharacteristics += characteristic.uuid
         writes += FakeBleWrite(characteristic = characteristic, data = data.copyOf(), writeType = writeType)


### PR DESCRIPTION
Give BLE retry callers an explicit authority predicate that is checked after each failure and again after backoff. The initial attempt remains unconditional, cancellation still propagates immediately, and revocation rethrows the exact latest operation failure without consuming another attempt.

Bind queued radio writes to the Meshtastic profile captured under the write mutex. When disconnect or reconnect replaces that profile, the old write stops retrying and cannot tear down the replacement session; its final stale failure is reduced to debug-level diagnostics.

Add deterministic retry-revocation and remote-disconnect coverage, plus fake write-attempt accounting that includes failures occurring before a write is recorded.

## Summary by Sourcery

Tighten BLE write retry behavior to respect session lifecycles and simplify bonded reconnect scanning, while expanding CI and review tooling coverage and updating release notes.

Bug Fixes:
- Ensure BLE write retries stop once the originating radio session is retired, preventing stale writes from tearing down replacement connections.
- Guard BLE retry logic with an authority predicate so revoked sessions rethrow the latest failure immediately instead of consuming extra attempts.
- Adjust bonded reconnect scanning to use a single bounded scan per attempt, reducing the risk of Android BLE scan throttling during rapid device switching.

Enhancements:
- Track total BLE write attempts in tests, including failures occurring before a write is recorded, to better validate retry behavior.
- Relax logging for stale BLE write failures to debug-level diagnostics to avoid noisy warnings when sessions are replaced.

CI:
- Broaden the pull-request CI workflow to run on additional branches and allow manual workflow dispatch, while simplifying repository and branch filters.
- Update CodeRabbit review configuration to a more assertive profile with customized summary instructions, chat auto-replies, and disabled auto-review on drafts.

Documentation:
- Extend the changelog with recent messaging, notification, database, navigation, node, UI, and refactor entries, including new contributor acknowledgments.

Tests:
- Add BLE retry tests that cover retry revocation, authority rechecks after backoff, and cancellation behavior.
- Add radio transport tests to verify bonded reconnect uses a single bounded scan, prefers fresh advertisements when available, and falls back correctly when the device never advertises.
- Augment reconnect crash tests to ensure queued radio writes stop retrying when a remote disconnect retires the captured session.