### PR TITLE
Move Coil Image Loader Ownership to MeshUtilApplication

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -44,11 +44,8 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
-import coil3.ImageLoader
-import coil3.compose.setSingletonImageLoaderFactory
 import com.eygraber.uri.toKmpUri
 import kotlinx.coroutines.launch
-import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.compose.koinInject
@@ -133,10 +130,6 @@ class MainActivity : AppCompatActivity() {
         }
 
         setContent {
-            // Bridge Koin-provided ImageLoader (with flavor-specific HttpClient, SVG, debug logger)
-            // to Coil's singleton so all AsyncImage composables use the custom configuration.
-            setSingletonImageLoaderFactory { get<ImageLoader>() }
-
             val theme by model.theme.collectAsStateWithLifecycle()
             val dynamic = theme == MODE_DYNAMIC
             val dark =

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -18,6 +18,7 @@ package org.meshtastic.app
 
 import android.app.Application
 import android.appwidget.AppWidgetProviderInfo
+import android.content.Context
 import android.os.Build
 import androidx.collection.intSetOf
 import androidx.glance.appwidget.GlanceAppWidgetManager
@@ -27,6 +28,8 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -62,9 +65,13 @@ import kotlin.time.toJavaDuration
  */
 open class MeshUtilApplication :
     Application(),
-    Configuration.Provider {
+    Configuration.Provider,
+    SingletonImageLoader.Factory {
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /** Supplies Coil's process-wide loader without retaining an Activity in its singleton factory. */
+    override fun newImageLoader(context: Context): ImageLoader = get<ImageLoader>()
 
     override fun onCreate() {
         super.onCreate()

--- a/androidApp/src/test/kotlin/org/meshtastic/app/CoilImageLoaderLifecycleTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/CoilImageLoaderLifecycleTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app
+
+import androidx.test.core.app.ApplicationProvider
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.annotation.DelicateCoilApi
+import org.junit.After
+import org.junit.runner.RunWith
+import org.koin.android.ext.android.get
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = MeshUtilApplication::class, sdk = [34])
+class CoilImageLoaderLifecycleTest {
+    @After
+    @OptIn(DelicateCoilApi::class)
+    fun tearDown() = SingletonImageLoader.reset()
+
+    @Test
+    fun productionApplicationProvidesConfiguredKoinImageLoader() {
+        val application = ApplicationProvider.getApplicationContext<MeshUtilApplication>()
+        val configuredImageLoader = application.get<ImageLoader>()
+
+        assertSame(configuredImageLoader, SingletonImageLoader.get(application))
+    }
+}


### PR DESCRIPTION


## Summary by Sourcery

Move Coil's singleton ImageLoader ownership from MainActivity to MeshUtilApplication to avoid activity retention and centralize configuration.

Enhancements:
- Implement SingletonImageLoader.Factory on MeshUtilApplication to supply the process-wide ImageLoader via Koin.
- Remove activity-level Coil singleton setup from MainActivity, relying on the application-provided loader instead.

Tests:
- Add Robolectric test verifying MeshUtilApplication provides the Koin-configured ImageLoader instance to Coil's singleton factory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This update moves Coil’s process-wide singleton image-loader configuration out of `MainActivity` and into `MeshUtilApplication`, so the singleton is owned by the application rather than an activity. It also adds a Robolectric test to ensure the app’s `SingletonImageLoader.Factory` returns the exact Koin-provided `ImageLoader`.

### Key changes
**Fixes**
- Removed Coil singleton wiring from `MainActivity` (including the `setSingletonImageLoaderFactory { ... }`/`AsyncImage` configuration) to avoid retaining an Android activity.
- Implemented `SingletonImageLoader.Factory` in `MeshUtilApplication` and provided `newImageLoader(...)` that returns the Koin-provided `ImageLoader` for the application scope.

**Refactors**
- Cleaned up unused Coil/Koin imports and deleted the related `setContent` Coil configuration in `MainActivity`.
- Kept the existing activity-level deep-link/NFC/USB selection logic and other Compose screen selection behavior unchanged.

**Tests**
- Added `CoilImageLoaderLifecycleTest` (Robolectric) to verify that `MeshUtilApplication`’s singleton factory returns the same configured `ImageLoader` supplied by Koin, and that resources are torn down cleanly.

### Breaking changes / migration
- No breaking changes or migration steps expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->