### PR TITLE
Fix BLE Reconnect Lifecycle

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -125,6 +125,7 @@ bluetooth_feature_discovery_description
 bluetooth_permission
 bluetooth_scan_missing_permission
 bluetooth_scan_start_failed
+bluetooth_scan_too_frequent
 bold_heading
 bonding_failed_permissions
 bonding_failed_retry

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBleScanStartLimiterTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBleScanStartLimiterTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+class AndroidBleScanStartLimiterTest {
+    @Test
+    fun `all scanner consumers share one process quota`() {
+        assertSame(createBleScanStartLimiter(), createBleScanStartLimiter())
+    }
+
+    @Test
+    fun `sixth scan inside Android quota window is rejected`() = runTest {
+        val limiter = AndroidBleScanStartLimiter(timeSource = TestTimeSource())
+
+        repeat(ANDROID_BLE_SCAN_START_LIMIT) { limiter.reserveStart() }
+
+        val failure = assertFailsWith<BleScanStartException> { limiter.reserveStart() }
+        assertEquals(BleScanStartFailureReason.ScanningTooFrequently, failure.reason)
+        assertEquals(ANDROID_BLE_SCAN_START_WINDOW, failure.retryAfter)
+    }
+
+    @Test
+    fun `reservation succeeds after oldest scan leaves quota window`() = runTest {
+        val timeSource = TestTimeSource()
+        val limiter = AndroidBleScanStartLimiter(timeSource = timeSource, maxStarts = 2, window = 30.seconds)
+
+        limiter.reserveStart()
+        timeSource += 10.seconds
+        limiter.reserveStart()
+        timeSource += 20.seconds
+
+        limiter.reserveStart()
+    }
+
+    @Test
+    fun `concurrent callers cannot exceed quota`() = runTest {
+        val limiter = AndroidBleScanStartLimiter(timeSource = TestTimeSource())
+
+        val results =
+            List(ANDROID_BLE_SCAN_START_LIMIT + 1) { async { runCatching { limiter.reserveStart() } } }.awaitAll()
+
+        assertEquals(ANDROID_BLE_SCAN_START_LIMIT, results.count { it.isSuccess })
+        val failure = results.single { it.isFailure }.exceptionOrNull()
+        assertTrue(failure is BleScanStartException)
+        assertEquals(BleScanStartFailureReason.ScanningTooFrequently, failure.reason)
+    }
+}

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBleScanStartLimiter.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBleScanStartLimiter.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+internal const val ANDROID_BLE_SCAN_START_LIMIT = 5
+internal val ANDROID_BLE_SCAN_START_WINDOW: Duration = 30.seconds
+
+/**
+ * Reserves Android BLE scan starts before Kable reaches BluetoothLeScanner.
+ *
+ * Android rejects the sixth scan start inside its rolling quota window. Some framework versions intentionally suppress
+ * the corresponding app callback, which leaves a scanner flow waiting without advertisements or a useful exception.
+ * Keeping the same rolling window in-process makes that condition deterministic and recoverable by callers.
+ */
+internal class AndroidBleScanStartLimiter(
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+    private val maxStarts: Int = ANDROID_BLE_SCAN_START_LIMIT,
+    private val window: Duration = ANDROID_BLE_SCAN_START_WINDOW,
+) : BleScanStartLimiter {
+    private val mutex = Mutex()
+    private val scanStarts = ArrayDeque<TimeMark>()
+
+    init {
+        require(maxStarts > 0) { "maxStarts must be positive" }
+        require(window.isPositive()) { "window must be positive" }
+    }
+
+    override suspend fun reserveStart() {
+        mutex.withLock {
+            discardExpiredStarts()
+            if (scanStarts.size >= maxStarts) {
+                val retryAfter = (window - scanStarts.first().elapsedNow()).coerceAtLeast(Duration.ZERO)
+                throw BleScanStartException(
+                    reason = BleScanStartFailureReason.ScanningTooFrequently,
+                    cause = IllegalStateException("Android BLE scan-start quota exhausted"),
+                    retryAfter = retryAfter,
+                )
+            }
+            scanStarts.add(timeSource.markNow())
+        }
+    }
+
+    private fun discardExpiredStarts() {
+        while (scanStarts.firstOrNull()?.elapsedNow()?.let { it >= window } == true) {
+            scanStarts.removeFirst()
+        }
+    }
+}
+
+private val processBleScanStartLimiter: BleScanStartLimiter = AndroidBleScanStartLimiter()
+
+internal actual fun createBleScanStartLimiter(): BleScanStartLimiter = processBleScanStartLimiter

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleRetry.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleRetry.kt
@@ -38,24 +38,32 @@ private const val BACKOFF_FACTOR = 2.0
  * @param count Total attempt count (default 3).
  * @param delayMs Initial delay before the first retry. Subsequent delays grow exponentially.
  * @param tag Tag for log prefixes.
