### PR TITLE
build(android): add no-LeakCanary debug comparison mode

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -52,6 +52,10 @@ if (keystorePropertiesFile.exists()) {
 // Build a Closed-track templated AAB with: -PenableCarTemplates=true
 val enableCarTemplates = providers.gradleProperty("enableCarTemplates").map { it.toBoolean() }.getOrElse(false)
 
+// LeakCanary remains enabled for debug builds by default so regular development and soak sessions retain continuous
+// leak detection. Disable it only for controlled responsiveness comparisons with: -PenableLeakCanary=false
+val enableLeakCanary = providers.gradleProperty("enableLeakCanary").map { it.toBoolean() }.getOrElse(true)
+
 configure<ApplicationExtension> {
     namespace = "org.meshtastic.app"
 
@@ -288,12 +292,11 @@ dependencies {
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.glance.preview)
-    // LeakCanary auto-installs via a manifest-declared ContentProvider -- no init code needed.
-    // Debug-only (0 method count in release, per LeakCanary's own design). Added after adversarial
-    // mesh-fuzz testing surfaced a GC-thrash concern in the debug log view; this gives continuous,
-    // automatic leak detection (dumped heap + leak trace + notification) for future soak/fuzz runs
-    // instead of manually polling `dumpsys meminfo`.
-    debugImplementation(libs.leakcanary.android)
+    if (enableLeakCanary) {
+        // LeakCanary auto-installs through its manifest ContentProvider. The property above provides a controlled
+        // no-LeakCanary debug build without weakening the default continuous leak-detection behavior.
+        debugImplementation(libs.leakcanary.android)
+    }
 
     googleImplementation(projects.feature.car)
     googleImplementation(libs.location.services)

--- a/docs/en/developer/testing.md
+++ b/docs/en/developer/testing.md
@@ -2,7 +2,7 @@
 title: Testing
 parent: Developer Guide
 nav_order: 7
-last_updated: 2026-06-11
+last_updated: 2026-07-18
 aliases:
   - tests
   - unit-tests
@@ -84,6 +84,22 @@ The Macrobenchmark generator (`BaselineProfileGenerator`) and the before/after b
 The generated profile is merged into `androidApp/src/google/generated/baselineProfiles/` and packaged into release builds via `androidx.profileinstaller`.
 
 > ⚠️ **Warning:** The journey currently covers cold start only (launch → first frame), because CI has no paired radio. Post-connection screens (node list, map, message thread) are not yet AOT-compiled; extend the journey once a fake transport or connected device is wired into the harness.
+
+### Debug responsiveness and LeakCanary
+
+Debug builds keep LeakCanary enabled by default for continuous leak detection during normal development, soak, and replay-fuzz sessions. Release builds are unchanged. For a controlled responsiveness comparison, build the same debug variant without LeakCanary:
+
+```bash
+./gradlew -PenableLeakCanary=false :androidApp:assembleFdroidDebug
+```
+
+Compare that build with the default LeakCanary-enabled debug build:
+
+```bash
+./gradlew :androidApp:assembleFdroidDebug
+```
+
+When reporting jank, record which mode produced the trace. A difference between these two builds identifies debug leak instrumentation as a contributor; no difference points elsewhere. Also compare against a release-like/profileable build before attributing debug-only stalls to production behavior.
 
 ## Test Organization
 


### PR DESCRIPTION
Keep LeakCanary enabled by default for ordinary debug development, soak testing, and replay-fuzz monitoring while allowing an explicit -PenableLeakCanary=false build for controlled responsiveness comparisons.

Gate only the debug dependency declaration, leaving release variants and their dependency graphs unchanged. Document how to build both modes and how to report results without treating debug instrumentation as a proven source of production jank.

## Summary by Sourcery

Add an opt-out property for LeakCanary in Android debug builds while keeping it enabled by default and document how to compare responsiveness between LeakCanary and non-LeakCanary debug modes.

Build:
- Introduce an enableLeakCanary Gradle property to conditionally include the LeakCanary dependency in Android debug builds without affecting release variants.

Documentation:
- Document how to build Android debug variants with and without LeakCanary and how to interpret responsiveness and jank comparisons between them.