### PR TITLE
fix(map): configure OSMdroid user agent at startup

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/FlavorApplicationConfiguration.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/FlavorApplicationConfiguration.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app
+
+import org.osmdroid.config.Configuration
+
+/** Configures F-Droid-only process globals before any OSMdroid map or tile provider can be created. */
+internal fun configureFlavorApplication(applicationId: String) {
+    Configuration.getInstance().userAgentValue = applicationId
+}

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -315,7 +315,6 @@ fun MapView(
     val initialCameraPosition = (initialCameraState as InitialCameraState.Ready).position
     val map =
         rememberMapViewWithLifecycle(
-            applicationId = mapViewModel.applicationId,
             zoomLevel = initialCameraPosition?.zoom ?: INITIAL_MAP_ZOOM,
             mapCenter = initialCameraPosition?.let { GeoPoint(it.latitude, it.longitude) } ?: GeoPoint(0.0, 0.0),
             tileSource = loadOnlineTileSourceBase(),

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
-import org.meshtastic.core.common.BuildConfigProvider
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.MapCameraPosition
 import org.meshtastic.core.repository.MapPrefs
@@ -47,7 +46,6 @@ class MapViewModel(
     radioController: RadioController,
     radioConfigRepository: RadioConfigRepository,
     notificationPrefs: NotificationPrefs,
-    buildConfigProvider: BuildConfigProvider,
     private val mapLayersManager: MapLayersManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseMapViewModel(
@@ -86,8 +84,6 @@ class MapViewModel(
         set(value) {
             mapPrefs.setMapStyle(value)
         }
-
-    val applicationId = buildConfigProvider.applicationId
 
     /** Imported overlay layers; owned by the flavor-neutral [MapLayersManager] and drawn on the OSMdroid map. */
     val mapLayers: StateFlow<List<MapLayerItem>> = mapLayersManager.mapLayers

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import org.osmdroid.config.Configuration
 import org.osmdroid.tileprovider.tilesource.ITileSource
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.BoundingBox
@@ -44,7 +43,6 @@ private const val DEFAULT_ZOOM_LEVEL = 15.0
 @Suppress("MagicNumber")
 @Composable
 fun rememberMapViewWithLifecycle(
-    applicationId: String,
     box: BoundingBox,
     tileSource: ITileSource = TileSourceFactory.DEFAULT_TILE_SOURCE,
 ): MapView {
@@ -55,18 +53,12 @@ fun rememberMapViewWithLifecycle(
             DEFAULT_ZOOM_LEVEL
         }
     val center = GeoPoint(box.centerLatitude, box.centerLongitude)
-    return rememberMapViewWithLifecycle(
-        applicationId = applicationId,
-        zoomLevel = zoom,
-        mapCenter = center,
-        tileSource = tileSource,
-    )
+    return rememberMapViewWithLifecycle(zoomLevel = zoom, mapCenter = center, tileSource = tileSource)
 }
 
 @Suppress("LongMethod")
 @Composable
 internal fun rememberMapViewWithLifecycle(
-    applicationId: String,
     zoomLevel: Double = MIN_ZOOM_LEVEL,
     mapCenter: GeoPoint = GeoPoint(0.0, 0.0),
     tileSource: ITileSource = TileSourceFactory.DEFAULT_TILE_SOURCE,
@@ -88,8 +80,6 @@ internal fun rememberMapViewWithLifecycle(
         MapView(context).apply {
             clipToOutline = true
 
-            // Required to get online tiles
-            Configuration.getInstance().userAgentValue = applicationId
             setTileSource(tileSource)
             isVerticalMapRepetitionEnabled = false // disables map repetition
             setMultiTouchControls(true)

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/discovery/DiscoveryOsmMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/discovery/DiscoveryOsmMap.kt
@@ -79,12 +79,7 @@ fun DiscoveryOsmMap(
 
     var hasCentered by remember { mutableStateOf(false) }
 
-    val mapView =
-        rememberMapViewWithLifecycle(
-            applicationId = context.packageName,
-            box = initialBounds,
-            tileSource = CustomTileSource.getTileSource(0),
-        )
+    val mapView = rememberMapViewWithLifecycle(box = initialBounds, tileSource = CustomTileSource.getTileSource(0))
 
     // Camera auto-center once
     LaunchedEffect(allGeoPoints) {

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeMapScreen.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeMapScreen.kt
@@ -46,7 +46,6 @@ fun NodeMapScreen(nodeMapViewModel: NodeMapViewModel, onNavigateUp: () -> Unit) 
     ) { paddingValues ->
         NodeTrackOsmMap(
             positions = positions,
-            applicationId = nodeMapViewModel.applicationId,
             mapStyleId = nodeMapViewModel.mapStyleId,
             modifier = Modifier.fillMaxSize().padding(paddingValues),
         )

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackMap.kt
@@ -24,8 +24,7 @@ import org.meshtastic.proto.Position
 
 /**
  * Flavor-unified entry point for the embeddable node-track map. Resolves [destNum] to obtain
- * [NodeMapViewModel.applicationId] and [NodeMapViewModel.mapStyleId], then delegates to the OSMDroid implementation
- * ([NodeTrackOsmMap]).
+ * [NodeMapViewModel.mapStyleId], then delegates to the OSMDroid implementation ([NodeTrackOsmMap]).
  *
  * Supports optional synchronized selection via [selectedPositionTime] and [onPositionSelected].
  */
@@ -41,7 +40,6 @@ fun NodeTrackMap(
     vm.setDestNum(destNum)
     NodeTrackOsmMap(
         positions = positions,
-        applicationId = vm.applicationId,
         mapStyleId = vm.mapStyleId,
         modifier = modifier,
         selectedPositionTime = selectedPositionTime,

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackOsmMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackOsmMap.kt
@@ -72,7 +72,6 @@ import kotlin.math.roundToInt
 @Composable
 fun NodeTrackOsmMap(
     positions: List<Position>,
-    applicationId: String,
     mapStyleId: Int,
     modifier: Modifier = Modifier,
     selectedPositionTime: Int? = null,
@@ -96,11 +95,7 @@ fun NodeTrackOsmMap(
         }
     val cameraView = remember(geoPoints) { BoundingBox.fromGeoPoints(geoPoints) }
     val mapView =
-        rememberMapViewWithLifecycle(
-            applicationId = applicationId,
-            box = cameraView,
-            tileSource = CustomTileSource.getTileSource(mapStyleId),
-        )
+        rememberMapViewWithLifecycle(box = cameraView, tileSource = CustomTileSource.getTileSource(mapStyleId))
 
     var filterMenuExpanded by remember { mutableStateOf(false) }
 

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/traceroute/TracerouteOsmMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/traceroute/TracerouteOsmMap.kt
@@ -161,7 +161,6 @@ fun TracerouteOsmMap(
 
     val mapView =
         rememberMapViewWithLifecycle(
-            applicationId = mapViewModel.applicationId,
             box = initialCameraView ?: BoundingBox(),
             tileSource = CustomTileSource.getTileSource(mapViewModel.mapStyleId),
         )

--- a/androidApp/src/google/kotlin/org/meshtastic/app/FlavorApplicationConfiguration.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/FlavorApplicationConfiguration.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app
+
+/** Google builds have no flavor-specific application globals to configure. */
+internal fun configureFlavorApplication(@Suppress("UNUSED_PARAMETER") applicationId: String) = Unit

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -76,6 +76,7 @@ open class MeshUtilApplication :
     override fun onCreate() {
         super.onCreate()
         ContextServices.app = this
+        configureFlavorApplication(BuildConfig.APPLICATION_ID)
 
         startKoin<AndroidKoinApp> {
             androidContext(this@MeshUtilApplication)

--- a/androidApp/src/testFdroid/kotlin/org/meshtastic/app/FlavorApplicationConfigurationTest.kt
+++ b/androidApp/src/testFdroid/kotlin/org/meshtastic/app/FlavorApplicationConfigurationTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.runner.RunWith
+import org.osmdroid.config.Configuration
+import org.osmdroid.views.MapView
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FlavorApplicationConfigurationTest {
+    @Test
+    fun `configureFlavorApplication helper sets osmdroid user agent`() {
+        val configuration = Configuration.getInstance()
+        val original = configuration.userAgentValue
+        try {
+            configureFlavorApplication("test.user.agent")
+            assertEquals("test.user.agent", configuration.userAgentValue)
+        } finally {
+            configuration.userAgentValue = original
+        }
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = MeshUtilApplication::class, sdk = [34])
+class FlavorApplicationStartupTest {
+    @Test
+    fun `production startup configures osmdroid before first map creation`() {
+        val configuration = Configuration.getInstance()
+        val original = configuration.userAgentValue
+        try {
+            val application = ApplicationProvider.getApplicationContext<MeshUtilApplication>()
+
+            assertEquals(BuildConfig.APPLICATION_ID, configuration.userAgentValue)
+            MapView(application).let { mapView ->
+                try {
+                    assertEquals(BuildConfig.APPLICATION_ID, configuration.userAgentValue)
+                } finally {
+                    mapView.onDetach()
+                }
+            }
+        } finally {
+            configuration.userAgentValue = original
+        }
+    }
+}

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/node/NodeMapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/node/NodeMapViewModel.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.toList
 import org.koin.core.annotation.KoinViewModel
-import org.meshtastic.core.common.BuildConfigProvider
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.repository.MapPrefs
 import org.meshtastic.core.repository.MeshLogRepository
@@ -43,7 +42,6 @@ class NodeMapViewModel(
     savedStateHandle: SavedStateHandle,
     nodeRepository: NodeRepository,
     meshLogRepository: MeshLogRepository,
-    buildConfigProvider: BuildConfigProvider,
     private val mapPrefs: MapPrefs,
 ) : ViewModel() {
     private val destNumFromRoute = savedStateHandle.get<Int>("destNum")
@@ -61,8 +59,6 @@ class NodeMapViewModel(
             .flatMapLatest { destNum -> nodeRepository.nodeDBbyNum.mapLatest { it[destNum] } }
             .distinctUntilChanged()
             .stateInWhileSubscribed(initialValue = null)
-
-    val applicationId = buildConfigProvider.applicationId
 
     private val ourNodeNumFlow = nodeRepository.myNodeInfo.map { it?.myNodeNum }.distinctUntilChanged()
 


### PR DESCRIPTION
## Summary by Sourcery

Configure flavor-specific application startup to set the OSMdroid user agent for F-Droid builds without affecting Google builds.

New Features:
- Initialize OSMdroid configuration with the app package name as user agent during application startup for F-Droid flavors.

Tests:
- Add F-Droid flavor test ensuring the OSMdroid user agent is configured before map creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Configures the OSMdroid user agent during application startup for F-Droid builds, before Koin and map initialization. Google builds remain unchanged. Per-map application ID plumbing and redundant user-agent assignments were removed.

## Key changes

### Features
- Added F-Droid startup configuration that sets OSMdroid’s `userAgentValue` to the generated application ID.
- Added Google flavor configuration as an explicit no-op.
- Added tests for the configuration helper and production application startup lifecycle.

### Refactors
- Removed `applicationId` parameters and properties from map composables and view models.
- Removed redundant OSMdroid configuration from individual map creation paths.
- Removed unnecessary `BuildConfigProvider` dependencies from map view models.
- Kept the existing map lifecycle, rendering, and camera behavior unchanged.

## Breaking changes and migration

- Internal map APIs that accepted `applicationId` no longer require it.
- Callers of the affected map composables and view models must use their updated signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->