+ * @param retryWhile Checked after a failed attempt and again before each retry. Returning false rethrows the latest
+ *   failure immediately without logging or waiting, which lets callers revoke retries when the operation's session is
+ *   no longer current. The initial attempt always runs.
  * @param block The operation to perform.
  * @return The result of the operation.
  * @throws Exception If the operation fails after all attempts. [CancellationException] is always re-thrown immediately.
  */
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "ThrowsCount")
 suspend fun <T> retryBleOperation(
     count: Int = 3,
     delayMs: Long = 250L,
     tag: String = "BLE",
+    retryWhile: () -> Boolean = { true },
     block: suspend () -> T,
 ): T {
     var currentAttempt = 0
+    var lastFailure: Exception? = null
     while (true) {
+        lastFailure?.let { if (!retryWhile()) throw it }
         try {
             return block()
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            lastFailure = e
+            if (!retryWhile()) throw e
             currentAttempt++
             if (currentAttempt >= count) {
                 Logger.w(e) { "[$tag] BLE operation failed after $count attempts, giving up" }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartException.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartException.kt
@@ -16,6 +16,8 @@
  */
 package org.meshtastic.core.ble
 
+import kotlin.time.Duration
+
 /** Known reasons a BLE discovery scan failed before Android registered the scanner. */
 enum class BleScanStartFailureReason(val androidCode: String, val description: String) {
     ApplicationRegistrationFailed(
@@ -26,8 +28,12 @@ enum class BleScanStartFailureReason(val androidCode: String, val description: S
         androidCode = "MISSING_SCAN_PERMISSION",
         description = "A runtime permission required for BLE scanning is not granted",
     ),
+    ScanningTooFrequently(
+        androidCode = "SCAN_FAILED_SCANNING_TOO_FREQUENTLY(6)",
+        description = "Android rejected a BLE scan because the app reached its scan-start quota",
+    ),
 }
 
 /** A discovery scan-start failure. No advertisements can be delivered until a future scan starts successfully. */
-class BleScanStartException(val reason: BleScanStartFailureReason, cause: Throwable) :
+class BleScanStartException(val reason: BleScanStartFailureReason, cause: Throwable, val retryAfter: Duration? = null) :
     IllegalStateException("BLE scan could not start: ${reason.androidCode}", cause)

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartLimiter.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartLimiter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+internal fun interface BleScanStartLimiter {
+    suspend fun reserveStart()
+}
+
+internal object NoOpBleScanStartLimiter : BleScanStartLimiter {
+    override suspend fun reserveStart() = Unit
+}
+
+internal expect fun createBleScanStartLimiter(): BleScanStartLimiter

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -55,6 +55,10 @@ private fun Advertisement.toScanResult(): KableScanResult =
 
 @Single(binds = [BleScanner::class])
 open class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleScanner {
+    private val scanStartLimiter = createBleScanStartLimiter()
+
+    internal open suspend fun reserveScanStart() = scanStartLimiter.reserveStart()
+
     internal open fun advertisements(filter: KableScanFilter): Flow<KableScanResult> {
         val scanner = Scanner {
             logging { applyConfig(loggingConfig) }
@@ -74,6 +78,7 @@ open class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleSca
         // By wrapping it in a channelFlow with a timeout, we enforce the BleScanner contract cleanly.
         return channelFlow {
             withTimeoutOrNull(timeout) {
+                reserveScanStart()
                 try {
                     advertisements(filter).collect { advertisement ->
                         send(
@@ -108,6 +113,7 @@ private fun Throwable.asBleScanStartExceptionOrNull(): BleScanStartException? {
 
 private fun Throwable.scanStartFailureReasonOrNull(): BleScanStartFailureReason? = when {
     isApplicationRegistrationFailure() -> BleScanStartFailureReason.ApplicationRegistrationFailed
+    isScanningTooFrequentlyFailure() -> BleScanStartFailureReason.ScanningTooFrequently
     isMissingScanPermission() -> BleScanStartFailureReason.MissingScanPermission
     else -> null
 }
@@ -118,6 +124,12 @@ private fun Throwable.isApplicationRegistrationFailure(): Boolean = this is Ille
     message?.let { failureMessage ->
         failureMessage.contains("app cannot be registered", ignoreCase = true) ||
             failureMessage.contains("SCAN_FAILED_APPLICATION_REGISTRATION_FAILED", ignoreCase = true)
+    } == true
+
+private fun Throwable.isScanningTooFrequentlyFailure(): Boolean = this is IllegalStateException &&
+    message?.let { failureMessage ->
+        failureMessage.contains("scanning too frequently", ignoreCase = true) ||
+            failureMessage.contains("SCAN_FAILED_SCANNING_TOO_FREQUENTLY", ignoreCase = true)
     } == true
 
 // Kable's scan-permission check throws a plain IllegalStateException "Missing required <permission> for scanning"

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleRetryTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleRetryTest.kt
@@ -18,11 +18,14 @@ package org.meshtastic.core.ble
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
+import kotlin.test.assertSame
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BleRetryTest {
@@ -65,9 +68,50 @@ class BleRetryTest {
                 }
             }
 
-        assertTrue(ex is RuntimeException)
         assertEquals("Persistent error", ex.message)
         assertEquals(3, attempts)
+    }
+
+    @Test
+    fun retryBleOperation_stops_after_failure_when_retry_authority_is_revoked() = runTest {
+        val expected = IllegalStateException("session replaced")
+        var retryActive = true
+        var attempts = 0
+
+        val actual =
+            assertFailsWith<IllegalStateException> {
+                retryBleOperation(count = 3, delayMs = 10L, retryWhile = { retryActive }) {
+                    attempts++
+                    retryActive = false
+                    throw expected
+                }
+            }
+
+        assertSame(expected, actual)
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun retryBleOperation_rechecks_authority_after_backoff_before_retrying() = runTest {
+        val expected = IllegalStateException("session replaced during backoff")
+        var retryActive = true
+        var attempts = 0
+        val result = async {
+            runCatching {
+                retryBleOperation(count = 3, delayMs = 10L, retryWhile = { retryActive }) {
+                    attempts++
+                    throw expected
+                }
+            }
+        }
+
+        runCurrent()
+        assertEquals(1, attempts)
+        retryActive = false
+        advanceUntilIdle()
+
+        assertSame(expected, result.await().exceptionOrNull())
+        assertEquals(1, attempts)
     }
 
     @Test

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -67,6 +67,34 @@ class KableBleConnectionTest {
     }
 
     @Test
+    fun `scan reserves one platform start before collecting advertisements`() = runTest {
+        val reservationEvent = "scan-start-reserved"
+        val collectionEvent = "advertisements-collected"
+        val events = mutableListOf<String>()
+        val scanner =
+            TestKableBleScanner(
+                scanResults = flow { events += collectionEvent },
+                scanStartLimiter = BleScanStartLimiter { events += reservationEvent },
+            )
+
+        scanner.scan(timeout = 1.seconds).toList()
+
+        assertEquals(1, events.count { it == reservationEvent })
+        assertEquals(listOf(reservationEvent, collectionEvent), events)
+    }
+
+    @Test
+    fun `expired timeout does not reserve a platform start`() = runTest {
+        var reservations = 0
+        val scanner =
+            TestKableBleScanner(scanResults = emptyFlow(), scanStartLimiter = BleScanStartLimiter { reservations += 1 })
+
+        scanner.scan(timeout = 0.seconds).toList()
+
+        assertEquals(0, reservations)
+    }
+
+    @Test
     fun `timeout terminates scan`() = runTest {
         var cancelled = false
         val scanner =
@@ -146,6 +174,16 @@ class KableBleConnectionTest {
     }
 
     @Test
+    fun `scan wraps Android scanning too frequently failure`() = runTest {
+        val message = "Failed. App is scanning too frequently"
+        val scanner = TestKableBleScanner(scanResults = flow { throw IllegalStateException(message) })
+
+        val failure = assertFailsWith<BleScanStartException> { scanner.scan(timeout = 1.seconds).toList() }
+
+        assertEquals(BleScanStartFailureReason.ScanningTooFrequently, failure.reason)
+    }
+
+    @Test
     fun `scan wraps missing scan permission failure`() = runTest {
         val message = "Missing required android.permission.ACCESS_COARSE_LOCATION for scanning"
         val scanner = TestKableBleScanner(scanResults = flow { throw IllegalStateException(message) })
@@ -165,10 +203,14 @@ class KableBleConnectionTest {
         assertEquals("Unexpected scanner state", failure.message)
     }
 
-    private class TestKableBleScanner(private val scanResults: Flow<KableScanResult>) :
-        KableBleScanner(BleLoggingConfig.Release) {
+    private class TestKableBleScanner(
+        private val scanResults: Flow<KableScanResult>,
+        private val scanStartLimiter: BleScanStartLimiter = NoOpBleScanStartLimiter,
+    ) : KableBleScanner(BleLoggingConfig.Release) {
         var lastFilter: KableScanFilter? = null
             private set
+
+        override suspend fun reserveScanStart() = scanStartLimiter.reserveStart()
 
         override fun advertisements(filter: KableScanFilter): Flow<KableScanResult> {
             lastFilter = filter

--- a/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/BleScanStartLimiter.ios.kt
+++ b/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/BleScanStartLimiter.ios.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+internal actual fun createBleScanStartLimiter(): BleScanStartLimiter = NoOpBleScanStartLimiter

--- a/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/BleScanStartLimiter.jvm.kt
+++ b/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/BleScanStartLimiter.jvm.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+internal actual fun createBleScanStartLimiter(): BleScanStartLimiter = NoOpBleScanStartLimiter

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -79,16 +79,15 @@ private val CONNECTION_TIMEOUT = 15.seconds
  */
 private val HEARTBEAT_DRAIN_DELAY = 200.milliseconds
 
-internal val TARGETED_SCAN_TIMEOUT = 2.seconds
-
 /**
  * Bounded scan duration used by both discovery paths in [findDevice]:
- * - Bonded escalation: after the 2s [TARGETED_SCAN_TIMEOUT] misses the low-duty advertisement window, this is the
- *   single bounded retry before falling back to the bonded handle.
- * - Non-bonded retry: each of the [SCAN_RETRY_COUNT] attempts uses this duration.
+ * - Bonded devices get one address-filtered scan before falling back to the bonded handle.
+ * - Non-bonded retries each use this duration.
  *
- * 5s covers multiple advertising intervals for typical BLE power-save slots (~1–2s each). If the bounded bonded scan
- * window still misses, [findDevice] falls back to the bonded handle and [attemptConnection] keeps that patient
+ * Keeping the bonded path to one scanner registration is important on Android, which throttles applications that start
+ * BLE scans too frequently. A single 5s window still covers multiple advertising intervals for typical power-save slots
+ * (~1–2s each), resolves immediately when the target advertises, and avoids consuming two scan starts per reconnect. If
+ * the scan misses, [findDevice] falls back to the bonded handle and [attemptConnection] keeps that patient
  * `autoConnect` path bounded through [CONNECTION_TIMEOUT].
  */
 internal val SCAN_TIMEOUT = 5.seconds
@@ -242,23 +241,16 @@ class BleRadioTransport(
             bluetoothRepository.state.value.bondedDevices.firstOrNull { it.address.equals(address, ignoreCase = true) }
 
         if (bondedDevice != null) {
-            // Fast path: 2s targeted scan catches active advertising.
-            Logger.i {
-                "[${address.anonymize()}] Bonded device found; attempting short targeted scan for fresh advertisement"
-            }
-            scanForFreshDevice(TARGETED_SCAN_TIMEOUT)?.let {
+            // Use one bounded, address-filtered scan. Splitting this into a short scan plus an escalated scan consumed
+            // two Android scanner registrations per reconnect and could hit SCAN_FAILED_SCANNING_TOO_FREQUENTLY when a
+            // user switched devices while the reconnect policy and the Connections screen were also scanning.
+            Logger.i { "[${address.anonymize()}] Bonded device found; scanning once for a fresh advertisement" }
+            scanForFreshDevice(SCAN_TIMEOUT)?.let {
                 Logger.i { "[${address.anonymize()}] Fresh advertisement found; using scanned device" }
                 return it
             }
 
-            // Escalation: radio may be in a low-duty advertising slot. Try one bounded SCAN_TIMEOUT scan.
-            Logger.i { "[${address.anonymize()}] Targeted scan missed; escalating to bounded scan before fallback" }
-            scanForFreshDevice(SCAN_TIMEOUT)?.let {
-                Logger.i { "[${address.anonymize()}] Fresh advertisement found during escalated scan" }
-                return it
-            }
-
-            // If both scans miss, fall back to the bonded handle. Bonded-only devices have no fresh advertisement, so
+            // If the scan misses, fall back to the bonded handle. Bonded-only devices have no fresh advertisement, so
             // Kable uses autoConnect=true and Android can patiently wait for the device to advertise again.
             // This remains bounded by CONNECTION_TIMEOUT in connectAndAwait(), after which BleReconnectPolicy owns
             // retry/backoff.
@@ -288,7 +280,7 @@ class BleRadioTransport(
      *
      * One scan attempt only — no retry, no backoff. Both bonded and non-bonded paths in [findDevice] share this
      * primitive so retry policy stays centralized:
-     * - Bonded: escalated from [TARGETED_SCAN_TIMEOUT] to [SCAN_TIMEOUT] before [findDevice] returns the bonded handle.
+     * - Bonded: one address-filtered [SCAN_TIMEOUT] attempt before [findDevice] returns the bonded handle.
      * - Non-bonded: [SCAN_RETRY_COUNT] attempts at [SCAN_TIMEOUT] with [SCAN_RETRY_DELAY] between attempts.
      *
      * The outer [withTimeoutOrNull] is binding: the scanner receives [timeout] as a hint, but this coroutine resumes on

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -707,7 +707,9 @@ class BleRadioTransport(
                             return@withLock
                         }
                 try {
-                    retryBleOperation(tag = address) { currentService.sendToRadio(p) }
+                    retryBleOperation(tag = address, retryWhile = { currentService === radioService }) {
+                        currentService.sendToRadio(p)
+                    }
                     val sent = packetsSent.incrementAndGet()
                     val txBytes = bytesSent.addAndGet(p.size.toLong())
                     Logger.v {
@@ -726,7 +728,7 @@ class BleRadioTransport(
                         }
                         handleFailure(e)
                     } else {
-                        Logger.w(e) { "[$address] Stale write failure ignored (session was replaced)" }
+                        Logger.d(e) { "[$address] Stale write failure ignored because the session was replaced" }
                     }
                 }
             }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -60,12 +60,10 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration
 
 private const val BONDED_FALLBACK_CONNECT_BUFFER_MILLIS = 1_000L
-private val targetedScanTimeoutMillis = TARGETED_SCAN_TIMEOUT.inWholeMilliseconds
-private val escalatedScanTimeoutMillis = SCAN_TIMEOUT.inWholeMilliseconds
+private val bondedScanTimeoutMillis = SCAN_TIMEOUT.inWholeMilliseconds
 private val bondedReconnectWindowMillis =
     BleReconnectPolicy.DEFAULT_SETTLE_DELAY.inWholeMilliseconds +
-        targetedScanTimeoutMillis +
-        escalatedScanTimeoutMillis +
+        bondedScanTimeoutMillis +
         BONDED_FALLBACK_CONNECT_BUFFER_MILLIS
 
 /**
@@ -1081,24 +1079,17 @@ class BleRadioTransportReconnectCrashTest {
     // ─── Bonded fresh-advertisement discovery ─────────────────────────────────────────────────────
 
     /**
-     * Regression: bonded auto-reconnect must NOT reuse the stale bonded handle when the targeted scan misses the
-     * advertising window. The escalation path (TARGETED_SCAN_TIMEOUT → SCAN_TIMEOUT) must surface a freshly-scanned
-     * device.
-     *
-     * Sequenced scanner: call 0 (targeted) returns empty; call 1 (escalated) emits a fresh `FakeBleDevice` for the
-     * bonded address. The transport must connect using the fresh scanned device, never the stale bonded handle.
+     * Regression: bonded reconnect uses one bounded scanner registration and still prefers a fresh advertisement over
+     * the stale bonded handle. Starting a short scan and then a second escalated scan consumed two Android scan starts
+     * per reconnect, which could trigger SCAN_FAILED_SCANNING_TOO_FREQUENTLY during rapid device switching.
      */
     @Test
-    fun `bonded device missed by targeted scan is found by escalated scan`() = runTest {
+    fun `bonded reconnect uses one bounded scan and prefers its fresh device`() = runTest {
         val bondedDevice = FakeBleDevice(address = address, name = "Bonded Handle")
         bluetoothRepository.bond(bondedDevice)
 
         val freshDevice = FakeBleDevice(address = address, name = "Fresh Scan Result")
-        val sequencedScanner =
-            SequencedBleScanner().apply {
-                responses += { flow { awaitCancellation() } } // call 0: targeted scan misses
-                responses += { flow { emit(freshDevice) } } // call 1: escalated scan emits fresh device
-            }
+        val sequencedScanner = SequencedBleScanner().apply { responses += { flow { emit(freshDevice) } } }
 
         // Profile setup needs FROMNUM/FROMRADIO so the transport reaches a stable Connected state
         // rather than tearing down before we can inspect which device was connected.
@@ -1119,24 +1110,14 @@ class BleRadioTransportReconnectCrashTest {
 
             advanceTimeBy(bondedReconnectWindowMillis)
 
-            assertTrue(
-                sequencedScanner.callCount >= 2,
-                "Expected at least 2 scan calls (targeted + escalated); got ${sequencedScanner.callCount}",
-            )
+            assertEquals(1, sequencedScanner.callCount, "Bonded reconnect must consume one scan registration")
             assertEquals(
-                targetedScanTimeoutMillis,
-                sequencedScanner.calls[0].timeout.inWholeMilliseconds,
-                "First scan must use TARGETED_SCAN_TIMEOUT",
+                bondedScanTimeoutMillis,
+                sequencedScanner.calls.single().timeout.inWholeMilliseconds,
+                "The single bonded scan must use SCAN_TIMEOUT",
             )
-            assertEquals(
-                escalatedScanTimeoutMillis,
-                sequencedScanner.calls[1].timeout.inWholeMilliseconds,
-                "Second scan must use SCAN_TIMEOUT",
-            )
-            assertEquals(SERVICE_UUID, sequencedScanner.calls[0].serviceUuid, "First scan must include service UUID")
-            assertEquals(address, sequencedScanner.calls[0].address, "First scan must target selected address")
-            assertEquals(SERVICE_UUID, sequencedScanner.calls[1].serviceUuid, "Second scan must include service UUID")
-            assertEquals(address, sequencedScanner.calls[1].address, "Second scan must target selected address")
+            assertEquals(SERVICE_UUID, sequencedScanner.calls.single().serviceUuid, "Scan must include service UUID")
+            assertEquals(address, sequencedScanner.calls.single().address, "Scan must target selected address")
             assertEquals(1, connection.connectAndAwaitCalls, "Must connect exactly once with the fresh scanned device")
             assertTrue(
                 connection.device === freshDevice,
@@ -1151,22 +1132,15 @@ class BleRadioTransportReconnectCrashTest {
     }
 
     /**
-     * Regression: when the bonded device misses both fresh scan windows, [findDevice] must fall back to the bonded
-     * handle so Android's autoConnect path can patiently wait for the radio to advertise again.
-     *
-     * The fallback remains bounded by [CONNECTION_TIMEOUT] in `connectAndAwait`, after which the reconnect policy owns
-     * the next retry/backoff iteration.
+     * Regression: when the bonded device misses the bounded fresh-advertisement scan, [findDevice] must fall back to
+     * the bonded handle so Android's autoConnect path can patiently wait for the radio to advertise again.
      */
     @Test
-    fun `bonded device never advertising falls back to bounded autoConnect`() = runTest {
+    fun `bonded device never advertising falls back after one bounded scan`() = runTest {
         val bondedDevice = FakeBleDevice(address = address, name = "Bonded Handle")
         bluetoothRepository.bond(bondedDevice)
 
-        val sequencedScanner =
-            SequencedBleScanner().apply {
-                responses += { flow { awaitCancellation() } } // call 0: targeted scan misses
-                responses += { flow { awaitCancellation() } } // call 1: escalated scan misses
-            }
+        val sequencedScanner = SequencedBleScanner().apply { responses += { flow { awaitCancellation() } } }
 
         // Keep profile setup stable so the test can inspect the connected device.
         connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
@@ -1186,24 +1160,16 @@ class BleRadioTransportReconnectCrashTest {
 
             advanceTimeBy(bondedReconnectWindowMillis)
 
-            assertTrue(
-                sequencedScanner.callCount >= 2,
-                "Expected at least 2 scan calls (targeted + escalated); got ${sequencedScanner.callCount}",
-            )
+            assertEquals(1, sequencedScanner.callCount, "Bonded fallback must consume one scan registration")
             assertEquals(
-                targetedScanTimeoutMillis,
-                sequencedScanner.calls[0].timeout.inWholeMilliseconds,
-                "First scan must use TARGETED_SCAN_TIMEOUT",
-            )
-            assertEquals(
-                escalatedScanTimeoutMillis,
-                sequencedScanner.calls[1].timeout.inWholeMilliseconds,
-                "Second scan must use SCAN_TIMEOUT",
+                bondedScanTimeoutMillis,
+                sequencedScanner.calls.single().timeout.inWholeMilliseconds,
+                "The single bonded scan must use SCAN_TIMEOUT",
             )
             assertEquals(1, connection.connectAndAwaitCalls, "Must connect once through the bounded bonded fallback")
             assertTrue(
                 connection.device === bondedDevice,
-                "Must use the bonded handle after fresh scans miss (got: ${connection.device?.name})",
+                "Must use the bonded handle after the fresh scan misses (got: ${connection.device?.name})",
             )
 
             bleTransport.close()

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportReconnectCrashTest.kt
@@ -419,6 +419,45 @@ class BleRadioTransportReconnectCrashTest {
     }
 
     @Test
+    fun `write retry stops when remote disconnect retires the captured session`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Radio")
+        bluetoothRepository.bond(device)
+        scanner.emitDevice(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        try {
+            bleTransport.start()
+            advanceTimeBy(4_000L)
+
+            val attemptsBefore = connection.service.writeAttempts
+            connection.service.writeException = NotConnectedException("session closed")
+            bleTransport.handleSendToRadio(byteArrayOf(1))
+            testScheduler.runCurrent()
+            assertEquals(attemptsBefore + 1, connection.service.writeAttempts)
+
+            connection.simulateRemoteDisconnect()
+            testScheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertEquals(
+                attemptsBefore + 1,
+                connection.service.writeAttempts,
+                "A write captured from a retired session must not consume more retry attempts",
+            )
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
     fun `repeated writes after session failure do not spam onDisconnect`() = runTest {
         val device = FakeBleDevice(address = address, name = "Test Radio")
         bluetoothRepository.bond(device)

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -118,7 +118,7 @@ class BleRadioTransportTest {
     fun `onDisconnect is called after DEFAULT_FAILURE_THRESHOLD consecutive failures`() = runTest {
         val device = FakeBleDevice(address = address, name = "Test Device")
         bluetoothRepository.bond(device)
-        scanner.emitDevice(device) // targeted scan resolves immediately; this test covers reconnect timing
+        scanner.emitDevice(device) // bounded scan resolves immediately; this test covers reconnect timing
 
         // Make every connectAndAwait call throw so each iteration counts as one failure.
         connection.connectException = RadioNotConnectedException("simulated failure")
@@ -234,8 +234,8 @@ class BleRadioTransportTest {
             )
         bleTransport.start()
         try {
-            // 3s settle + 2s targeted + 5s escalated scan = 10s before bonded fallback.
-            advanceTimeBy(11_000)
+            // 3s settle + one 5s bounded scan before bonded fallback.
+            advanceTimeBy(9_000)
 
             assertEquals(1, connection.connectAndAwaitCalls, "Must use bounded bonded fallback after fresh scans miss")
             assertEquals("Bonded Device", connection.device?.name)

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -143,6 +143,10 @@
     <string name="bluetooth_permission">Bluetooth</string>
     <string name="bluetooth_scan_missing_permission">Bluetooth scan needs permission. Grant the Nearby devices (or Location) permission to find devices.</string>
     <string name="bluetooth_scan_start_failed">Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues.</string>
+    <plurals name="bluetooth_scan_too_frequent">
+        <item quantity="one">Bluetooth scan limit reached. Try again in %1$d second.</item>
+        <item quantity="other">Bluetooth scan limit reached. Try again in %1$d seconds.</item>
+    </plurals>
     <string name="bold_heading">Bold Heading</string>
     <string name="bonding_failed_permissions">Pairing failed. Grant nearby device permissions and try again.</string>
     <string name="bonding_failed_retry">Pairing did not complete. Try pairing again.</string>

--- a/core/resources/src/commonMain/kotlin/org/meshtastic/core/resources/GetString.kt
+++ b/core/resources/src/commonMain/kotlin/org/meshtastic/core/resources/GetString.kt
@@ -17,7 +17,9 @@
 package org.meshtastic.core.resources
 
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.getPluralString as composeGetPluralString
 import org.jetbrains.compose.resources.getString as composeGetString
 
 /** Retrieves a string from the [StringResource] in a blocking manner. Use primarily in non-composable code. */
@@ -66,4 +68,16 @@ suspend fun getStringSuspend(stringResource: StringResource, vararg formatArgs: 
     } else {
         composeGetString(stringResource)
     }
+}
+
+/** Retrieves a plural string in a suspending manner. */
+suspend fun getPluralStringSuspend(
+    pluralStringResource: PluralStringResource,
+    quantity: Int,
+    vararg formatArgs: Any,
+): String = if (formatArgs.isNotEmpty()) {
+    @Suppress("SpreadOperator")
+    composeGetPluralString(pluralStringResource, quantity, *formatArgs)
+} else {
+    composeGetPluralString(pluralStringResource, quantity)
 }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -216,6 +216,10 @@ class FakeBleService : BleService {
 
     val writes = mutableListOf<FakeBleWrite>()
 
+    /** Counts every write invocation, including attempts that fail before they can be recorded in [writes]. */
+    var writeAttempts: Int = 0
+        private set
+
     /** When non-null, [write] throws this exception on every call until explicitly cleared. */
     var writeException: Exception? = null
 
@@ -298,6 +302,7 @@ class FakeBleService : BleService {
     override fun preferredWriteType(characteristic: BleCharacteristic): BleWriteType = BleWriteType.WITH_RESPONSE
 
     override suspend fun write(characteristic: BleCharacteristic, data: ByteArray, writeType: BleWriteType) {
+        writeAttempts++
         writeException?.let { ex -> throw ex }
         availableCharacteristics += characteristic.uuid
         writes += FakeBleWrite(characteristic = characteristic, data = data.copyOf(), writeType = writeType)

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -61,6 +61,8 @@ import org.meshtastic.core.repository.UiPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.bluetooth_scan_missing_permission
 import org.meshtastic.core.resources.bluetooth_scan_start_failed
+import org.meshtastic.core.resources.bluetooth_scan_too_frequent
+import org.meshtastic.core.resources.getPluralStringSuspend
 import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
@@ -73,6 +75,14 @@ import kotlin.time.Duration.Companion.seconds
 internal val BLE_SCAN_START_FAILURE_RETRY_COOLDOWN = 15.seconds
 private const val BLE_SCAN_START_FAILURE_MESSAGE_FALLBACK =
     "Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues."
+
+private fun effectiveBleScanRetryCooldown(retryAfter: Duration?): Duration =
+    maxOf(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN, retryAfter ?: Duration.ZERO)
+
+private fun Duration.roundedUpWholeSeconds(): Long {
+    val completeSeconds = inWholeSeconds
+    return completeSeconds + if (this > completeSeconds.seconds) 1 else 0
+}
 
 /**
  * Platform-neutral ViewModel that drives the Connections screen: device discovery (BLE/USB/TCP), scan state, current
@@ -393,29 +403,49 @@ open class ScannerViewModel(
         scanJob = null
         _isBleScanning.value = false
         uiPrefs.setBleAutoScan(false)
-        startBleScanRetryCooldown()
+        val retryCooldown = effectiveBleScanRetryCooldown(exception.retryAfter)
+        startBleScanRetryCooldown(retryCooldown)
 
         Logger.w(exception) {
             "BLE scan could not start: ${exception.reason.androidCode} (${exception.reason.description})"
         }
-        val messageRes =
-            when (exception.reason) {
-                BleScanStartFailureReason.MissingScanPermission -> Res.string.bluetooth_scan_missing_permission
-                BleScanStartFailureReason.ApplicationRegistrationFailed -> Res.string.bluetooth_scan_start_failed
-            }
+        val retryCooldownSeconds = retryCooldown.roundedUpWholeSeconds()
         val errorMessage =
-            safeCatchingAll { getStringSuspend(messageRes) }.getOrDefault(BLE_SCAN_START_FAILURE_MESSAGE_FALLBACK)
+            safeCatchingAll {
+                when (exception.reason) {
+                    BleScanStartFailureReason.MissingScanPermission ->
+                        getStringSuspend(Res.string.bluetooth_scan_missing_permission)
+
+                    BleScanStartFailureReason.ApplicationRegistrationFailed ->
+                        getStringSuspend(Res.string.bluetooth_scan_start_failed)
+
+                    BleScanStartFailureReason.ScanningTooFrequently ->
+                        getPluralStringSuspend(
+                            Res.plurals.bluetooth_scan_too_frequent,
+                            retryCooldownSeconds.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+                            retryCooldownSeconds,
+                        )
+                }
+            }
+                .getOrDefault(
+                    if (exception.reason == BleScanStartFailureReason.ScanningTooFrequently) {
+                        val unit = if (retryCooldownSeconds == 1L) "second" else "seconds"
+                        "Bluetooth scan limit reached. Try again in $retryCooldownSeconds $unit."
+                    } else {
+                        BLE_SCAN_START_FAILURE_MESSAGE_FALLBACK
+                    },
+                )
         serviceRepository.setErrorMessage(text = errorMessage, severity = Severity.Warn)
     }
 
-    private fun startBleScanRetryCooldown() {
+    private fun startBleScanRetryCooldown(cooldown: Duration) {
         val generation = ++scanStartFailureCooldownGeneration
         scanStartFailureCooldownActive.value = true
         scanStartFailureCooldownJob?.cancel()
         scanStartFailureCooldownJob =
             viewModelScope.launch {
                 try {
-                    delay(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN)
+                    delay(cooldown)
                 } finally {
                     if (scanStartFailureCooldownGeneration == generation) {
                         scanStartFailureCooldownActive.value = false

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -42,6 +42,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ScannerViewModelTest {
@@ -147,6 +149,32 @@ class ScannerViewModelTest {
         harness.testDispatcher.scheduler.advanceTimeBy(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN.inWholeMilliseconds + 1)
         viewModel.startBleScan()
 
+        assertEquals(2, scanAttempts)
+    }
+
+    @Test
+    fun `scan quota failure honors retry-after cooldown`() = runTest {
+        var scanAttempts = 0
+        every { bleScanner.scan(any(), any()) } returns
+            flow {
+                scanAttempts += 1
+                throw BleScanStartException(
+                    reason = BleScanStartFailureReason.ScanningTooFrequently,
+                    cause = IllegalStateException("Android BLE scan-start quota exhausted"),
+                    retryAfter = 30.seconds + 1.milliseconds,
+                )
+            }
+
+        viewModel.startBleScan()
+        assertEquals(1, scanAttempts)
+        assertEquals("Bluetooth scan limit reached. Try again in 31 seconds.", serviceRepository.errorMessage.value)
+
+        harness.testDispatcher.scheduler.advanceTimeBy(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN.inWholeMilliseconds + 1)
+        viewModel.startBleScan()
+        assertEquals(1, scanAttempts)
+
+        harness.testDispatcher.scheduler.advanceTimeBy(15.seconds.inWholeMilliseconds + 1)
+        viewModel.startBleScan()
         assertEquals(2, scanAttempts)
     }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change improves how BLE scanning and reconnection are paced and retried across shared code and Android-specific behavior. It introduces a platform scan-start limiter on Android with a rolling, process-wide quota and clear failure signaling, propagates Android-derived cooldown/retry timing up to the UI layer, and tightens retry behavior so retired sessions/services don’t continue retrying. It also simplifies bonded-device discovery to a single bounded scan flow and updates/extends unit tests to cover the new lifecycle and timing rules.

## Key changes

### Features
- Added a BLE scan-start limiting abstraction:
  - Introduced `BleScanStartLimiter` (common) with platform `createBleScanStartLimiter()` factory.
  - Implemented Android limiter with:
    - Monotonic time tracking and concurrency-safe reservations.
    - A shared, process-wide rolling quota.
    - Computed `retryAfter` when the scan start quota is exceeded.
  - Implemented no-op limiters for iOS and JVM.
- Added typed scan-start failure metadata:
  - Extended `BleScanStartFailureReason` with `ScanningTooFrequently`.
  - Extended `BleScanStartException` to carry an optional `retryAfter: Duration?`.
- Added scan startup throttling integration:
  - Updated `KableBleScanner` to reserve a scan start slot before scanning.
  - Mapped “scanning too frequently” failures from Kable into `BleScanStartFailureReason.ScanningTooFrequently`.
- Added server/client controlled retry gating:
  - Extended `retryBleOperation` with a `retryWhile` predicate to decide whether retries should continue.

### Fixes
- Prevented retries after session/profile replacement:
  - `retryBleOperation` is now used with a predicate so retries stop once the captured radio service/session is no longer the active one.
- Improved BLE reconnect/bonded discovery retry flow correctness:
  - Simplified bonded-device discovery to a single bounded, address-filtered scan, with bonded-handle fallback if no fresh advertisement is found.
  - Updated reconnect timing/expectations so retries don’t consume additional attempts after remote disconnect retires the captured session.
- Corrected user-visible scan retry cooldown handling:
  - Updated `ScannerViewModel` to compute the BLE scan retry cooldown from `BleScanStartException.retryAfter` and to avoid earlier cooldown jobs clearing newer state.
- Enhanced test coverage for the lifecycle edge cases:
  - Added Android quota-sharing and concurrency tests for the limiter (including correct failure reason and `retryAfter` behavior).
  - Added/updated tests for scan reservation ordering and mapping to `ScanningTooFrequently`.
  - Added tests verifying `retryBleOperation` stops when `retryWhile` is revoked and re-checks the predicate after backoff.

### Refactors and test/utility updates
- Refactored scan retry handling to be driven by `retryAfter` rather than a fixed cooldown helper.
- Tightened/refined retry logic in BLE radio transport and updated reconnect regression tests accordingly.
- Updated testing utilities:
  - `FakeBleService` now tracks `writeAttempts`.
  - Improved coroutine control in `BleRetryTest` (extra scheduling helpers and additional predicate-driven retry tests).

## Breaking changes and migration
- `retryBleOperation` signature changed: it now accepts `retryWhile: () -> Boolean` (default `{ true }`). Any internal callers relying on positional arguments may need adjustment.
- `BleScanStartException` constructor signature changed: it now optionally accepts `retryAfter: Duration? = null`. Callers that construct this exception should pass `retryAfter` when available/needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->