### PR TITLE
Refactor UI components to improve performance and resource handling

### DIFF
--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
@@ -27,10 +27,14 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -68,6 +72,7 @@ class MeshNotificationManagerImplConversationTest {
     private val packetRepository: PacketRepository = mock(MockMode.autofill)
     private val nodeRepository: NodeRepository = mock(MockMode.autofill)
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
+    private val notificationScope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
     private val manager =
         MeshNotificationManagerImpl(
@@ -89,6 +94,7 @@ class MeshNotificationManagerImplConversationTest {
                 )
             },
             radioConfigRepository = lazy { radioConfigRepository },
+            scope = notificationScope,
         )
 
     @Before
@@ -107,6 +113,11 @@ class MeshNotificationManagerImplConversationTest {
                 ),
             )
         manager.initChannels()
+    }
+
+    @After
+    fun tearDown() {
+        notificationScope.cancel()
     }
 
     /** Newest-first message history, mirroring the repository's ordering. */

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
@@ -29,12 +29,9 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
-import org.junit.After
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,6 +43,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
+import org.meshtastic.core.testing.runWithRenderScope
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.User
 import org.robolectric.annotation.Config
@@ -72,30 +70,28 @@ class MeshNotificationManagerImplConversationTest {
     private val packetRepository: PacketRepository = mock(MockMode.autofill)
     private val nodeRepository: NodeRepository = mock(MockMode.autofill)
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
-    private val notificationScope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
-    private val manager =
-        MeshNotificationManagerImpl(
-            context = context,
-            packetRepository = lazy { packetRepository },
-            nodeRepository = lazy { nodeRepository },
-            conversationShortcutPublisher =
-            lazy {
-                ConversationShortcutPublisher(
-                    context,
-                    nodeRepository,
-                    packetRepository,
-                    radioConfigRepository,
-                    CoroutineDispatchers(
-                        io = Dispatchers.Unconfined,
-                        main = Dispatchers.Unconfined,
-                        default = Dispatchers.Unconfined,
-                    ),
-                )
-            },
-            radioConfigRepository = lazy { radioConfigRepository },
-            scope = notificationScope,
-        )
+    private fun createManager(scope: CoroutineScope) = MeshNotificationManagerImpl(
+        context = context,
+        packetRepository = lazy { packetRepository },
+        nodeRepository = lazy { nodeRepository },
+        conversationShortcutPublisher =
+        lazy {
+            ConversationShortcutPublisher(
+                context,
+                nodeRepository,
+                packetRepository,
+                radioConfigRepository,
+                CoroutineDispatchers(
+                    io = Dispatchers.Unconfined,
+                    main = Dispatchers.Unconfined,
+                    default = Dispatchers.Unconfined,
+                ),
+            )
+        },
+        radioConfigRepository = lazy { radioConfigRepository },
+        scope = scope,
+    )
 
     @Before
     fun setUp() {
@@ -112,12 +108,6 @@ class MeshNotificationManagerImplConversationTest {
                     lora_config = MeshChannel.default.loraConfig,
                 ),
             )
-        manager.initChannels()
-    }
-
-    @After
-    fun tearDown() {
-        notificationScope.cancel()
     }
 
     /** Newest-first message history, mirroring the repository's ordering. */
@@ -162,7 +152,8 @@ class MeshNotificationManagerImplConversationTest {
     }
 
     @Test
-    fun `read messages become historic context and unread messages stay alerting`() = runTest {
+    fun `read messages become historic context and unread messages stay alerting`() = runWithRenderScope { scope ->
+        val manager = createManager(scope).also { it.initChannels() }
         mockHistory(
             message("new unread", read = false, receivedTime = 3_000),
             message("older read 2", read = true, receivedTime = 2_000),
@@ -176,6 +167,7 @@ class MeshNotificationManagerImplConversationTest {
             isBroadcast = true,
             channelName = "LongFast",
         )
+        advanceUntilIdle()
 
         val posted = activeByTag("message").single().notification
         val alerting = posted.extras.getParcelableArray(Notification.EXTRA_MESSAGES)
@@ -186,57 +178,74 @@ class MeshNotificationManagerImplConversationTest {
     }
 
     @Test
-    fun `group summary alerts via children only and is dropped with the last conversation`() = runTest {
-        mockHistory(message("hello", read = false, receivedTime = 1_000))
+    fun `group summary alerts via children only and is dropped with the last conversation`() =
+        runWithRenderScope { scope ->
+            val manager = createManager(scope).also { it.initChannels() }
+            mockHistory(message("hello", read = false, receivedTime = 1_000))
 
-        manager.updateMessageNotification("0^all", "Hawk Ridge", "hello", isBroadcast = true, channelName = "LongFast")
+            manager.updateMessageNotification(
+                "0^all",
+                "Hawk Ridge",
+                "hello",
+                isBroadcast = true,
+                channelName = "LongFast",
+            )
+            advanceUntilIdle()
 
-        val summary = activeByTag("message_summary").single().notification
-        assertEquals(Notification.GROUP_ALERT_CHILDREN, summary.groupAlertBehavior)
-        // The summary line is rebuilt from the child's real MessagingStyle, so it carries the actual sender.
-        val summaryLatest =
-            androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(summary)
-                ?.messages
-                ?.lastOrNull()
-        assertEquals("hello", summaryLatest?.text?.toString())
-        assertEquals("Hawk Ridge", summaryLatest?.person?.name?.toString())
+            val summary = activeByTag("message_summary").single().notification
+            assertEquals(Notification.GROUP_ALERT_CHILDREN, summary.groupAlertBehavior)
+            // The summary line is rebuilt from the child's real MessagingStyle, so it carries the actual sender.
+            val summaryLatest =
+                androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(summary)
+                    ?.messages
+                    ?.lastOrNull()
+            assertEquals("hello", summaryLatest?.text?.toString())
+            assertEquals("Hawk Ridge", summaryLatest?.person?.name?.toString())
 
-        manager.cancelMessageNotification("0^all")
+            manager.cancelMessageNotification("0^all")
 
-        assertTrue(activeByTag("message").isEmpty(), "conversation should be cancelled")
-        assertTrue(activeByTag("message_summary").isEmpty(), "summary must not outlive the last conversation")
-    }
-
-    @Test
-    fun `notification ids are namespaced per type so a node num cannot clobber the service notification`() = runTest {
-        // SERVICE_NOTIFY_ID is 101; a node whose num is also 101 used to overwrite the foreground notification.
-        manager.updateServiceStateNotification(ConnectionState.Connected, telemetry = null)
-        manager.showOrUpdateLowBatteryNotification(Node(num = 101), isRemote = false)
-
-        val service = systemNotificationManager.activeNotifications.filter { it.id == 101 && it.tag == null }
-        val battery = activeByTag("low_battery").filter { it.id == 101 }
-        assertEquals(1, service.size, "service notification should survive")
-        assertEquals(1, battery.size, "low-battery notification should coexist under its own tag")
-        assertEquals(0xFF67EA94.toInt(), service.single().notification.color, "brand accent color")
-    }
+            assertTrue(activeByTag("message").isEmpty(), "conversation should be cancelled")
+            assertTrue(activeByTag("message_summary").isEmpty(), "summary must not outlive the last conversation")
+        }
 
     @Test
-    fun `refreshConversationAfterReply reposts the conversation with the effective channel name`() = runTest {
-        mockHistory(message("original", read = true, receivedTime = 1_000))
+    fun `notification ids are namespaced per type so a node num cannot clobber the service notification`() =
+        runWithRenderScope { scope ->
+            val manager = createManager(scope).also { it.initChannels() }
+            // SERVICE_NOTIFY_ID is 101; a node whose num is also 101 used to overwrite the foreground notification.
+            manager.updateServiceStateNotification(ConnectionState.Connected, telemetry = null)
+            manager.showOrUpdateLowBatteryNotification(Node(num = 101), isRemote = false)
+            advanceUntilIdle()
 
-        manager.refreshConversationAfterReply("0^all")
-
-        val posted = activeByTag("message").single().notification
-        // Empty primary channel resolves to its modem-preset display name, matching the in-app conversation list.
-        assertEquals("LongFast", posted.extras.getCharSequence(Notification.EXTRA_CONVERSATION_TITLE)?.toString())
-        assertNotNull(posted.extras.getParcelableArray(Notification.EXTRA_MESSAGES))
-    }
+            val service = systemNotificationManager.activeNotifications.filter { it.id == 101 && it.tag == null }
+            val battery = activeByTag("low_battery").filter { it.id == 101 }
+            assertEquals(1, service.size, "service notification should survive")
+            assertEquals(1, battery.size, "low-battery notification should coexist under its own tag")
+            assertEquals(0xFF67EA94.toInt(), service.single().notification.color, "brand accent color")
+        }
 
     @Test
-    fun `refreshConversationAfterReply resolves a dm peer name for the shortcut label`() = runTest {
+    fun `refreshConversationAfterReply reposts the conversation with the effective channel name`() =
+        runWithRenderScope { scope ->
+            val manager = createManager(scope).also { it.initChannels() }
+            mockHistory(message("original", read = true, receivedTime = 1_000))
+
+            manager.refreshConversationAfterReply("0^all")
+            advanceUntilIdle()
+
+            val posted = activeByTag("message").single().notification
+            // Empty primary channel resolves to its modem-preset display name, matching the in-app conversation list.
+            assertEquals("LongFast", posted.extras.getCharSequence(Notification.EXTRA_CONVERSATION_TITLE)?.toString())
+            assertNotNull(posted.extras.getParcelableArray(Notification.EXTRA_MESSAGES))
+        }
+
+    @Test
+    fun `refreshConversationAfterReply resolves a dm peer name for the shortcut label`() = runWithRenderScope { scope ->
+        val manager = createManager(scope).also { it.initChannels() }
         mockHistory(message("dm text", read = true, receivedTime = 1_000))
 
         manager.refreshConversationAfterReply("0!00000007")
+        advanceUntilIdle()
 
         val posted = activeByTag("message").single().notification
         // A DM is not a group conversation, so no conversation title is set.

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
@@ -99,6 +99,7 @@ class MeshNotificationManagerImplConversationTest {
         systemNotificationManager.cancelAll()
         every { nodeRepository.ourNodeInfo } returns MutableStateFlow(me)
         every { nodeRepository.myNodeInfo } returns MutableStateFlow<MyNodeInfo?>(null)
+        every { nodeRepository.localStats } returns MutableStateFlow(org.meshtastic.proto.LocalStats())
         every { nodeRepository.nodeDBbyNum } returns MutableStateFlow(mapOf(7 to sender, 42 to me))
         everySuspend { nodeRepository.getNode(any()) } returns sender
         every { radioConfigRepository.channelSetFlow } returns

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
@@ -16,18 +16,40 @@
  */
 package org.meshtastic.core.service
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.SERVICE_NOTIFY_ID
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.disconnected
+import org.meshtastic.core.resources.getString
+import org.meshtastic.proto.LocalStats
+import org.meshtastic.proto.Telemetry
 import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -37,32 +59,27 @@ class MeshNotificationManagerImplTest {
 
     private lateinit var context: Context
     private lateinit var systemNotificationManager: NotificationManager
+    private val nodeRepository: NodeRepository = mock(MockMode.autofill)
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
         systemNotificationManager = context.getSystemService(NotificationManager::class.java)!!
+        systemNotificationManager.cancelAll()
         clearManagedChannels()
+        every { nodeRepository.myNodeInfo } returns MutableStateFlow<MyNodeInfo?>(null)
     }
 
     @After
     fun tearDown() {
+        systemNotificationManager.cancelAll()
         clearManagedChannels()
     }
 
     @Test
-    fun `initChannels removes legacy categories and creates canonical channels`() {
+    fun `initChannels removes legacy categories and creates canonical channels`() = runWithRenderScope { renderScope ->
         NotificationChannels.LEGACY_CATEGORY_IDS.forEach(::createChannel)
-
-        val notifications =
-            MeshNotificationManagerImpl(
-                context = context,
-                packetRepository = lazy<PacketRepository> { error("Not used in this test") },
-                nodeRepository = lazy<NodeRepository> { error("Not used in this test") },
-                conversationShortcutPublisher = lazy { error("Not used in this test") },
-                radioConfigRepository = lazy { error("Not used in this test") },
-            )
-
+        val notifications = createManager(renderScope)
         notifications.initChannels()
 
         NotificationChannels.LEGACY_CATEGORY_IDS.forEach { legacyId ->
@@ -86,6 +103,66 @@ class MeshNotificationManagerImplTest {
             assertNotNull(systemNotificationManager.getNotificationChannel(channelId))
         }
     }
+
+    @Test
+    fun `initial foreground notification uses an immediate Android label fallback`() =
+        runWithRenderScope { renderScope ->
+            val notification = createManager(renderScope).getServiceNotification()
+            val title = notification.extras.getCharSequence(Notification.EXTRA_TITLE)?.toString()
+            val expected = context.applicationInfo.loadLabel(context.packageManager).toString()
+
+            assertEquals(expected, title)
+        }
+
+    @Test
+    fun `service state rendering is deferred from the caller`() = runWithRenderScope { renderScope ->
+        val notifications = createManager(renderScope)
+        notifications.initChannels()
+
+        notifications.updateServiceStateNotification(ConnectionState.Disconnected, populatedTelemetry())
+
+        assertNull(activeServiceNotification())
+        advanceUntilIdle()
+        assertNotNull(activeServiceNotification())
+    }
+
+    @Test
+    fun `newer service state cancels a pending render`() = runWithRenderScope { renderScope ->
+        val notifications = createManager(renderScope)
+        notifications.initChannels()
+
+        notifications.updateServiceStateNotification(ConnectionState.Connecting, populatedTelemetry())
+        notifications.updateServiceStateNotification(ConnectionState.Disconnected, populatedTelemetry())
+
+        advanceUntilIdle()
+        val title =
+            activeServiceNotification()?.notification?.extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
+        assertEquals(getString(Res.string.disconnected), title)
+    }
+
+    private fun runWithRenderScope(block: suspend TestScope.(CoroutineScope) -> Unit) = runTest {
+        val renderScope = CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())
+        try {
+            block(renderScope)
+        } finally {
+            renderScope.cancel()
+        }
+    }
+
+    private fun createManager(scope: CoroutineScope) = MeshNotificationManagerImpl(
+        context = context,
+        packetRepository = lazy<PacketRepository> { error("Not used in this test") },
+        nodeRepository = lazy { nodeRepository },
+        conversationShortcutPublisher = lazy { error("Not used in this test") },
+        radioConfigRepository = lazy { error("Not used in this test") },
+        scope = scope,
+    )
+
+    private fun populatedTelemetry() =
+        Telemetry(local_stats = LocalStats(uptime_seconds = 1, num_online_nodes = 1, num_total_nodes = 1))
+
+    private fun activeServiceNotification() =
+        systemNotificationManager.activeNotifications.singleOrNull { it.id == SERVICE_NOTIFY_ID }
 
     private fun createChannel(id: String) {
         systemNotificationManager.createNotificationChannel(

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
@@ -41,6 +41,7 @@ import org.meshtastic.core.repository.SERVICE_NOTIFY_ID
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.disconnected
 import org.meshtastic.core.resources.getString
+import org.meshtastic.core.resources.local_stats_nodes
 import org.meshtastic.core.testing.runWithRenderScope
 import org.meshtastic.proto.LocalStats
 import org.meshtastic.proto.Telemetry
@@ -48,6 +49,7 @@ import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34])
@@ -134,6 +136,41 @@ class MeshNotificationManagerImplTest {
         val title =
             activeServiceNotification()?.notification?.extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
         assertEquals(getString(Res.string.disconnected), title)
+    }
+
+    @Test
+    fun `identical service state can repost after notifications are cleared`() = runWithRenderScope { renderScope ->
+        val notifications = createManager(renderScope)
+        notifications.initChannels()
+        val telemetry = populatedTelemetry()
+
+        notifications.updateServiceStateNotification(ConnectionState.Disconnected, telemetry)
+        advanceUntilIdle()
+        // Align the replayed snapshot with the now-cached rendered message; the post-clear update is then identical.
+        notifications.updateServiceStateNotification(ConnectionState.Disconnected, telemetry)
+        advanceUntilIdle()
+
+        notifications.clearNotifications()
+        assertNull(activeServiceNotification())
+
+        notifications.updateServiceStateNotification(ConnectionState.Disconnected, telemetry)
+        advanceUntilIdle()
+        assertNotNull(activeServiceNotification())
+    }
+
+    @Test
+    fun `service state seeds local stats before the local node row is available`() = runWithRenderScope { renderScope ->
+        val stats = LocalStats(uptime_seconds = 1, num_online_nodes = 2, num_total_nodes = 3)
+        every { nodeRepository.localStats } returns MutableStateFlow(stats)
+        val notifications = createManager(renderScope)
+        notifications.initChannels()
+
+        notifications.updateServiceStateNotification(ConnectionState.Disconnected, telemetry = null)
+        advanceUntilIdle()
+
+        val text = activeServiceNotification()?.notification?.extras?.getCharSequence(Notification.EXTRA_TEXT)
+        assertNotNull(text)
+        assertTrue(text.contains(getString(Res.string.local_stats_nodes, 2, 3)))
     }
 
     private fun createManager(scope: CoroutineScope) = MeshNotificationManagerImpl(

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
@@ -27,13 +27,8 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -46,6 +41,7 @@ import org.meshtastic.core.repository.SERVICE_NOTIFY_ID
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.disconnected
 import org.meshtastic.core.resources.getString
+import org.meshtastic.core.testing.runWithRenderScope
 import org.meshtastic.proto.LocalStats
 import org.meshtastic.proto.Telemetry
 import org.robolectric.annotation.Config
@@ -138,15 +134,6 @@ class MeshNotificationManagerImplTest {
         val title =
             activeServiceNotification()?.notification?.extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
         assertEquals(getString(Res.string.disconnected), title)
-    }
-
-    private fun runWithRenderScope(block: suspend TestScope.(CoroutineScope) -> Unit) = runTest {
-        val renderScope = CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())
-        try {
-            block(renderScope)
-        } finally {
-            renderScope.cancel()
-        }
     }
 
     private fun createManager(scope: CoroutineScope) = MeshNotificationManagerImpl(

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
@@ -34,10 +34,10 @@ import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
@@ -158,7 +158,6 @@ class MeshNotificationManagerImpl(
     }
 
     private data class ServiceNotificationSnapshot(
-        val generation: Long,
         val state: ConnectionState,
         val localStats: LocalStats?,
         val deviceMetrics: DeviceMetrics?,
@@ -348,8 +347,12 @@ class MeshNotificationManagerImpl(
     private var nextStatsUpdateMillis: Long = 0
     private var cachedMessage: String? = null
     private var cachedServiceNotification: Notification? = null
-    private var serviceNotificationGeneration: Long = 0
-    private var serviceNotificationJob: Job? = null
+    private val serviceNotificationSnapshots =
+        MutableSharedFlow<ServiceNotificationSnapshot>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    init {
+        scope.launch { serviceNotificationSnapshots.collectLatest(::renderAndPostServiceNotification) }
+    }
 
     /**
      * Returns the last-built service state notification, or an immediately available application-label fallback. This
@@ -362,70 +365,42 @@ class MeshNotificationManagerImpl(
     }
 
     // region Public Notification Methods
-    @Suppress("TooGenericExceptionCaught")
     override fun updateServiceStateNotification(state: ConnectionState, telemetry: Telemetry?) {
-        val snapshot = synchronized(serviceNotificationLock) { captureServiceNotificationSnapshot(state, telemetry) }
-        // LAZY prevents the renderer from completing before its job is installed as the current generation.
-        val job =
-            scope.launch(start = CoroutineStart.LAZY) {
-                try {
-                    val rendered = renderServiceNotification(snapshot)
-                    commitServiceNotification(
-                        snapshot = snapshot,
-                        notification = rendered.notification,
-                        message = rendered.message,
-                    )
-                        ?.let { notification -> notificationManager.notify(SERVICE_NOTIFY_ID, notification) }
-                } catch (ex: CancellationException) {
-                    throw ex
-                } catch (ex: Exception) {
-                    Logger.e(ex) { "Failed to render service notification resources" }
-                    val fallback =
-                        createServiceStateNotification(
-                            name = applicationLabel,
-                            message = snapshot.previousMessage,
-                            nextUpdateAt = snapshot.nextUpdateAt,
-                        )
-                    commitServiceNotification(
-                        snapshot = snapshot,
-                        notification = fallback,
-                        message = snapshot.previousMessage,
-                    )
-                        ?.let { notification ->
-                            safeCatching { notificationManager.notify(SERVICE_NOTIFY_ID, notification) }
-                                .onFailure { Logger.e(it) { "Failed to post fallback service notification" } }
-                        }
-                }
-            }
-
-        val previousJob =
-            synchronized(serviceNotificationLock) {
-                if (snapshot.generation != serviceNotificationGeneration) {
-                    job.cancel()
-                    null
-                } else {
-                    serviceNotificationJob.also { serviceNotificationJob = job }
-                }
-            }
-        previousJob?.cancel()
-        job.start()
+        synchronized(serviceNotificationLock) {
+            serviceNotificationSnapshots.tryEmit(captureServiceNotificationSnapshot(state, telemetry))
+        }
     }
 
     /**
-     * Commits a rendered notification only while its captured generation is still current. The Android notification
-     * Binder call intentionally happens after this method returns so foreground startup and state snapshots never wait
-     * behind notification-manager IPC while holding [serviceNotificationLock].
+     * Renders service notifications in one ordered collector. [collectLatest] cancels obsolete resource work and does
+     * not start the next renderer until the previous block has completed, so Binder notification posts cannot overtake
+     * one another and leave stale text visible.
      */
-    private fun commitServiceNotification(
-        snapshot: ServiceNotificationSnapshot,
-        notification: Notification,
-        message: String?,
-    ): Notification? = synchronized(serviceNotificationLock) {
-        if (snapshot.generation != serviceNotificationGeneration) return@synchronized null
-        cachedMessage = message
-        cachedServiceNotification = notification
-        serviceNotificationJob = null
-        notification
+    private suspend fun renderAndPostServiceNotification(snapshot: ServiceNotificationSnapshot) {
+        safeCatching {
+            val rendered = renderServiceNotification(snapshot)
+            postServiceNotification(rendered.notification, rendered.message)
+        }
+            .onFailure { ex ->
+                Logger.e(ex) { "Failed to render service notification resources" }
+                val fallback =
+                    createServiceStateNotification(
+                        name = applicationLabel,
+                        message = snapshot.previousMessage,
+                        nextUpdateAt = snapshot.nextUpdateAt,
+                    )
+                safeCatching { postServiceNotification(fallback, snapshot.previousMessage) }
+                    .onFailure { Logger.e(it) { "Failed to post fallback service notification" } }
+            }
+    }
+
+    /** Updates the foreground fallback cache before posting the same notification through Android's Binder API. */
+    private fun postServiceNotification(notification: Notification, message: String?) {
+        synchronized(serviceNotificationLock) {
+            cachedMessage = message
+            cachedServiceNotification = notification
+        }
+        notificationManager.notify(SERVICE_NOTIFY_ID, notification)
     }
 
     private fun captureServiceNotificationSnapshot(
@@ -444,18 +419,15 @@ class MeshNotificationManagerImpl(
         if (cachedLocalStats == null || cachedDeviceMetrics == null) {
             val repo = nodeRepository.value
             val myNodeNum = repo.myNodeInfo.value?.myNodeNum
-            if (myNodeNum != null) {
-                repo.nodeDBbyNum.value[myNodeNum]?.let { node ->
-                    if (cachedDeviceMetrics == null) cachedDeviceMetrics = node.deviceMetrics
-                    if (cachedLocalStats == null) {
-                        cachedLocalStats = repo.localStats.value.takeIf { it.uptime_seconds != 0 }
-                    }
-                }
+            if (cachedDeviceMetrics == null && myNodeNum != null) {
+                cachedDeviceMetrics = repo.nodeDBbyNum.value[myNodeNum]?.deviceMetrics
+            }
+            if (cachedLocalStats == null) {
+                cachedLocalStats = repo.localStats.value.takeIf { it.uptime_seconds != 0 }
             }
         }
 
         return ServiceNotificationSnapshot(
-            generation = ++serviceNotificationGeneration,
             state = state,
             localStats = cachedLocalStats,
             deviceMetrics = cachedDeviceMetrics,

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
@@ -33,8 +33,15 @@ import androidx.core.content.LocusIdCompat
 import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.NumberFormatter
 import org.meshtastic.core.common.util.nowMillis
@@ -60,6 +67,7 @@ import org.meshtastic.core.resources.connecting
 import org.meshtastic.core.resources.device_sleeping
 import org.meshtastic.core.resources.disconnected
 import org.meshtastic.core.resources.getString
+import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.resources.local_stats_bad
 import org.meshtastic.core.resources.local_stats_battery
 import org.meshtastic.core.resources.local_stats_diagnostics_prefix
@@ -114,6 +122,7 @@ class MeshNotificationManagerImpl(
     private val nodeRepository: Lazy<NodeRepository>,
     private val conversationShortcutPublisher: Lazy<ConversationShortcutPublisher>,
     private val radioConfigRepository: Lazy<RadioConfigRepository>,
+    @Named("ServiceScope") private val scope: CoroutineScope,
 ) : MeshNotificationManager {
 
     private val notificationManager =
@@ -146,6 +155,17 @@ class MeshNotificationManagerImpl(
         private const val TAG_LOW_BATTERY = "low_battery"
         private const val TAG_CLIENT = "client"
     }
+
+    private data class ServiceNotificationSnapshot(
+        val generation: Long,
+        val state: ConnectionState,
+        val localStats: LocalStats?,
+        val deviceMetrics: DeviceMetrics?,
+        val previousMessage: String?,
+        val nextUpdateAt: Long,
+    )
+
+    private data class RenderedServiceNotification(val notification: Notification, val message: String)
 
     /**
      * Caches generated avatar icons keyed by (person id + short name + colors) so a conversation rebuild does not
@@ -318,93 +338,155 @@ class MeshNotificationManagerImpl(
         notificationManager.createNotificationChannel(channel)
     }
 
+    private val serviceNotificationLock = Any()
+    private val applicationLabel: String by lazy {
+        context.applicationInfo.loadLabel(context.packageManager).toString().ifBlank { context.packageName }
+    }
     private var cachedDeviceMetrics: DeviceMetrics? = null
     private var cachedLocalStats: LocalStats? = null
     private var nextStatsUpdateMillis: Long = 0
     private var cachedMessage: String? = null
     private var cachedServiceNotification: Notification? = null
+    private var serviceNotificationGeneration: Long = 0
+    private var serviceNotificationJob: Job? = null
 
     /**
-     * Returns the last-built service state notification, or builds a default one if none exists. This is used by
-     * [MeshService] for [android.app.Service.startForeground].
+     * Returns the last-built service state notification, or an immediately available application-label fallback. This
+     * method is used by [MeshService] for [android.app.Service.startForeground], so it must not wait for Compose
+     * Multiplatform resource loading.
      */
-    fun getServiceNotification(): Notification = cachedServiceNotification
-        ?: createServiceStateNotification(
-            name = getString(Res.string.meshtastic_app_name),
-            message = null,
-            nextUpdateAt = 0,
-        )
+    fun getServiceNotification(): Notification {
+        val cached = synchronized(serviceNotificationLock) { cachedServiceNotification }
+        return cached ?: createServiceStateNotification(name = applicationLabel, message = null, nextUpdateAt = 0)
+    }
 
     // region Public Notification Methods
-    @Suppress("CyclomaticComplexMethod", "NestedBlockDepth")
+    @Suppress("TooGenericExceptionCaught")
     override fun updateServiceStateNotification(state: ConnectionState, telemetry: Telemetry?) {
-        val summaryString =
-            when (state) {
-                is ConnectionState.Connected ->
-                    getString(Res.string.meshtastic_app_name) + ": " + getString(Res.string.connected)
-
-                is ConnectionState.Disconnected -> getString(Res.string.disconnected)
-
-                is ConnectionState.DeviceSleep -> getString(Res.string.device_sleeping)
-
-                is ConnectionState.Connecting -> getString(Res.string.connecting)
+        val snapshot = synchronized(serviceNotificationLock) { captureServiceNotificationSnapshot(state, telemetry) }
+        // LAZY prevents the renderer from completing before its job is installed as the current generation.
+        val job =
+            scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    val rendered = renderServiceNotification(snapshot)
+                    commitServiceNotification(
+                        snapshot = snapshot,
+                        notification = rendered.notification,
+                        message = rendered.message,
+                    )
+                        ?.let { notification -> notificationManager.notify(SERVICE_NOTIFY_ID, notification) }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Logger.e(ex) { "Failed to render service notification resources" }
+                    val fallback =
+                        createServiceStateNotification(
+                            name = applicationLabel,
+                            message = snapshot.previousMessage,
+                            nextUpdateAt = snapshot.nextUpdateAt,
+                        )
+                    commitServiceNotification(
+                        snapshot = snapshot,
+                        notification = fallback,
+                        message = snapshot.previousMessage,
+                    )
+                        ?.let { notification -> notificationManager.notify(SERVICE_NOTIFY_ID, notification) }
+                }
             }
 
-        // Update caches if telemetry is provided
-        telemetry?.let { t ->
-            t.local_stats?.let { stats ->
+        val previousJob =
+            synchronized(serviceNotificationLock) {
+                if (snapshot.generation != serviceNotificationGeneration) {
+                    job.cancel()
+                    null
+                } else {
+                    serviceNotificationJob.also { serviceNotificationJob = job }
+                }
+            }
+        previousJob?.cancel()
+        job.start()
+    }
+
+    /**
+     * Commits a rendered notification only while its captured generation is still current. The Android notification
+     * Binder call intentionally happens after this method returns so foreground startup and state snapshots never wait
+     * behind notification-manager IPC while holding [serviceNotificationLock].
+     */
+    private fun commitServiceNotification(
+        snapshot: ServiceNotificationSnapshot,
+        notification: Notification,
+        message: String?,
+    ): Notification? = synchronized(serviceNotificationLock) {
+        if (snapshot.generation != serviceNotificationGeneration) return@synchronized null
+        cachedMessage = message
+        cachedServiceNotification = notification
+        serviceNotificationJob = null
+        notification
+    }
+
+    private fun captureServiceNotificationSnapshot(
+        state: ConnectionState,
+        telemetry: Telemetry?,
+    ): ServiceNotificationSnapshot {
+        telemetry?.let { currentTelemetry ->
+            currentTelemetry.local_stats?.let { stats ->
                 cachedLocalStats = stats
                 nextStatsUpdateMillis = nowMillis + STATS_UPDATE_INTERVAL.inWholeMilliseconds
             }
-            t.device_metrics?.let { metrics -> cachedDeviceMetrics = metrics }
+            currentTelemetry.device_metrics?.let { metrics -> cachedDeviceMetrics = metrics }
         }
 
-        // Seeding from database if caches are still null (e.g. on restart or reconnection)
+        // Seed from database if the in-memory telemetry cache is empty after a process or transport restart.
         if (cachedLocalStats == null || cachedDeviceMetrics == null) {
             val repo = nodeRepository.value
             val myNodeNum = repo.myNodeInfo.value?.myNodeNum
             if (myNodeNum != null) {
-                // Use .value instead of runBlocking { .first() } to avoid potential deadlock
-                // if called on the same dispatcher the Flow's upstream coroutine needs.
-                val nodes = repo.nodeDBbyNum.value
-                nodes[myNodeNum]?.let { node ->
-                    if (cachedDeviceMetrics == null) {
-                        cachedDeviceMetrics = node.deviceMetrics
-                    }
+                repo.nodeDBbyNum.value[myNodeNum]?.let { node ->
+                    if (cachedDeviceMetrics == null) cachedDeviceMetrics = node.deviceMetrics
                     if (cachedLocalStats == null) {
-                        // Fallback to DB stats if repository hasn't received any fresh ones yet
                         cachedLocalStats = repo.localStats.value.takeIf { it.uptime_seconds != 0 }
                     }
                 }
             }
         }
 
-        val stats = cachedLocalStats
-        val metrics = cachedDeviceMetrics
+        return ServiceNotificationSnapshot(
+            generation = ++serviceNotificationGeneration,
+            state = state,
+            localStats = cachedLocalStats,
+            deviceMetrics = cachedDeviceMetrics,
+            previousMessage = cachedMessage,
+            nextUpdateAt = nextStatsUpdateMillis,
+        )
+    }
 
-        val message =
-            when {
-                stats != null -> stats.formatToString(metrics?.battery_level)
-                metrics != null -> metrics.formatToString()
-                else -> null
+    private suspend fun renderServiceNotification(snapshot: ServiceNotificationSnapshot): RenderedServiceNotification {
+        val title =
+            when (snapshot.state) {
+                is ConnectionState.Connected ->
+                    getStringSuspend(Res.string.meshtastic_app_name) + ": " + getStringSuspend(Res.string.connected)
+
+                is ConnectionState.Disconnected -> getStringSuspend(Res.string.disconnected)
+
+                is ConnectionState.DeviceSleep -> getStringSuspend(Res.string.device_sleeping)
+
+                is ConnectionState.Connecting -> getStringSuspend(Res.string.connecting)
             }
 
-        // Only update cachedMessage if we have something new, otherwise keep what we have.
-        // Fallback to "No Stats Available" only if we truly have nothing.
-        if (message != null) {
-            cachedMessage = message
-        } else if (cachedMessage == null) {
-            cachedMessage = getString(Res.string.no_local_stats)
-        }
+        val freshMessage =
+            when {
+                snapshot.localStats != null ->
+                    snapshot.localStats.formatToStringSuspend(snapshot.deviceMetrics?.battery_level)
 
-        val notification =
-            createServiceStateNotification(
-                name = summaryString.orEmpty(),
-                message = cachedMessage,
-                nextUpdateAt = nextStatsUpdateMillis,
-            )
-        cachedServiceNotification = notification
-        notificationManager.notify(SERVICE_NOTIFY_ID, notification)
+                snapshot.deviceMetrics != null -> snapshot.deviceMetrics.formatToStringSuspend()
+
+                else -> null
+            }
+        val message = freshMessage ?: snapshot.previousMessage ?: getStringSuspend(Res.string.no_local_stats)
+        return RenderedServiceNotification(
+            notification = createServiceStateNotification(title, message, snapshot.nextUpdateAt),
+            message = message,
+        )
     }
 
     override suspend fun updateMessageNotification(
@@ -994,20 +1076,20 @@ class MeshNotificationManagerImpl(
 
     // region Extension Functions (Localized)
 
-    private fun LocalStats.formatToString(batteryLevel: Int? = null): String {
+    private suspend fun LocalStats.formatToStringSuspend(batteryLevel: Int? = null): String {
         val parts = mutableListOf<String>()
         batteryLevel?.let {
             if (it > MAX_BATTERY_LEVEL) {
-                parts.add(BULLET + getString(Res.string.powered))
+                parts.add(BULLET + getStringSuspend(Res.string.powered))
             } else {
-                parts.add(BULLET + getString(Res.string.local_stats_battery, it))
+                parts.add(BULLET + getStringSuspend(Res.string.local_stats_battery, it))
             }
         }
-        parts.add(BULLET + getString(Res.string.local_stats_nodes, num_online_nodes, num_total_nodes))
-        parts.add(BULLET + getString(Res.string.local_stats_uptime, formatUptime(uptime_seconds)))
+        parts.add(BULLET + getStringSuspend(Res.string.local_stats_nodes, num_online_nodes, num_total_nodes))
+        parts.add(BULLET + getStringSuspend(Res.string.local_stats_uptime, formatUptime(uptime_seconds)))
         parts.add(
             BULLET +
-                getString(
+                getStringSuspend(
                     Res.string.local_stats_utilization,
                     NumberFormatter.format(channel_utilization.toDouble(), 2),
                     NumberFormatter.format(air_util_tx.toDouble(), 2),
@@ -1017,45 +1099,48 @@ class MeshNotificationManagerImpl(
         if (heap_free_bytes > 0 || heap_total_bytes > 0) {
             parts.add(
                 BULLET +
-                    getString(Res.string.local_stats_heap) +
+                    getStringSuspend(Res.string.local_stats_heap) +
                     ": " +
-                    getString(Res.string.local_stats_heap_value, heap_free_bytes, heap_total_bytes),
+                    getStringSuspend(Res.string.local_stats_heap_value, heap_free_bytes, heap_total_bytes),
             )
         }
 
         // Traffic Stats
         if (num_packets_tx > 0 || num_packets_rx > 0) {
-            parts.add(BULLET + getString(Res.string.local_stats_traffic, num_packets_tx, num_packets_rx, num_rx_dupe))
+            parts.add(
+                BULLET + getStringSuspend(Res.string.local_stats_traffic, num_packets_tx, num_packets_rx, num_rx_dupe),
+            )
         }
         if (num_tx_relay > 0) {
-            parts.add(BULLET + getString(Res.string.local_stats_relays, num_tx_relay, num_tx_relay_canceled))
+            parts.add(BULLET + getStringSuspend(Res.string.local_stats_relays, num_tx_relay, num_tx_relay_canceled))
         }
 
         // Diagnostic Fields
         val diagnosticParts = mutableListOf<String>()
-        if (noise_floor != 0) diagnosticParts.add(getString(Res.string.local_stats_noise, noise_floor))
+        if (noise_floor != 0) diagnosticParts.add(getStringSuspend(Res.string.local_stats_noise, noise_floor))
         if (num_packets_rx_bad > 0) {
-            diagnosticParts.add(getString(Res.string.local_stats_bad, num_packets_rx_bad))
+            diagnosticParts.add(getStringSuspend(Res.string.local_stats_bad, num_packets_rx_bad))
         }
-        if (num_tx_dropped > 0) diagnosticParts.add(getString(Res.string.local_stats_dropped, num_tx_dropped))
+        if (num_tx_dropped > 0) diagnosticParts.add(getStringSuspend(Res.string.local_stats_dropped, num_tx_dropped))
 
         if (diagnosticParts.isNotEmpty()) {
             parts.add(
-                BULLET + getString(Res.string.local_stats_diagnostics_prefix, diagnosticParts.joinToString(" | ")),
+                BULLET +
+                    getStringSuspend(Res.string.local_stats_diagnostics_prefix, diagnosticParts.joinToString(" | ")),
             )
         }
 
         return parts.joinToString("\n")
     }
 
-    private fun DeviceMetrics.formatToString(): String {
+    private suspend fun DeviceMetrics.formatToStringSuspend(): String {
         val parts = mutableListOf<String>()
-        battery_level?.let { parts.add(BULLET + getString(Res.string.local_stats_battery, it)) }
-        uptime_seconds?.let { parts.add(BULLET + getString(Res.string.local_stats_uptime, formatUptime(it))) }
+        battery_level?.let { parts.add(BULLET + getStringSuspend(Res.string.local_stats_battery, it)) }
+        uptime_seconds?.let { parts.add(BULLET + getStringSuspend(Res.string.local_stats_uptime, formatUptime(it))) }
         if (channel_utilization != null || air_util_tx != null) {
             parts.add(
                 BULLET +
-                    getString(
+                    getStringSuspend(
                         Res.string.local_stats_utilization,
                         NumberFormatter.format((channel_utilization ?: 0f).toDouble(), 2),
                         NumberFormatter.format((air_util_tx ?: 0f).toDouble(), 2),

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
@@ -45,6 +45,7 @@ import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.NumberFormatter
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.model.Channel
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Message
@@ -390,7 +391,10 @@ class MeshNotificationManagerImpl(
                         notification = fallback,
                         message = snapshot.previousMessage,
                     )
-                        ?.let { notification -> notificationManager.notify(SERVICE_NOTIFY_ID, notification) }
+                        ?.let { notification ->
+                            safeCatching { notificationManager.notify(SERVICE_NOTIFY_ID, notification) }
+                                .onFailure { Logger.e(it) { "Failed to post fallback service notification" } }
+                        }
                 }
             }
 

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
@@ -132,6 +132,8 @@ class MeshService : Service() {
             return START_NOT_STICKY
         }
 
+        // Queue the localized status render asynchronously. startForeground uses the last cached notification, or an
+        // immediate application-label fallback, and the renderer updates the same notification ID when it completes.
         connectionManager.updateStatusNotification()
         val notification = androidNotifications.getServiceNotification()
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/TestScopes.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/TestScopes.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.testing
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+
+/** Runs a test with a structured child scope driven by the test scheduler and always cancels it afterward. */
+fun runWithRenderScope(block: suspend TestScope.(CoroutineScope) -> Unit) = runTest {
+    val renderScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job(coroutineContext[Job]))
+    try {
+        block(renderScope)
+    } finally {
+        renderScope.cancel()
+    }
+}

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
@@ -174,7 +174,7 @@ fun Snr(snr: Float, modifier: Modifier = Modifier, modemPreset: ModemPreset? = L
 }
 
 @Composable
-fun Rssi(rssi: Int, modifier: Modifier = Modifier) {
+fun Rssi(rssi: Int, modifier: Modifier = Modifier, label: String = stringResource(Res.string.rssi)) {
     val color: Color =
         if (rssi > RSSI_GOOD_THRESHOLD) {
             Quality.GOOD.color.invoke()
@@ -185,7 +185,7 @@ fun Rssi(rssi: Int, modifier: Modifier = Modifier) {
         }
     Text(
         modifier = modifier,
-        text = "${stringResource(Res.string.rssi)} ${MetricFormatter.rssi(rssi)}",
+        text = "$label ${MetricFormatter.rssi(rssi)}",
         color = color,
         style = MaterialTheme.typography.labelSmall,
     )

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MaterialBatteryInfo.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MaterialBatteryInfo.kt
@@ -58,8 +58,9 @@ fun MaterialBatteryInfo(
     level: Int?,
     voltage: Float? = null,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    unknownLabel: String = stringResource(Res.string.unknown),
 ) {
-    val levelString = level?.let { MetricFormatter.percent(it) } ?: stringResource(Res.string.unknown)
+    val levelString = level?.let { MetricFormatter.percent(it) } ?: unknownLabel
 
     Row(
         modifier = modifier,
@@ -71,7 +72,7 @@ fun MaterialBatteryInfo(
                 modifier = Modifier.size(SIZE_ICON.dp),
                 imageVector = MeshtasticIcons.BatteryUnknown,
                 tint = contentColor.copy(alpha = 0.65f),
-                contentDescription = stringResource(Res.string.unknown),
+                contentDescription = unknownLabel,
             )
         } else if (level > 100) {
             Icon(

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicatorUiTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicatorUiTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.component
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.ui.theme.AppTheme
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LoraSignalIndicatorUiTest {
+
+    @Test
+    fun rssiUsesCallerProvidedLabel() = runComposeUiTest {
+        setContent { AppTheme { Rssi(rssi = -70, label = "Signal strength") } }
+
+        onNodeWithText("Signal strength -70 dBm").assertIsDisplayed()
+    }
+
+    @Test
+    fun batteryUsesCallerProvidedUnknownLabel() = runComposeUiTest {
+        setContent { AppTheme { MaterialBatteryInfo(level = null, unknownLabel = "Unavailable") } }
+
+        onNodeWithContentDescription("Unavailable").assertIsDisplayed()
+    }
+}

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -244,9 +244,9 @@ fun ConnectionsScreen(
         )
     }
 
-    // Work around CMP-6615: Android stringResource currently enters a blocking resource state. Keep these stable
-    // slots outside AnimatedContent so connection-state transitions do not re-enter resource loading while the main
-    // thread is applying an animation frame.
+    // Work around CMP-6615 in Compose Multiplatform 1.11.1: Android stringResource enters a blocking resource state.
+    // Keep these stable slots outside AnimatedContent so connection-state transitions do not re-enter resource loading
+    // while the main thread is applying an animation frame.
     val firmwareVersion =
         ourNode
             ?.metadata

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -67,6 +67,7 @@ import org.meshtastic.core.navigation.SettingsRoute
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.bluetooth_disabled
 import org.meshtastic.core.resources.connections
+import org.meshtastic.core.resources.disconnect
 import org.meshtastic.core.resources.firmware_event_ended_banner
 import org.meshtastic.core.resources.firmware_event_ended_button
 import org.meshtastic.core.resources.firmware_recovery_banner
@@ -77,10 +78,13 @@ import org.meshtastic.core.resources.firmware_update_notification_android
 import org.meshtastic.core.resources.firmware_update_notification_flasher
 import org.meshtastic.core.resources.firmware_update_open
 import org.meshtastic.core.resources.firmware_update_open_flasher
+import org.meshtastic.core.resources.firmware_version
 import org.meshtastic.core.resources.no_device_selected
 import org.meshtastic.core.resources.open_bluetooth_settings
 import org.meshtastic.core.resources.open_wifi_settings
+import org.meshtastic.core.resources.rssi
 import org.meshtastic.core.resources.set_your_region
+import org.meshtastic.core.resources.unknown
 import org.meshtastic.core.resources.unknown_device
 import org.meshtastic.core.resources.wifi_unavailable
 import org.meshtastic.core.ui.component.AdaptiveTwoPane
@@ -109,6 +113,7 @@ import org.meshtastic.feature.connections.ScannerViewModel
 import org.meshtastic.feature.connections.model.DeviceListEntry
 import org.meshtastic.feature.connections.ui.components.ConnectingDeviceInfo
 import org.meshtastic.feature.connections.ui.components.CurrentlyConnectedInfo
+import org.meshtastic.feature.connections.ui.components.CurrentlyConnectedText
 import org.meshtastic.feature.connections.ui.components.DeviceList
 import org.meshtastic.feature.connections.ui.components.TransportSelector
 import org.meshtastic.feature.settings.navigation.ConfigRoute
@@ -239,6 +244,23 @@ fun ConnectionsScreen(
         )
     }
 
+    // Work around CMP-6615: Android stringResource currently enters a blocking resource state. Keep these stable
+    // slots outside AnimatedContent so connection-state transitions do not re-enter resource loading while the main
+    // thread is applying an animation frame.
+    val firmwareVersion =
+        ourNode
+            ?.metadata
+            ?.firmware_version
+            ?.takeIf { it.isNotBlank() }
+            ?.let { stringResource(Res.string.firmware_version, it) }
+    val currentlyConnectedText =
+        CurrentlyConnectedText(
+            unknownLabel = stringResource(Res.string.unknown),
+            rssiLabel = stringResource(Res.string.rssi),
+            disconnectLabel = stringResource(Res.string.disconnect),
+            firmwareVersion = firmwareVersion,
+        )
+
     Scaffold(
         topBar = {
             MainAppBar(
@@ -294,6 +316,7 @@ fun ConnectionsScreen(
                                                 ourNode = ourNode,
                                                 selectedDevice = selectedDevice,
                                                 bleDevices = bleDevices,
+                                                text = currentlyConnectedText,
                                                 onNavigateToNodeDetails = onNavigateToNodeDetails,
                                                 onClickDisconnect = { scanModel.disconnect() },
                                             )
@@ -550,12 +573,14 @@ private fun ConnectedDeviceContent(
     ourNode: org.meshtastic.core.model.Node?,
     selectedDevice: String,
     bleDevices: List<DeviceListEntry>,
+    text: CurrentlyConnectedText,
     onNavigateToNodeDetails: (Int) -> Unit,
     onClickDisconnect: () -> Unit,
 ) {
     ourNode?.let { node ->
         CurrentlyConnectedInfo(
             node = node,
+            text = text,
             bleDevice = bleDevices.find { it.fullAddress == selectedDevice } as DeviceListEntry.Ble?,
             onNavigateToNodeDetails = onNavigateToNodeDetails,
             onClickDisconnect = onClickDisconnect,

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfo.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfo.kt
@@ -42,7 +42,12 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
+import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.disconnect
+import org.meshtastic.core.resources.rssi
+import org.meshtastic.core.resources.unknown
 import org.meshtastic.core.ui.component.MaterialBatteryInfo
 import org.meshtastic.core.ui.component.NodeChip
 import org.meshtastic.core.ui.component.Rssi
@@ -138,9 +143,9 @@ private fun CurrentlyConnectedInfoPreview() {
             ),
             text =
             CurrentlyConnectedText(
-                unknownLabel = "Unknown",
-                rssiLabel = "RSSI",
-                disconnectLabel = "Disconnect",
+                unknownLabel = stringResource(Res.string.unknown),
+                rssiLabel = stringResource(Res.string.rssi),
+                disconnectLabel = stringResource(Res.string.disconnect),
                 firmwareVersion = null,
             ),
             onNavigateToNodeDetails = {},

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfo.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfo.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -41,10 +42,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
-import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.model.Node
-import org.meshtastic.core.resources.Res
-import org.meshtastic.core.resources.firmware_version
 import org.meshtastic.core.ui.component.MaterialBatteryInfo
 import org.meshtastic.core.ui.component.NodeChip
 import org.meshtastic.core.ui.component.Rssi
@@ -58,10 +56,20 @@ import kotlin.time.Duration.Companion.seconds
 private const val RSSI_DELAY = 2
 private const val RSSI_TIMEOUT = 1
 
+/** Plain text resolved outside the animated connected-device subtree. */
+@Immutable
+data class CurrentlyConnectedText(
+    val unknownLabel: String,
+    val rssiLabel: String,
+    val disconnectLabel: String,
+    val firmwareVersion: String?,
+)
+
 @Suppress("LoopWithTooManyJumpStatements", "TooGenericExceptionCaught")
 @Composable
 fun CurrentlyConnectedInfo(
     node: Node,
+    text: CurrentlyConnectedText,
     onNavigateToNodeDetails: (Int) -> Unit,
     onClickDisconnect: () -> Unit,
     modifier: Modifier = Modifier,
@@ -89,9 +97,9 @@ fun CurrentlyConnectedInfo(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            MaterialBatteryInfo(level = node.batteryLevel, voltage = node.voltage)
+            MaterialBatteryInfo(level = node.batteryLevel, voltage = node.voltage, unknownLabel = text.unknownLabel)
             if (bleDevice != null) {
-                Rssi(rssi = rssi)
+                Rssi(rssi = rssi, label = text.rssiLabel)
             }
         }
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -100,21 +108,18 @@ fun CurrentlyConnectedInfo(
             Column(modifier = Modifier.weight(1f, fill = true)) {
                 Text(text = node.user.long_name, style = MaterialTheme.typography.titleMediumEmphasized)
 
-                node.metadata
-                    ?.firmware_version
-                    ?.takeIf { it.isNotBlank() }
-                    ?.let { firmwareVersion ->
-                        Text(
-                            text = stringResource(Res.string.firmware_version, firmwareVersion),
-                            style = MaterialTheme.typography.bodySmall,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
+                text.firmwareVersion?.let { firmwareVersion ->
+                    Text(
+                        text = firmwareVersion,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
         }
 
-        DisconnectButton(onClick = onClickDisconnect)
+        DisconnectButton(onClick = onClickDisconnect, label = text.disconnectLabel)
     }
 }
 
@@ -130,6 +135,13 @@ private fun CurrentlyConnectedInfoPreview() {
                 isIgnored = false,
                 paxcounter = Paxcount(ble = 10, wifi = 5),
                 environmentMetrics = EnvironmentMetrics(temperature = 25f, relative_humidity = 60f),
+            ),
+            text =
+            CurrentlyConnectedText(
+                unknownLabel = "Unknown",
+                rssiLabel = "RSSI",
+                disconnectLabel = "Disconnect",
+                firmwareVersion = null,
             ),
             onNavigateToNodeDetails = {},
             onClickDisconnect = {},

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfo.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfo.kt
@@ -61,7 +61,12 @@ import kotlin.time.Duration.Companion.seconds
 private const val RSSI_DELAY = 2
 private const val RSSI_TIMEOUT = 1
 
-/** Plain text resolved outside the animated connected-device subtree. */
+/**
+ * Plain text resolved outside the animated connected-device subtree.
+ *
+ * TODO(CMP-6615): Remove this bundle and the caller-provided component labels after upgrading from Compose
+ *   Multiplatform 1.11.1 to a release containing the Android resource-loading fix.
+ */
 @Immutable
 data class CurrentlyConnectedText(
     val unknownLabel: String,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR reduces work on the Android foreground “service state” notification path by changing it from synchronous rebuilding to an async, cancelable, snapshot-driven renderer. It also improves test determinism and isolation for notification rendering. Separately, it refactors parts of the UI to make certain labels configurable, precomputes “currently connected” card text to keep `stringResource` stable across connection-state transitions (CMP workaround), and adds/expands Compose and notification tests to cover the updated behavior.

## Key changes

### Features / UI improvements
- Made RSSI label configurable in the LoRa signal indicator:
  - `Rssi(rssi: Int, ..., label: String = stringResource(Res.string.rssi))`
- Made battery “unknown/unavailable” label configurable:
  - `MaterialBatteryInfo(..., unknownLabel: String = stringResource(Res.string.unknown))`
- Introduced a shared UI text model for the “currently connected” card:
  - Added `CurrentlyConnectedText(unknownLabel, rssiLabel, disconnectLabel, firmwareVersion?)`
  - `ConnectionsScreen` now precomputes `CurrentlyConnectedText` outside `AnimatedContent` so `stringResource` calls don’t change across connection-state transitions
  - `CurrentlyConnectedInfo` now renders from `text: CurrentlyConnectedText` and renders firmware version via the provided model (`Text` with ellipsis overflow)
- Added Compose UI tests covering caller-provided RSSI label and caller-provided battery unknown label.

### Fixes / behavioral correctness (notifications)
- Foreground service notification updates now have immediate fallback content:
  - `startForeground`/`getServiceNotification()` can return a notification using a lazily resolved application label while async rendering updates the notification later.
- Updated “service state” notification rendering to be cancelable and consistent:
  - `updateServiceStateNotification()` now emits a `ServiceNotificationSnapshot` into a shared flow
  - an init coroutine collects with `collectLatest` so newer snapshots cancel obsolete rendering work
  - localized title/message rendering happens asynchronously; on non-cancellation errors it falls back to cached snapshot data
- Notification test determinism and cleanup:
  - tests now drive async rendering with `advanceUntilIdle()` before asserting notification contents
  - test teardown also cancels active posted notifications via `systemNotificationManager.cancelAll()`
  - notification managers are created per test to avoid shared state across tests

### Refactors
- Refactored `MeshNotificationManagerImpl` “service state” notification pipeline:
  - added injected coroutine scope: `@Named("ServiceScope") scope: CoroutineScope`
  - introduced snapshot-driven types (`ServiceNotificationSnapshot`, `RenderedServiceNotification`)
  - protected cached message/notification fields with a lock during posting
- Refactored telemetry string formatting to async-friendly localized suspend APIs:
  - converted formatting to suspend variants (e.g., `formatToStringSuspend`, `DeviceMetrics.formatToStringSuspend`)
  - updated battery/heap/traffic/relay/diagnostic string construction to use suspend string assembly and localized formatting
- Added test helper for coroutine rendering:
  - `runWithRenderScope` creates a child scope tied to the `runTest` scheduler and always cancels it afterward
- Refactored notification tests to use per-test managers and `runWithRenderScope`:
  - conversation/active notification tests now build a fresh manager per test and initialize channels in that isolated instance

## Breaking changes / migration notes
- `MeshNotificationManagerImpl` constructor now requires an injected coroutine scope:
  - ensure DI/test wiring provides `@Named("ServiceScope") CoroutineScope`
- `CurrentlyConnectedInfo` API changed:
  - it now requires `text: CurrentlyConnectedText`; update callers (notably `ConnectionsScreen`) to construct and pass this model
- UI component signature changes:
  - `Rssi` now accepts an optional `label` parameter
  - `MaterialBatteryInfo` now accepts an optional `unknownLabel` parameter
<!-- end of auto-generated comment: release notes by coderabbit.ai -->