### PR TITLE
Fix profile import sequencing and restoration error handling

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -789,6 +789,7 @@ ignore_mqtt
 ignore_remove
 ### IMPORT ###
 import_configuration
+import_configuration_failed
 import_export_label
 import_known_shared_contact_text
 import_label
@@ -802,6 +803,8 @@ insert
 insert_link_message
 insert_link_title
 insert_link_url_hint
+install_configuration_bluetooth_repair_hint
+install_configuration_failed
 installed_firmware_version
 internal
 interval_always_on

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
@@ -33,6 +33,7 @@ import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.TelemetryType
 import org.meshtastic.core.model.util.isWithinSizeLimit
+import org.meshtastic.core.repository.AwaitedSendResult
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
@@ -90,6 +91,8 @@ class CommandSenderImpl(
     override fun getCachedChannelSet(): ChannelSet = channelSet.value
 
     override fun getCurrentPacketId(): Long = currentPacketId.value
+
+    private fun Int.nonZeroRequestId(): Int = takeUnless { it == 0 } ?: generatePacketId()
 
     override fun generatePacketId(): Int {
         val numPacketIds = ((1L shl PACKET_ID_SHIFT_BITS) - 1)
@@ -178,20 +181,30 @@ class CommandSenderImpl(
     override suspend fun sendAdmin(destNum: Int, requestId: Int, wantResponse: Boolean, initFn: () -> AdminMessage) {
         val adminMsg = initFn().copy(session_passkey = sessionManager.getPasskey(destNum))
         val packet =
-            buildAdminPacket(to = destNum, id = requestId, wantResponse = wantResponse, adminMessage = adminMsg)
+            buildAdminPacket(
+                to = destNum,
+                id = requestId.nonZeroRequestId(),
+                wantResponse = wantResponse,
+                adminMessage = adminMsg,
+            )
         packetHandler.sendToRadio(packet)
     }
 
-    override suspend fun sendAdminAwait(
+    override suspend fun sendAdminAwaitResult(
         destNum: Int,
         requestId: Int,
         wantResponse: Boolean,
         initFn: () -> AdminMessage,
-    ): Boolean {
+    ): AwaitedSendResult {
         val adminMsg = initFn().copy(session_passkey = sessionManager.getPasskey(destNum))
         val packet =
-            buildAdminPacket(to = destNum, id = requestId, wantResponse = wantResponse, adminMessage = adminMsg)
-        return packetHandler.sendToRadioAndAwait(packet)
+            buildAdminPacket(
+                to = destNum,
+                id = requestId.nonZeroRequestId(),
+                wantResponse = wantResponse,
+                adminMessage = adminMsg,
+            )
+        return packetHandler.sendToRadioAndAwaitResult(packet)
     }
 
     override suspend fun sendPosition(pos: ProtoPosition, destNum: Int?, wantResponse: Boolean) {
@@ -276,19 +289,22 @@ class CommandSenderImpl(
     }
 
     override suspend fun requestTraceroute(requestId: Int, destNum: Int) {
-        tracerouteHandler.recordStartTime(requestId)
-        packetHandler.sendToRadio(
-            buildMeshPacket(
-                to = destNum,
-                wantAck = true,
-                id = requestId,
-                channel = getChannelIndex(destNum),
-                decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
-            ),
-        )
+        val effectiveRequestId = requestId.nonZeroRequestId()
+        val queued =
+            packetHandler.sendToRadio(
+                buildMeshPacket(
+                    to = destNum,
+                    wantAck = true,
+                    id = effectiveRequestId,
+                    channel = getChannelIndex(destNum),
+                    decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
+                ),
+            )
+        if (queued) tracerouteHandler.recordStartTime(effectiveRequestId)
     }
 
     override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) {
+        val effectiveRequestId = requestId.nonZeroRequestId()
         val type = TelemetryType.entries.getOrNull(typeValue) ?: TelemetryType.DEVICE
 
         val portNum: PortNum
@@ -315,7 +331,7 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(
             buildMeshPacket(
                 to = destNum,
-                id = requestId,
+                id = effectiveRequestId,
                 channel = getChannelIndex(destNum),
                 decoded = Data(portnum = portNum, payload = payloadBytes, want_response = true, dest = destNum),
             ),
@@ -323,57 +339,59 @@ class CommandSenderImpl(
     }
 
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {
-        neighborInfoHandler.recordStartTime(requestId)
+        val effectiveRequestId = requestId.nonZeroRequestId()
         val myNum = nodeManager.myNodeNum.value ?: 0
-        if (destNum == myNum) {
-            val neighborInfoToSend =
-                neighborInfoHandler.lastNeighborInfo
-                    ?: run {
-                        val oneHour = 1.hours.inWholeMinutes.toInt()
-                        Logger.d { "No stored neighbor info from connected radio, sending dummy data" }
-                        NeighborInfo(
-                            node_id = myNum,
-                            last_sent_by_id = myNum,
-                            node_broadcast_interval_secs = oneHour,
-                            neighbors =
-                            listOf(
-                                Neighbor(
-                                    node_id = 0, // Dummy node ID that can be intercepted
-                                    snr = 0f,
-                                    last_rx_time = (nowMillis / 1000L).toInt(),
-                                    node_broadcast_interval_secs = oneHour,
+        val queued =
+            if (destNum == myNum) {
+                val neighborInfoToSend =
+                    neighborInfoHandler.lastNeighborInfo
+                        ?: run {
+                            val oneHour = 1.hours.inWholeMinutes.toInt()
+                            Logger.d { "No stored neighbor info from connected radio, sending dummy data" }
+                            NeighborInfo(
+                                node_id = myNum,
+                                last_sent_by_id = myNum,
+                                node_broadcast_interval_secs = oneHour,
+                                neighbors =
+                                listOf(
+                                    Neighbor(
+                                        node_id = 0, // Dummy node ID that can be intercepted
+                                        snr = 0f,
+                                        last_rx_time = (nowMillis / 1000L).toInt(),
+                                        node_broadcast_interval_secs = oneHour,
+                                    ),
                                 ),
-                            ),
-                        )
-                    }
+                            )
+                        }
 
-            // Send the neighbor info from our connected radio to ourselves (simulated)
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = requestId,
-                    channel = getChannelIndex(destNum),
-                    decoded =
-                    Data(
-                        portnum = PortNum.NEIGHBORINFO_APP,
-                        payload = neighborInfoToSend.encode().toByteString(),
-                        want_response = true,
+                // Send the neighbor info from our connected radio to ourselves (simulated)
+                packetHandler.sendToRadio(
+                    buildMeshPacket(
+                        to = destNum,
+                        wantAck = true,
+                        id = effectiveRequestId,
+                        channel = getChannelIndex(destNum),
+                        decoded =
+                        Data(
+                            portnum = PortNum.NEIGHBORINFO_APP,
+                            payload = neighborInfoToSend.encode().toByteString(),
+                            want_response = true,
+                        ),
                     ),
-                ),
-            )
-        } else {
-            // Send request to remote
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = requestId,
-                    channel = getChannelIndex(destNum),
-                    decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
-                ),
-            )
-        }
+                )
+            } else {
+                // Send request to remote
+                packetHandler.sendToRadio(
+                    buildMeshPacket(
+                        to = destNum,
+                        wantAck = true,
+                        id = effectiveRequestId,
+                        channel = getChannelIndex(destNum),
+                        decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
+                    ),
+                )
+            }
+        if (queued) neighborInfoHandler.recordStartTime(effectiveRequestId)
     }
 
     override fun sendLockdownPassphrase(

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -17,17 +17,22 @@
 package org.meshtastic.core.data.manager
 
 import co.touchlab.kermit.Logger
+import kotlinx.atomicfu.AtomicBoolean
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.asDeferred
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Named
@@ -41,6 +46,8 @@ import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
 import org.meshtastic.core.model.util.toOneLineString
 import org.meshtastic.core.model.util.toPIIString
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketHandler
@@ -78,6 +85,7 @@ class PacketHandlerImpl(
     }
 
     private var queueJob: Job? = null
+    private var queueGeneration = 0L
 
     private val queueMutex = Mutex()
     private val queuedPackets = mutableListOf<MeshPacket>()
@@ -87,15 +95,24 @@ class PacketHandlerImpl(
     private var queueStopped = false
 
     private val responseMutex = Mutex()
-    private val queueResponse = mutableMapOf<Int, CompletableDeferred<Boolean>>()
+
+    private data class PendingResponse(
+        val deferred: CompletableDeferred<AwaitedSendStatus> = CompletableDeferred(),
+        val dispatched: AtomicBoolean = atomic(false),
+    )
+
+    private val queueResponse = mutableMapOf<Int, PendingResponse>()
 
     override fun sendToRadio(p: ToRadio) {
+        dispatchToRadio(p)
+    }
+
+    private fun dispatchToRadio(p: ToRadio): Boolean {
         Logger.d { "Sending to radio ${p.toPIIString()}" }
-        val b = p.encode()
+        val dispatched = radioInterfaceService.trySendToRadio(p.encode())
+        if (!dispatched) return false
 
-        radioInterfaceService.sendToRadio(b)
         p.packet?.id?.let { changeStatus(it, MessageStatus.ENROUTE) }
-
         val packet = p.packet
         if (packet?.decoded != null) {
             val packetToSave =
@@ -110,6 +127,7 @@ class PacketHandlerImpl(
                 )
             insertMeshLog(packetToSave)
         }
+        return true
     }
 
     /**
@@ -118,37 +136,60 @@ class PacketHandlerImpl(
      * multiple calls — e.g. an `editSettings { … }` begin → writes → commit sequence — MUST be issued from a single
      * coroutine; concurrent senders share FIFO only at the per-call grain.
      */
-    override suspend fun sendToRadio(packet: MeshPacket) {
-        queueMutex.withLock {
-            queueStopped = false
-            queuedPackets.add(packet)
-            startPacketQueueLocked()
+    override suspend fun sendToRadio(packet: MeshPacket): Boolean {
+        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
+        when {
+            packet.id == 0 -> Logger.w { "Dropping queued packet without an ID" }
+            pending == null -> Logger.w { "Dropping duplicate queued packet id=${packet.id.toUInt()}" }
         }
+        return pending != null
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    override suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean {
-        // Pre-register the deferred so the queue processor and QueueStatus handler
-        // can find it immediately — no polling required.
-        val deferred = CompletableDeferred<Boolean>()
-        responseMutex.withLock { queueResponse[packet.id] = deferred }
-        queueMutex.withLock {
-            queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
-            queuedPackets.add(packet)
-            startPacketQueueLocked()
+    override suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult {
+        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
+        if (pending == null) {
+            if (packet.id == 0) {
+                Logger.w { "Rejecting awaited packet without an ID" }
+            } else {
+                Logger.w { "Rejecting duplicate awaited packet id=${packet.id.toUInt()}" }
+            }
+            return AwaitedSendResult(status = AwaitedSendStatus.SEND_FAILED, dispatched = false)
         }
         return try {
-            withTimeout(TIMEOUT) { deferred.await() }
-        } catch (e: TimeoutCancellationException) {
-            Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} timeout" }
-            false
+            // The queue processor owns the response timeout and starts it only after this packet reaches the head of
+            // the FIFO and is sent. A caller-level timeout here would incorrectly include time spent behind earlier
+            // packets and can reject a valid transaction boundary before it has even left the phone.
+            AwaitedSendResult(status = pending.deferred.await(), dispatched = pending.dispatched.value)
         } catch (e: CancellationException) {
             throw e // Preserve structured concurrency cancellation propagation.
         } catch (e: Exception) {
             Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} failed: ${e.message}" }
-            false
+            AwaitedSendResult(status = AwaitedSendStatus.SEND_FAILED, dispatched = pending.dispatched.value)
         } finally {
-            responseMutex.withLock { queueResponse.remove(packet.id) }
+            // The queue lifecycle owns an incomplete reservation. In particular, cancellation while this packet is
+            // still behind the FIFO backlog must not release its ID for a newer packet that the stale queue entry could
+            // accidentally satisfy.
+            if (pending.deferred.isCompleted) {
+                responseMutex.withLock { if (queueResponse[packet.id] === pending) queueResponse.remove(packet.id) }
+            }
+        }
+    }
+
+    /**
+     * Reserves [packet]'s non-zero ID and queues it as one atomic admission. The reservation spans both queued and
+     * in-flight work, so a second sender cannot replace the original caller's [PendingResponse].
+     */
+    private suspend fun enqueuePacket(packet: MeshPacket): PendingResponse? = queueMutex.withLock {
+        responseMutex.withLock responseLock@{
+            if (queueResponse.containsKey(packet.id)) return@responseLock null
+
+            val pending = PendingResponse()
+            queueResponse[packet.id] = pending
+            queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
+            queuedPackets.add(packet)
+            startPacketQueueLocked()
+            pending
         }
     }
 
@@ -161,11 +202,9 @@ class PacketHandlerImpl(
                 queueStopped = true
                 queueJob?.cancel()
                 queueJob = null
+                queueGeneration++
                 queuedPackets.clear()
-            }
-            responseMutex.withLock {
-                queueResponse.values.forEach { if (!it.isCompleted) it.complete(false) }
-                queueResponse.clear()
+                completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
             }
         }
     }
@@ -182,16 +221,21 @@ class PacketHandlerImpl(
         scope.launch {
             responseMutex.withLock {
                 if (requestId != 0) {
-                    queueResponse.remove(requestId)?.complete(success)
+                    queueResponse.remove(requestId)?.deferred?.complete(success.toAwaitedSendStatus())
                 } else {
-                    queueResponse.values.firstOrNull { !it.isCompleted }?.complete(success)
+                    queueResponse.values
+                        .firstOrNull { !it.deferred.isCompleted }
+                        ?.deferred
+                        ?.complete(success.toAwaitedSendStatus())
                 }
             }
         }
     }
 
     override suspend fun removeResponse(dataRequestId: Int, complete: Boolean) {
-        responseMutex.withLock { queueResponse.remove(dataRequestId)?.complete(complete) }
+        responseMutex.withLock {
+            queueResponse.remove(dataRequestId)?.deferred?.complete(complete.toAwaitedSendStatus())
+        }
     }
 
     /**
@@ -201,6 +245,7 @@ class PacketHandlerImpl(
     private fun startPacketQueueLocked() {
         if (queueStopped) return
         if (queueJob?.isActive == true) return
+        val generation = ++queueGeneration
         queueJob =
             scope.handledLaunch {
                 try {
@@ -210,30 +255,60 @@ class PacketHandlerImpl(
                         try {
                             val response = sendPacket(packet)
                             Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
-                            val success = withTimeout(TIMEOUT) { response.await() }
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} success $success" }
+                            val status = withTimeout(TIMEOUT) { response.await() }
+                            Logger.d { "queueJob packet id=${packet.id.toUInt()} status $status" }
+                            // QueueStatus normally removes keyed responses before completing them. Keep cleanup here
+                            // as well for local send failures and legacy ID-less statuses, which complete the deferred
+                            // without removing its map entry.
+                            responseMutex.withLock { queueResponse.remove(packet.id) }
                         } catch (e: TimeoutCancellationException) {
                             Logger.d { "queueJob packet id=${packet.id.toUInt()} timeout" }
-                            // Clean up the deferred for this packet. sendToRadioAndAwait callers
-                            // also clean up in their own finally block (idempotent remove).
-                            responseMutex.withLock { queueResponse.remove(packet.id) }
+                            // Complete an awaiting caller before removing the response. Its timeout starts here, after
+                            // the packet is actually sent, rather than while it waits behind the existing FIFO backlog.
+                            responseMutex.withLock {
+                                queueResponse.remove(packet.id)?.deferred?.complete(AwaitedSendStatus.TIMED_OUT)
+                            }
                         } catch (e: CancellationException) {
                             throw e // Preserve structured concurrency cancellation propagation.
                         } catch (e: Exception) {
                             Logger.d { "queueJob packet id=${packet.id.toUInt()} failed" }
-                            responseMutex.withLock { queueResponse.remove(packet.id) }
+                            responseMutex.withLock {
+                                queueResponse.remove(packet.id)?.deferred?.complete(AwaitedSendStatus.SEND_FAILED)
+                            }
                         }
-                        // Deferred cleanup is now handled in the catch blocks above.
-                        // handleQueueStatus (normal success) and stopPacketQueue (bulk cleanup)
-                        // also remove entries, and these removals are idempotent.
+                        // handleQueueStatus and stopPacketQueue also remove entries; every path is intentionally
+                        // idempotent because the queue worker and caller can observe completion concurrently.
                     }
                 } finally {
-                    // Hold queueMutex so that clearing queueJob and the restart decision are
-                    // atomic with respect to new senders calling startPacketQueueLocked().
-                    queueMutex.withLock {
-                        queueJob = null
-                        if (!queueStopped && queuedPackets.isNotEmpty()) {
-                            startPacketQueueLocked()
+                    // Keep completion, replacement, and disconnect draining atomic with new admissions. An older
+                    // cancelled processor must not clear a replacement job started for a newer generation.
+                    withContext(NonCancellable) {
+                        queueMutex.withLock {
+                            if (generation != queueGeneration) return@withLock
+                            queueJob = null
+                            when {
+                                queueStopped || !scope.isActive -> {
+                                    queueStopped = true
+                                    queuedPackets.clear()
+                                    completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                                }
+
+                                connectionStateProvider.connectionState.value == ConnectionState.Connected ->
+                                    if (queuedPackets.isEmpty()) {
+                                        // A normally completed worker has no pending response. Anything left here
+                                        // belongs to an in-flight packet interrupted by cancellation or an unexpected
+                                        // worker exit.
+                                        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                                    } else {
+                                        startPacketQueueLocked()
+                                    }
+
+                                else -> {
+                                    queueStopped = true
+                                    queuedPackets.clear()
+                                    completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                                }
+                            }
                         }
                     }
                 }
@@ -259,25 +334,45 @@ class PacketHandlerImpl(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun sendPacket(packet: MeshPacket): Deferred<Boolean> {
-        // Reuse a deferred pre-registered by sendToRadioAndAwait, or create a new one.
-        val deferred = responseMutex.withLock { queueResponse.getOrPut(packet.id) { CompletableDeferred() } }
-        try {
-            if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
-                throw RadioNotConnectedException()
+    private suspend fun sendPacket(packet: MeshPacket): Deferred<AwaitedSendStatus> {
+        val pending =
+            checkNotNull(responseMutex.withLock { queueResponse[packet.id] }) {
+                "Queued packet id=${packet.id.toUInt()} lost its response reservation"
             }
-            sendToRadio(ToRadio(packet = packet))
+        try {
+            requireConnected()
+            pending.dispatched.value = dispatchToRadio(ToRadio(packet = packet))
+            if (!pending.dispatched.value) {
+                throw RadioNotConnectedException("No active transport accepted the packet")
+            }
         } catch (ex: RadioNotConnectedException) {
             Logger.w(ex) { "sendToRadio skipped: Not connected to radio" }
-            deferred.complete(false)
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+        } catch (ex: CancellationException) {
+            throw ex
         } catch (ex: Exception) {
             Logger.e(ex) { "sendToRadio error: ${ex.message}" }
-            deferred.complete(false)
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
         }
-        // Return a read-only Deferred view (kotlinx.coroutines 1.11+) so callers can await it
-        // without being able to complete the underlying CompletableDeferred; cancellation is
-        // still exposed via Deferred/Job.
-        return deferred.asDeferred()
+        // Return a read-only Deferred view (kotlinx.coroutines 1.11+) so callers can await it without completing the
+        // underlying response; cancellation is still exposed via Deferred/Job.
+        return pending.deferred.asDeferred()
+    }
+
+    private fun requireConnected() {
+        if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
+            throw RadioNotConnectedException()
+        }
+    }
+
+    private fun Boolean.toAwaitedSendStatus(): AwaitedSendStatus =
+        if (this) AwaitedSendStatus.ACCEPTED else AwaitedSendStatus.REJECTED
+
+    private suspend fun completePendingResponses(status: AwaitedSendStatus) {
+        responseMutex.withLock {
+            queueResponse.values.forEach { pending -> pending.deferred.complete(status) }
+            queueResponse.clear()
+        }
     }
 
     private fun insertMeshLog(packetToSave: MeshLog) {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -21,8 +21,10 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.capture.capture
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -34,6 +36,8 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.PacketHandler
@@ -158,7 +162,7 @@ class CommandSenderImplTest {
     fun sendData_setsIdWhenZero() = runTest {
         val packet = DataPacket(to = "^all", bytes = "hi".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
         packet.id = 0
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.sendData(packet)
         assertNotEquals(0, packet.id)
@@ -167,7 +171,7 @@ class CommandSenderImplTest {
     @Test
     fun sendData_setsStatusQueued() = runTest {
         val packet = DataPacket(to = "^all", bytes = "hello".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.sendData(packet)
         assertEquals(MessageStatus.QUEUED, packet.status)
@@ -195,22 +199,68 @@ class CommandSenderImplTest {
     fun sendAdmin_injectsSessionPasskey() = runTest {
         val passkey = "secret".encodeUtf8()
         every { sessionManager.getPasskey(DEST_NODE) } returns passkey
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.sendAdmin(DEST_NODE) { org.meshtastic.proto.AdminMessage(get_owner_request = true) }
 
         verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
     }
 
+    @Test
+    fun sendAdmin_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
+
+        commandSender.sendAdmin(DEST_NODE, requestId = 0) {
+            org.meshtastic.proto.AdminMessage(get_owner_request = true)
+        }
+
+        assertNotEquals(0, packets.single().id)
+    }
+
+    @Test
+    fun sendAdminAwaitResult_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadioAndAwaitResult(capture(packets)) } returns
+            AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
+        commandSender.sendAdminAwaitResult(DEST_NODE, requestId = 0) {
+            org.meshtastic.proto.AdminMessage(get_owner_request = true)
+        }
+
+        assertNotEquals(0, packets.single().id)
+    }
+
     // --- requestTraceroute ---
 
     @Test
     fun requestTraceroute_recordsStartTime() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
 
         verify { tracerouteHandler.recordStartTime(42) }
+    }
+
+    @Test
+    fun requestTraceroute_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
+
+        verify(exactly(0)) { tracerouteHandler.recordStartTime(any()) }
+    }
+
+    @Test
+    fun requestTraceroute_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
+
+        commandSender.requestTraceroute(requestId = 0, destNum = DEST_NODE)
+
+        val generatedId = packets.single().id
+        assertNotEquals(0, generatedId)
+        verify { tracerouteHandler.recordStartTime(generatedId) }
     }
 
     // --- requestNeighborInfo ---
@@ -219,7 +269,7 @@ class CommandSenderImplTest {
     fun requestNeighborInfo_localNode_usesCachedNeighborInfo() = runTest {
         val cached = NeighborInfo(node_id = MY_NODE_NUM, last_sent_by_id = MY_NODE_NUM)
         every { neighborInfoHandler.lastNeighborInfo } returns cached
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
@@ -229,7 +279,7 @@ class CommandSenderImplTest {
     @Test
     fun requestNeighborInfo_localNode_generatesDummyWhenNoCached() = runTest {
         every { neighborInfoHandler.lastNeighborInfo } returns null
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
@@ -238,7 +288,7 @@ class CommandSenderImplTest {
 
     @Test
     fun requestNeighborInfo_remoteNode_sendsRequest() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
 
@@ -249,7 +299,7 @@ class CommandSenderImplTest {
 
     @Test
     fun sendPosition_updatesLocalPositionWhenNotFixed() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
         commandSender.sendPosition(pos)
@@ -276,7 +326,7 @@ class CommandSenderImplTest {
                 scope = testScope,
             )
         testScope.testScheduler.advanceUntilIdle()
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
         fixedSender.sendPosition(pos)

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
@@ -19,6 +19,8 @@ package org.meshtastic.core.data.manager
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.service.LockdownState
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MeshConnectionManager
@@ -114,12 +116,12 @@ class LockdownCoordinatorImplTest {
             initFn: () -> AdminMessage,
         ) = Unit
 
-        override suspend fun sendAdminAwait(
+        override suspend fun sendAdminAwaitResult(
             destNum: Int,
             requestId: Int,
             wantResponse: Boolean,
             initFn: () -> AdminMessage,
-        ) = true
+        ) = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
 
         override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) =
             Unit

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -17,21 +17,26 @@
 package org.meshtastic.core.data.manager
 
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioInterfaceService
@@ -43,6 +48,7 @@ import org.meshtastic.proto.QueueStatus
 import org.meshtastic.proto.ToRadio
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -64,6 +70,7 @@ class PacketHandlerImplTest {
     @BeforeTest
     fun setUp() {
         every { serviceRepository.connectionState } returns connectionStateFlow
+        every { radioInterfaceService.trySendToRadio(any()) } returns true
 
         handler =
             PacketHandlerImpl(
@@ -86,7 +93,7 @@ class PacketHandlerImplTest {
 
         handler.sendToRadio(toRadio)
 
-        verify { radioInterfaceService.sendToRadio(any()) }
+        verify { radioInterfaceService.trySendToRadio(any()) }
     }
 
     @Test
@@ -97,7 +104,7 @@ class PacketHandlerImplTest {
         handler.sendToRadio(packet)
         testScheduler.runCurrent()
 
-        verify { radioInterfaceService.sendToRadio(any()) }
+        verify { radioInterfaceService.trySendToRadio(any()) }
     }
 
     @Test
@@ -162,6 +169,187 @@ class PacketHandlerImplTest {
 
         assertFalse(result.await())
     }
+
+    @Test
+    fun `await response timeout starts after earlier queued packets`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 800))
+        handler.sendToRadio(MeshPacket(id = 801))
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 802)) }
+        testScheduler.runCurrent()
+
+        // Let both earlier packets consume their full response windows. The awaited packet has not timed out
+        // because
+        // it has not reached the head of the queue yet.
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+        assertFalse(result.isCompleted)
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+        assertFalse(result.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 802, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertTrue(result.await())
+    }
+
+    @Test
+    fun `stopping the queue completes an awaiting packet still behind the backlog`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 803))
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 804)) }
+        testScheduler.runCurrent()
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+    }
+
+    @Test
+    fun `stopping transport reports an awaited packet was already dispatched`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 807)) }
+        testScheduler.runCurrent()
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertTrue(stopped.dispatched)
+    }
+
+    @Test
+    fun `disconnect drains queued responses without restarting the processor`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val first = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 813)) }
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 814)) }
+        testScheduler.runCurrent()
+
+        connectionStateFlow.value = ConnectionState.Disconnected
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 813, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertEquals(AwaitedSendStatus.ACCEPTED, first.await().status)
+        val stopped = queued.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+        verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `queue response timeout completes awaiting caller with failure`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 805)) }
+        testScheduler.runCurrent()
+
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+
+        val timedOut = result.await()
+        assertEquals(AwaitedSendStatus.TIMED_OUT, timedOut.status)
+        assertTrue(timedOut.dispatched)
+    }
+
+    @Test
+    fun `transport refusing dispatch completes awaiting caller with failure`() = runTest(testDispatcher) {
+        every { radioInterfaceService.trySendToRadio(any()) } returns false
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 808)) }
+        testScheduler.runCurrent()
+
+        val failed = result.await()
+        assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
+        assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `queue send failure completes awaiting caller with failure`() = runTest(testDispatcher) {
+        every { radioInterfaceService.trySendToRadio(any()) } calls { error("test send failure") }
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 806)) }
+        testScheduler.runCurrent()
+
+        val failed = result.await()
+        assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
+        assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `cancelled queue handoff releases the current response reservation`() = runTest(testDispatcher) {
+        every { radioInterfaceService.trySendToRadio(any()) } calls
+            {
+                throw CancellationException("transport stopped")
+            }
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 815)) }
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+    }
+
+    @Test
+    fun `duplicate awaited packet id is rejected without replacing the original waiter`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val original = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 809)) }
+        testScheduler.runCurrent()
+
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 809))
+
+        assertEquals(AwaitedSendStatus.SEND_FAILED, duplicate.status)
+        assertFalse(duplicate.dispatched)
+        assertFalse(original.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 809, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        val accepted = original.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+        assertTrue(accepted.dispatched)
+    }
+
+    @Test
+    fun `cancelling an awaiting caller does not release its queued packet id`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 811))
+        val awaiting = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 812)) }
+        testScheduler.runCurrent()
+
+        awaiting.cancelAndJoin()
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 812))
+
+        assertEquals(AwaitedSendStatus.SEND_FAILED, duplicate.status)
+        assertFalse(duplicate.dispatched)
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `fire and forget rejects invalid packet ids without throwing or replacing queued work`() =
+        runTest(testDispatcher) {
+            connectionStateFlow.value = ConnectionState.Connected
+            assertTrue(handler.sendToRadio(MeshPacket(id = 810)))
+            testScheduler.runCurrent()
+
+            assertFalse(handler.sendToRadio(MeshPacket(id = 810)))
+            assertFalse(handler.sendToRadio(MeshPacket()))
+            testScheduler.runCurrent()
+
+            verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+
+            handler.stopPacketQueue()
+            testScheduler.runCurrent()
+        }
 
     @Test
     fun `handleQueueStatus property test`() = runTest(testDispatcher) {

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCase.kt
@@ -16,97 +16,242 @@
  */
 package org.meshtastic.core.domain.usecase.settings
 
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
-import org.meshtastic.core.model.Position
-import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.DeviceType
+import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.NodeRestartTracker
+import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
+import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.DeviceProfile
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.User
+import kotlin.time.Duration.Companion.seconds
 
-/** Use case for installing a device profile onto a radio. */
+/** Installs a local device profile using firmware-compatible, restart-aware phases. */
 @Single
-open class InstallProfileUseCase constructor(private val radioController: RadioController) {
+open class InstallProfileUseCase
+constructor(
+    private val radioController: RadioController,
+    private val radioInterfaceService: RadioInterfaceService,
+    private val radioConfigRepository: RadioConfigRepository,
+    private val nodeRepository: NodeRepository,
+    private val nodeRestartTracker: NodeRestartTracker,
+) {
+    private val installMutex = Mutex()
+
     /**
-     * Installs the provided [DeviceProfile] onto the radio at [destNum].
+     * Installs [profile] onto the locally connected radio at [destNum].
      *
-     * @param destNum The destination node number.
-     * @param profile The device profile to install.
-     * @param currentUser The current user configuration of the destination node (to preserve names if not in profile).
+     * Firmware edit transactions defer normal config persistence until `commit_edit_settings`, but firmware versions
+     * already in the field can interrupt Bluetooth as soon as MQTT or Serial configuration is processed. Those
+     * transport-sensitive commands therefore cannot be sent inside the transaction: a BLE link can disappear before the
+     * remaining writes and commit reach the device. Every committed edit and standalone config write also schedules a
+     * firmware reboot, regardless of transport, so each non-terminal stage must complete a fresh application handshake
+     * before the next write.
+     *
+     * The profile is applied in this order:
+     * 1. owner, channels, non-terminal config, fixed position, and non-disruptive modules in one edit transaction;
+     * 2. MQTT as a standalone stage;
+     * 3. configuration for transports other than the active one;
+     * 4. the active transport's own configuration last, because it may prevent that transport from reconnecting.
+     *
+     * Bluetooth and Network are always kept out of the ordinary transaction. If more than one general-config write
+     * would end the active transport, those writes share one final edit transaction so firmware accepts all of them
+     * before the connection disappears. This covers, for example, enabling Wi-Fi while disabling Bluetooth over BLE.
+     *
+     * Every stage observes the firmware restart. Stages that need another write also wait for the application handshake
+     * to return to [ConnectionState.Connected], then resolve the current local node number so a security restore that
+     * changes identity cannot strand later writes on the old destination.
      */
-    open suspend operator fun invoke(destNum: Int, profile: DeviceProfile, currentUser: User?) {
-        radioController.editSettings(destNum) {
-            installOwner(profile, currentUser)
-            installConfig(profile.config)
-            installFixedPosition(profile.fixed_position)
-            installModuleConfig(profile.module_config)
+    open suspend operator fun invoke(destNum: Int, profile: DeviceProfile, currentUser: User?, isLocal: Boolean) =
+        installMutex.withLock {
+            require(isLocal) { "Device profiles can only be installed on the locally connected node" }
+            require(radioController.connectionState.value is ConnectionState.Connected) {
+                "A connected local node is required to install a device profile"
+            }
+            val activeTransport =
+                checkNotNull(radioInterfaceService.getDeviceAddress()?.let(DeviceType::fromAddress)) {
+                    "The connected node transport is unavailable"
+                }
+            require(destNum == currentLocalNodeNum()) {
+                "The profile destination no longer matches the connected local node"
+            }
+
+            validateOwnerRestore(profile, currentUser)
+            val currentConfig = radioConfigRepository.localConfigFlow.first()
+            val currentModuleConfig = radioConfigRepository.moduleConfigFlow.first()
+            val plan =
+                ProfileInstallPlanner.create(
+                    profile = profile,
+                    currentConfig = currentConfig,
+                    currentModuleConfig = currentModuleConfig,
+                    currentUser = currentUser,
+                    activeTransport = activeTransport,
+                )
+
+            if (plan.hasTransactionalWrites) {
+                installTransactionStage(
+                    profile = plan.profile,
+                    currentUser = currentUser,
+                    config = plan.config,
+                    moduleConfig = plan.moduleConfig,
+                    channelRestore = plan.channelRestore,
+                )
+            }
+
+            installTransportSensitiveStages(plan.transportPlan)
         }
+
+    /**
+     * Applies the ordinary edit transaction while keeping the local channel cache aligned with commands that were
+     * actually issued. A failure before the first channel command leaves the cache untouched. After a successful send,
+     * the imported authoritative set is reconciled on both normal and exceptional exits.
+     */
+    private suspend fun installTransactionStage(
+        profile: DeviceProfile,
+        currentUser: User?,
+        config: LocalConfig?,
+        moduleConfig: LocalModuleConfig?,
+        channelRestore: ChannelRestore?,
+    ) {
+        var channelWriteIssued = false
+        var channelCacheReconciliationAttempted = false
+
+        suspend fun reconcileChannelCache() {
+            val restore = channelRestore ?: return
+            if (!channelWriteIssued || channelCacheReconciliationAttempted) return
+
+            channelCacheReconciliationAttempted = true
+            // Replace the whole list: handshake persistence ignores DISABLED slots, so replaying individual packets
+            // cannot reliably clear stale trailing channels after an interrupted authoritative restore.
+            withContext(NonCancellable) { radioConfigRepository.replaceAllSettings(restore.normalizedSettings) }
+        }
+
+        var primaryFailure: Exception? = null
+        var reconciliationFailure: Throwable? = null
+        try {
+            runInstallStage(stage = ProfileInstallStage.TRANSACTION, expectReconnect = true) {
+                radioController.editLocalSettings {
+                    installOwner(profile, currentUser)
+                    installConfig(config)
+                    installChannels(channelRestore) { channelWriteIssued = true }
+                    installFixedPosition(profile.fixed_position)
+                    installModuleConfig(moduleConfig)
+                }
+                // Reconcile before waiting for the reboot handshake. Incoming channel packets can then only refine the
+                // authoritative imported set instead of merging into the pre-import cache.
+                reconcileChannelCache()
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+            primaryFailure = error
+        } finally {
+            // A later channel/config/commit failure can occur after earlier set_channel commands reached firmware.
+            // Preserve the imported authoritative set in that case, even though the stage itself failed. This is
+            // cleanup, so retain its failure until the original stage failure can be restored after `finally`.
+            reconciliationFailure = runCatching { reconcileChannelCache() }.exceptionOrNull()
+        }
+
+        primaryFailure?.let { failure ->
+            reconciliationFailure?.let(failure::addSuppressed)
+            throw failure
+        }
+        reconciliationFailure?.let { throw it }
     }
 
-    // is_licensed is deliberately not installed here: enabling ham mode is a dedicated onboarding flow
-    // (set_ham_mode — rewrites the owner, disables encryption, applies tx power/frequency) that a plain
-    // set_owner would bypass, leaving the radio flagged licensed without those required side effects.
-    private suspend fun AdminEditScope.installOwner(profile: DeviceProfile, currentUser: User?) {
-        if (profile.long_name != null || profile.short_name != null || profile.is_unmessagable != null) {
-            currentUser?.let {
-                setOwner(
-                    it.copy(
-                        long_name = profile.long_name ?: it.long_name,
-                        short_name = profile.short_name ?: it.short_name,
-                        is_unmessagable = profile.is_unmessagable ?: it.is_unmessagable,
-                    ),
-                )
+    private suspend fun installTransportSensitiveStages(plan: TransportSensitivePlan) {
+        plan.mqtt?.let { mqtt -> installModuleConfigStage(ProfileInstallStage.MQTT, mqtt, expectReconnect = true) }
+
+        (plan.continuingStages + plan.terminalStages).forEach { stage ->
+            when (stage) {
+                is TransportSensitiveStage.ConfigWrite ->
+                    installConfigStage(stage.profileStage, stage.config, stage.expectsReconnect)
+
+                is TransportSensitiveStage.ModuleConfigWrite ->
+                    installModuleConfigStage(stage.profileStage, stage.config, stage.expectsReconnect)
+            }
+        }
+
+        if (plan.groupedTerminalConfig.isNotEmpty()) {
+            runInstallStage(ProfileInstallStage.TRANSPORT_CONFIG, expectReconnect = false) {
+                radioController.editLocalSettings { plan.groupedTerminalConfig.forEach { setConfig(it.config) } }
             }
         }
     }
 
-    private suspend fun AdminEditScope.installConfig(config: LocalConfig?) {
-        config?.let { lc ->
-            lc.device?.let { setConfig(Config(device = it)) }
-            lc.position?.let { setConfig(Config(position = it)) }
-            lc.power?.let { setConfig(Config(power = it)) }
-            lc.network?.let { setConfig(Config(network = it)) }
-            lc.display?.let { setConfig(Config(display = it)) }
-            lc.lora?.let { setConfig(Config(lora = it)) }
-            lc.bluetooth?.let { setConfig(Config(bluetooth = it)) }
-            lc.security?.let { setConfig(Config(security = it)) }
+    private suspend fun installConfigStage(stage: ProfileInstallStage, config: Config, expectReconnect: Boolean) =
+        runInstallStage(stage, expectReconnect) {
+            radioController.setConfig(currentLocalNodeNum(), config, radioController.generatePacketId())
+        }
+
+    private suspend fun installModuleConfigStage(
+        stage: ProfileInstallStage,
+        config: ModuleConfig,
+        expectReconnect: Boolean,
+    ) = runInstallStage(stage, expectReconnect) {
+        radioController.setModuleConfig(currentLocalNodeNum(), config, radioController.generatePacketId())
+    }
+
+    private suspend fun runInstallStage(
+        stage: ProfileInstallStage,
+        expectReconnect: Boolean,
+        action: suspend () -> Unit,
+    ) {
+        Logger.i { "Installing device profile stage=${stage.logName}" }
+        val baselineEpochs = radioController.connectionEpochs.value
+        nodeRestartTracker.expectRestart()
+        var completed = false
+        try {
+            action()
+            val departureEpochs =
+                checkNotNull(
+                    withTimeoutOrNull(PROFILE_DEPARTURE_TIMEOUT) {
+                        radioController.connectionEpochs.first { it.departures > baselineEpochs.departures }
+                    },
+                ) {
+                    "Device did not begin the ${stage.logName} profile restart"
+                }
+            if (expectReconnect) {
+                checkNotNull(
+                    withTimeoutOrNull(PROFILE_RECONNECT_TIMEOUT) {
+                        radioController.connectionEpochs.first {
+                            it.departures >= departureEpochs.departures &&
+                                it.completedHandshakes > it.handshakesAtLastDeparture
+                        }
+                    },
+                ) {
+                    "Device did not reconnect after the ${stage.logName} profile stage"
+                }
+            }
+            nodeRestartTracker.onConnected()
+            completed = true
+            Logger.i { "Installed device profile stage=${stage.logName}" }
+        } finally {
+            if (!completed && radioController.connectionState.value is ConnectionState.Connected) {
+                nodeRestartTracker.onConnected()
+            }
         }
     }
 
-    private suspend fun AdminEditScope.installFixedPosition(fixedPosition: org.meshtastic.proto.Position?) {
-        if (fixedPosition != null) {
-            setFixedPosition(Position(fixedPosition))
-        }
-    }
+    private fun currentLocalNodeNum(): Int =
+        checkNotNull(nodeRepository.myNodeInfo.value?.myNodeNum) { "The connected local node identity is unavailable" }
 
-    private suspend fun AdminEditScope.installModuleConfig(moduleConfig: LocalModuleConfig?) {
-        moduleConfig?.let { lmc ->
-            installModuleConfigPart1(lmc)
-            installModuleConfigPart2(lmc)
-        }
-    }
-
-    private suspend fun AdminEditScope.installModuleConfigPart1(lmc: LocalModuleConfig) {
-        lmc.mqtt?.let { setModuleConfig(ModuleConfig(mqtt = it)) }
-        lmc.serial?.let { setModuleConfig(ModuleConfig(serial = it)) }
-        lmc.external_notification?.let { setModuleConfig(ModuleConfig(external_notification = it)) }
-        lmc.store_forward?.let { setModuleConfig(ModuleConfig(store_forward = it)) }
-        lmc.range_test?.let { setModuleConfig(ModuleConfig(range_test = it)) }
-        lmc.telemetry?.let { setModuleConfig(ModuleConfig(telemetry = it)) }
-        lmc.canned_message?.let { setModuleConfig(ModuleConfig(canned_message = it)) }
-        lmc.audio?.let { setModuleConfig(ModuleConfig(audio = it)) }
-    }
-
-    private suspend fun AdminEditScope.installModuleConfigPart2(lmc: LocalModuleConfig) {
-        lmc.remote_hardware?.let { setModuleConfig(ModuleConfig(remote_hardware = it)) }
-        lmc.neighbor_info?.let { setModuleConfig(ModuleConfig(neighbor_info = it)) }
-        lmc.ambient_lighting?.let { setModuleConfig(ModuleConfig(ambient_lighting = it)) }
-        lmc.detection_sensor?.let { setModuleConfig(ModuleConfig(detection_sensor = it)) }
-        lmc.paxcounter?.let { setModuleConfig(ModuleConfig(paxcounter = it)) }
-        lmc.statusmessage?.let { setModuleConfig(ModuleConfig(statusmessage = it)) }
-        lmc.tak?.let { setModuleConfig(ModuleConfig(tak = it)) }
+    private companion object {
+        // Firmware normally begins its seven-second reboot promptly. Bound only the departure separately so a rejected
+        // MQTT/Serial payload fails visibly instead of consuming the full reconnection allowance without ever
+        // rebooting.
+        val PROFILE_DEPARTURE_TIMEOUT = 20.seconds
+        val PROFILE_RECONNECT_TIMEOUT = 90.seconds
     }
 }

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallFields.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallFields.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.User
+
+internal fun validateOwnerRestore(profile: DeviceProfile, currentUser: User?) {
+    require(!profile.hasOwnerWrite() || currentUser != null) {
+        "The connected node owner must be loaded before restoring owner fields"
+    }
+}
+
+internal fun DeviceProfile.hasOwnerWrite(): Boolean = long_name != null || short_name != null || is_unmessagable != null
+
+/** Removes owner/config/module fields that already match the completed handshake snapshot. */
+internal fun DeviceProfile.withoutUnchangedFields(
+    currentConfig: LocalConfig,
+    currentModuleConfig: LocalModuleConfig,
+    currentUser: User?,
+): DeviceProfile = copy(
+    long_name = long_name?.takeUnless { it == currentUser?.long_name },
+    short_name = short_name?.takeUnless { it == currentUser?.short_name },
+    is_unmessagable = is_unmessagable?.takeUnless { it == currentUser?.is_unmessagable },
+    config = config.withoutUnchangedFields(currentConfig),
+    module_config = module_config.withoutUnchangedFields(currentModuleConfig),
+)
+
+/** Removes profile config sections already reported by the current handshake. */
+private fun LocalConfig?.withoutUnchangedFields(current: LocalConfig): LocalConfig? = this?.let { incoming ->
+    incoming
+        .copy(
+            device = incoming.device?.takeUnless { it == current.device },
+            position = incoming.position?.takeUnless { it == current.position },
+            power = incoming.power?.takeUnless { it == current.power },
+            network = incoming.network?.takeUnless { it == current.network },
+            display = incoming.display?.takeUnless { it == current.display },
+            lora = incoming.lora?.takeUnless { it == current.lora },
+            bluetooth = incoming.bluetooth?.takeUnless { it == current.bluetooth },
+            security = incoming.security?.takeUnless { it == current.security },
+        )
+        .takeIf { it.hasProfileWrites() }
+}
+
+/** Removes module sections already reported by the current handshake, including transport-disruptive modules. */
+private fun LocalModuleConfig?.withoutUnchangedFields(current: LocalModuleConfig): LocalModuleConfig? =
+    this?.let { incoming ->
+        incoming
+            .copy(
+                mqtt = incoming.mqtt?.takeUnless { it == current.mqtt },
+                serial = incoming.serial?.takeUnless { it == current.serial },
+                external_notification =
+                incoming.external_notification?.takeUnless { it == current.external_notification },
+                store_forward = incoming.store_forward?.takeUnless { it == current.store_forward },
+                range_test = incoming.range_test?.takeUnless { it == current.range_test },
+                telemetry = incoming.telemetry?.takeUnless { it == current.telemetry },
+                canned_message = incoming.canned_message?.takeUnless { it == current.canned_message },
+                audio = incoming.audio?.takeUnless { it == current.audio },
+                remote_hardware = incoming.remote_hardware?.takeUnless { it == current.remote_hardware },
+                neighbor_info = incoming.neighbor_info?.takeUnless { it == current.neighbor_info },
+                ambient_lighting = incoming.ambient_lighting?.takeUnless { it == current.ambient_lighting },
+                detection_sensor = incoming.detection_sensor?.takeUnless { it == current.detection_sensor },
+                paxcounter = incoming.paxcounter?.takeUnless { it == current.paxcounter },
+                statusmessage = incoming.statusmessage?.takeUnless { it == current.statusmessage },
+                traffic_management = incoming.traffic_management?.takeUnless { it == current.traffic_management },
+                tak = incoming.tak?.takeUnless { it == current.tak },
+                mesh_beacon = incoming.mesh_beacon?.takeUnless { it == current.mesh_beacon },
+            )
+            .takeIf { it.hasProfileWrites() }
+    }
+
+internal fun LocalConfig?.withoutTransportSensitiveConfig(): LocalConfig? =
+    this?.copy(bluetooth = null, network = null)?.takeIf { it.hasInstallableWrites() }
+
+internal fun LocalConfig.hasInstallableWrites(): Boolean = installableConfigs().isNotEmpty()
+
+private fun LocalConfig.hasProfileWrites(): Boolean = hasInstallableWrites() || network != null || bluetooth != null
+
+internal fun LocalModuleConfig?.withoutTransportDisruptiveModules(): LocalModuleConfig? =
+    this?.copy(mqtt = null, serial = null)?.takeIf { it.hasInstallableWrites() }
+
+internal fun LocalModuleConfig.hasInstallableWrites(): Boolean = installableModuleConfigs().isNotEmpty()
+
+private fun LocalModuleConfig.hasProfileWrites(): Boolean = hasInstallableWrites() || mqtt != null || serial != null

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallPlan.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallPlan.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.core.common.util.CommonUri
+import org.meshtastic.core.model.DeviceType
+import org.meshtastic.core.model.util.CHANNEL_REPLACEMENT_SLOT_COUNT
+import org.meshtastic.core.model.util.getChannelReplacementList
+import org.meshtastic.core.model.util.normalizeReplacementSettings
+import org.meshtastic.core.model.util.toChannelSet
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.User
+
+internal object ProfileInstallPlanner {
+    fun create(
+        profile: DeviceProfile,
+        currentConfig: LocalConfig,
+        currentModuleConfig: LocalModuleConfig,
+        currentUser: User?,
+        activeTransport: DeviceType,
+    ): ProfileInstallPlan {
+        val channelRestore = prepareChannelRestore(profile, currentConfig)
+        val pendingProfile = profile.withoutUnchangedFields(currentConfig, currentModuleConfig, currentUser)
+
+        return ProfileInstallPlan(
+            profile = pendingProfile,
+            config = pendingProfile.config.withoutTransportSensitiveConfig(),
+            moduleConfig = pendingProfile.module_config.withoutTransportDisruptiveModules(),
+            channelRestore = channelRestore,
+            transportPlan = pendingProfile.transportSensitivePlan(activeTransport),
+        )
+    }
+
+    private fun prepareChannelRestore(profile: DeviceProfile, currentConfig: LocalConfig): ChannelRestore? {
+        val channelUrl = profile.channel_url ?: return null
+        val channelSet = CommonUri.parse(channelUrl).toChannelSet()
+        require(channelSet.settings.isNotEmpty()) { "Imported channel set must contain at least one channel" }
+        val currentLora = currentConfig.lora
+        val identityLora = profile.config?.lora ?: channelSet.lora_config ?: currentLora
+        val normalizedSettings = normalizeReplacementSettings(channelSet.settings, identityLora)
+        require(normalizedSettings.size <= CHANNEL_REPLACEMENT_SLOT_COUNT) {
+            "Imported channel set exceeds supported channel slot count"
+        }
+        val writes =
+            getChannelReplacementList(
+                new = normalizedSettings,
+                minimumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
+                maximumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
+            )
+        val loraConfig = channelSet.lora_config?.takeIf { profile.config?.lora == null && it != currentLora }
+        return ChannelRestore(writes = writes, normalizedSettings = normalizedSettings, loraConfig = loraConfig)
+    }
+}
+
+internal data class ProfileInstallPlan(
+    val profile: DeviceProfile,
+    val config: LocalConfig?,
+    val moduleConfig: LocalModuleConfig?,
+    val channelRestore: ChannelRestore?,
+    val transportPlan: TransportSensitivePlan,
+) {
+    val hasTransactionalWrites: Boolean
+        get() =
+            profile.hasOwnerWrite() ||
+                config != null ||
+                profile.fixed_position != null ||
+                moduleConfig != null ||
+                channelRestore?.hasInstallableWrites == true
+}
+
+internal data class ChannelRestore(
+    val writes: List<Channel>,
+    val normalizedSettings: List<ChannelSettings>,
+    val loraConfig: Config.LoRaConfig?,
+) {
+    val hasInstallableWrites: Boolean
+        get() = writes.isNotEmpty() || loraConfig != null
+}
+
+internal enum class ProfileInstallStage(val logName: String) {
+    TRANSACTION("transaction"),
+    MQTT("mqtt"),
+    SERIAL("serial"),
+    BLUETOOTH("bluetooth"),
+    NETWORK("network"),
+    TRANSPORT_CONFIG("terminal transport configuration"),
+}
+
+internal data class TransportSensitivePlan(
+    val mqtt: ModuleConfig?,
+    val continuingStages: List<TransportSensitiveStage>,
+    val terminalStages: List<TransportSensitiveStage>,
+    val groupedTerminalConfig: List<TransportSensitiveStage.ConfigWrite>,
+)
+
+internal sealed interface TransportSensitiveStage {
+    val profileStage: ProfileInstallStage
+    val expectsReconnect: Boolean
+
+    data class ConfigWrite(
+        override val profileStage: ProfileInstallStage,
+        val config: Config,
+        override val expectsReconnect: Boolean,
+    ) : TransportSensitiveStage
+
+    data class ModuleConfigWrite(
+        override val profileStage: ProfileInstallStage,
+        val config: ModuleConfig,
+        override val expectsReconnect: Boolean,
+    ) : TransportSensitiveStage
+}
+
+private fun DeviceProfile.transportSensitivePlan(activeTransport: DeviceType): TransportSensitivePlan {
+    val stages = transportSensitiveStages(activeTransport)
+    val configStages = stages.filterIsInstance<TransportSensitiveStage.ConfigWrite>()
+    val groupedTerminalConfig =
+        configStages.takeIf { writes -> writes.size > 1 && writes.any { !it.expectsReconnect } }.orEmpty()
+    val individualStages = stages - groupedTerminalConfig.toSet()
+    val (continuingStages, terminalStages) = individualStages.partition(TransportSensitiveStage::expectsReconnect)
+    val terminalStageCount = terminalStages.size + if (groupedTerminalConfig.isEmpty()) 0 else 1
+
+    check(terminalStageCount <= 1) { "Profile contains multiple settings that end the active transport" }
+
+    return TransportSensitivePlan(
+        mqtt = module_config?.mqtt?.let { ModuleConfig(mqtt = it) },
+        continuingStages = continuingStages,
+        terminalStages = terminalStages,
+        groupedTerminalConfig = groupedTerminalConfig,
+    )
+}
+
+private fun DeviceProfile.transportSensitiveStages(activeTransport: DeviceType): List<TransportSensitiveStage> =
+    buildList {
+        module_config?.serial?.let { serial ->
+            add(
+                TransportSensitiveStage.ModuleConfigWrite(
+                    profileStage = ProfileInstallStage.SERIAL,
+                    config = ModuleConfig(serial = serial),
+                    expectsReconnect = activeTransport != DeviceType.USB,
+                ),
+            )
+        }
+        config?.bluetooth?.let { bluetooth ->
+            add(
+                TransportSensitiveStage.ConfigWrite(
+                    profileStage = ProfileInstallStage.BLUETOOTH,
+                    config = Config(bluetooth = bluetooth),
+                    expectsReconnect = activeTransport != DeviceType.BLE || bluetooth.enabled,
+                ),
+            )
+        }
+        config?.network?.let { network ->
+            add(
+                TransportSensitiveStage.ConfigWrite(
+                    profileStage = ProfileInstallStage.NETWORK,
+                    config = Config(network = network),
+                    expectsReconnect = network.expectsActiveTransportReconnect(activeTransport),
+                ),
+            )
+        }
+    }
+
+private fun Config.NetworkConfig.expectsActiveTransportReconnect(activeTransport: DeviceType): Boolean =
+    when (activeTransport) {
+        DeviceType.BLE -> !wifi_enabled && !eth_enabled
+        DeviceType.TCP -> false
+        DeviceType.USB -> true
+    }

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallWrites.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallWrites.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.core.model.Position
+import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.User
+
+// is_licensed is deliberately excluded: enabling ham mode is a dedicated onboarding flow with additional side effects.
+internal suspend fun AdminEditScope.installOwner(profile: DeviceProfile, currentUser: User?) {
+    if (profile.hasOwnerWrite()) {
+        setOwner(
+            checkNotNull(currentUser)
+                .copy(
+                    long_name = profile.long_name ?: currentUser.long_name,
+                    short_name = profile.short_name ?: currentUser.short_name,
+                    is_unmessagable = profile.is_unmessagable ?: currentUser.is_unmessagable,
+                ),
+        )
+    }
+}
+
+internal suspend fun AdminEditScope.installConfig(config: LocalConfig?) {
+    config?.installableConfigs()?.forEach { setConfig(it) }
+}
+
+internal fun LocalConfig.installableConfigs(): List<Config> = listOfNotNull(
+    device?.let { Config(device = it) },
+    position?.let { Config(position = it) },
+    power?.let { Config(power = it) },
+    display?.let { Config(display = it) },
+    lora?.let { Config(lora = it) },
+    security?.let { Config(security = it) },
+)
+
+/** Writes an authoritative channel replacement and reports each successfully issued channel command. */
+internal suspend fun AdminEditScope.installChannels(restore: ChannelRestore?, onWriteIssued: () -> Unit) {
+    restore?.writes?.forEach { channel ->
+        setChannel(channel)
+        onWriteIssued()
+    }
+    restore?.loraConfig?.let { setConfig(Config(lora = it)) }
+}
+
+internal suspend fun AdminEditScope.installFixedPosition(fixedPosition: org.meshtastic.proto.Position?) {
+    fixedPosition?.let { setFixedPosition(Position(it)) }
+}
+
+/** Writes module configurations safe for the ordinary transaction; MQTT and Serial are staged separately. */
+internal suspend fun AdminEditScope.installModuleConfig(moduleConfig: LocalModuleConfig?) {
+    moduleConfig?.installableModuleConfigs()?.forEach { setModuleConfig(it) }
+}
+
+@Suppress("CyclomaticComplexMethod")
+internal fun LocalModuleConfig.installableModuleConfigs(): List<ModuleConfig> = listOfNotNull(
+    external_notification?.let { ModuleConfig(external_notification = it) },
+    store_forward?.let { ModuleConfig(store_forward = it) },
+    range_test?.let { ModuleConfig(range_test = it) },
+    telemetry?.let { ModuleConfig(telemetry = it) },
+    canned_message?.let { ModuleConfig(canned_message = it) },
+    audio?.let { ModuleConfig(audio = it) },
+    remote_hardware?.let { ModuleConfig(remote_hardware = it) },
+    neighbor_info?.let { ModuleConfig(neighbor_info = it) },
+    ambient_lighting?.let { ModuleConfig(ambient_lighting = it) },
+    detection_sensor?.let { ModuleConfig(detection_sensor = it) },
+    paxcounter?.let { ModuleConfig(paxcounter = it) },
+    statusmessage?.let { ModuleConfig(statusmessage = it) },
+    traffic_management?.let { ModuleConfig(traffic_management = it) },
+    tak?.let { ModuleConfig(tak = it) },
+    mesh_beacon?.let { ModuleConfig(mesh_beacon = it) },
+)

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
@@ -16,8 +16,30 @@
  */
 package org.meshtastic.core.domain.usecase.settings
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.util.CHANNEL_REPLACEMENT_SLOT_COUNT
+import org.meshtastic.core.model.util.MalformedMeshtasticUrlException
+import org.meshtastic.core.model.util.getChannelUrl
+import org.meshtastic.core.repository.NodeRestartTracker
+import org.meshtastic.core.testing.FakeNodeRepository
+import org.meshtastic.core.testing.FakeRadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioController
+import org.meshtastic.core.testing.FakeRadioInterfaceService
+import org.meshtastic.core.testing.TestDataFactory
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config.BluetoothConfig
 import org.meshtastic.proto.Config.DeviceConfig
 import org.meshtastic.proto.Config.DisplayConfig
@@ -27,95 +49,707 @@ import org.meshtastic.proto.Config.PositionConfig
 import org.meshtastic.proto.Config.PowerConfig
 import org.meshtastic.proto.Config.SecurityConfig
 import org.meshtastic.proto.DeviceProfile
-import org.meshtastic.proto.ModuleConfig.AmbientLightingConfig
-import org.meshtastic.proto.ModuleConfig.AudioConfig
-import org.meshtastic.proto.ModuleConfig.CannedMessageConfig
-import org.meshtastic.proto.ModuleConfig.DetectionSensorConfig
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.ModuleConfig.ExternalNotificationConfig
 import org.meshtastic.proto.ModuleConfig.MQTTConfig
-import org.meshtastic.proto.ModuleConfig.NeighborInfoConfig
-import org.meshtastic.proto.ModuleConfig.PaxcounterConfig
-import org.meshtastic.proto.ModuleConfig.RangeTestConfig
-import org.meshtastic.proto.ModuleConfig.RemoteHardwareConfig
+import org.meshtastic.proto.ModuleConfig.MeshBeaconConfig
 import org.meshtastic.proto.ModuleConfig.SerialConfig
-import org.meshtastic.proto.ModuleConfig.StatusMessageConfig
-import org.meshtastic.proto.ModuleConfig.StoreForwardConfig
-import org.meshtastic.proto.ModuleConfig.TAKConfig
-import org.meshtastic.proto.ModuleConfig.TelemetryConfig
+import org.meshtastic.proto.ModuleConfig.TrafficManagementConfig
 import org.meshtastic.proto.User
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class InstallProfileUseCaseTest {
 
     private lateinit var radioController: FakeRadioController
+    private lateinit var radioInterfaceService: FakeRadioInterfaceService
+    private lateinit var radioConfigRepository: FakeRadioConfigRepository
+    private lateinit var nodeRepository: FakeNodeRepository
+    private lateinit var testDispatcher: TestDispatcher
+    private lateinit var restartTrackerScope: CoroutineScope
+    private lateinit var restartTracker: NodeRestartTracker
     private lateinit var useCase: InstallProfileUseCase
 
     @BeforeTest
     fun setUp() {
-        radioController = FakeRadioController()
-        useCase = InstallProfileUseCase(radioController)
+        testDispatcher = StandardTestDispatcher()
+        restartTrackerScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        radioController = FakeRadioController().apply { setConnectionState(ConnectionState.Connected) }
+        radioInterfaceService =
+            FakeRadioInterfaceService(restartTrackerScope).apply { setDeviceAddress("x00:11:22:33:44:55") }
+        radioConfigRepository = FakeRadioConfigRepository()
+        nodeRepository =
+            FakeNodeRepository().apply { setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = 1234)) }
+        restartTracker = NodeRestartTracker(restartTrackerScope)
+        useCase =
+            InstallProfileUseCase(
+                radioController,
+                radioInterfaceService,
+                radioConfigRepository,
+                nodeRepository,
+                restartTracker,
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        restartTrackerScope.cancel()
     }
 
     @Test
-    fun `invoke calls begin and commit edit settings`() = runTest {
-        useCase(1234, DeviceProfile(), User())
+    fun `empty profile performs no restart or writes`() = runTest(testDispatcher) {
+        useCase(1234, DeviceProfile(), User(), isLocal = true)
+
+        assertNoDeviceWrites()
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `transaction on TCP waits for the firmware reboot and handshake`() = runTest(testDispatcher) {
+        radioInterfaceService.setDeviceAddress("t192.0.2.1")
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        val profile = DeviceProfile(config = LocalConfig(lora = LoRaConfig(region = LoRaConfig.RegionCode.US)))
+
+        useCase(1234, profile, User(), isLocal = true)
 
         assertTrue(radioController.editSettingsCalled)
+        assertEquals(ConnectionState.Connected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
     }
 
     @Test
-    fun `invoke installs all sections of a full profile`() = runTest {
+    fun `fast restart cycle cannot be lost to connection state conflation`() = runTest(testDispatcher) {
+        radioController.onEditSettingsCommitted = { emitFastRestartCycle() }
+        val profile = DeviceProfile(config = LocalConfig(device = DeviceConfig()))
+        val baselineEpochs = radioController.connectionEpochs.value
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(ConnectionState.Connected, radioController.connectionState.value)
+        assertEquals(baselineEpochs.departures + 1, radioController.connectionEpochs.value.departures)
+        assertEquals(
+            baselineEpochs.completedHandshakes + 1,
+            radioController.connectionEpochs.value.completedHandshakes,
+        )
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `reconnect must follow the latest departure rather than an older handshake`() = runTest(testDispatcher) {
+        val allowLatestReconnect = CompletableDeferred<Unit>()
+        radioController.onEditSettingsCommitted = {
+            emitFastRestartCycle()
+            radioController.setConnectionState(ConnectionState.Disconnected)
+            backgroundScope.launch {
+                allowLatestReconnect.await()
+                radioController.setConnectionState(ConnectionState.Connected)
+            }
+        }
+        radioController.onStandaloneModuleConfig = { emitFastRestartCycle() }
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(device = DeviceConfig()),
+                module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true)),
+            )
+
+        val installation = async { useCase(1234, profile, User(), isLocal = true) }
+        testScheduler.runCurrent()
+
+        assertFalse(installation.isCompleted)
+        assertTrue(radioController.moduleConfigWrites.isEmpty())
+
+        allowLatestReconnect.complete(Unit)
+        testScheduler.runCurrent()
+        installation.await()
+
+        assertEquals(MQTTConfig(enabled = true), radioController.moduleConfigs.single().mqtt)
+    }
+
+    @Test
+    fun `version-only remnants do not open an empty transaction`() = runTest(testDispatcher) {
+        radioController.onStandaloneModuleConfig = { emitFastRestartCycle() }
+        radioController.onStandaloneConfig = { emitDeparture() }
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(bluetooth = BluetoothConfig(enabled = false), version = 1),
+                module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true), version = 1),
+            )
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertFalse(radioController.editSettingsCalled)
+        assertEquals(listOf("module:update", "config:update"), radioController.adminOperations)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `unchanged profile config is skipped without restart or writes`() = runTest(testDispatcher) {
+        val currentConfig =
+            LocalConfig(
+                device = DeviceConfig(),
+                position = PositionConfig(),
+                power = PowerConfig(),
+                network = NetworkConfig(wifi_enabled = true, wifi_ssid = "existing"),
+                display = DisplayConfig(compass_north_top = true),
+                lora = LoRaConfig(region = LoRaConfig.RegionCode.US),
+                bluetooth = BluetoothConfig(enabled = true),
+                security = SecurityConfig(),
+                version = 7,
+            )
+        val currentModuleConfig =
+            LocalModuleConfig(
+                mqtt = MQTTConfig(enabled = true),
+                serial = SerialConfig(enabled = true),
+                external_notification = ExternalNotificationConfig(enabled = true),
+                traffic_management = TrafficManagementConfig(position_min_interval_secs = 30),
+                mesh_beacon = MeshBeaconConfig(broadcast_message = "existing beacon"),
+                version = 9,
+            )
+        radioConfigRepository.setLocalConfigDirect(currentConfig)
+        radioConfigRepository.setLocalModuleConfigDirect(currentModuleConfig)
+
+        val currentUser = User(long_name = "Current User", short_name = "CUR", is_unmessagable = true)
+        useCase(
+            1234,
+            DeviceProfile(
+                long_name = currentUser.long_name,
+                short_name = currentUser.short_name,
+                is_unmessagable = currentUser.is_unmessagable,
+                config = currentConfig,
+                module_config = currentModuleConfig,
+            ),
+            currentUser,
+            isLocal = true,
+        )
+
+        assertNoDeviceWrites()
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `mixed profile sends only changed ordinary and transport settings`() = runTest(testDispatcher) {
+        val currentConfig =
+            LocalConfig(
+                device = DeviceConfig(),
+                display = DisplayConfig(compass_north_top = false),
+                network = NetworkConfig(wifi_enabled = false),
+                bluetooth = BluetoothConfig(enabled = true),
+            )
+        val currentModuleConfig =
+            LocalModuleConfig(
+                mqtt = MQTTConfig(enabled = true),
+                serial = SerialConfig(enabled = false),
+                external_notification = ExternalNotificationConfig(enabled = true),
+                mesh_beacon = MeshBeaconConfig(broadcast_message = "old beacon"),
+            )
+        radioConfigRepository.setLocalConfigDirect(currentConfig)
+        radioConfigRepository.setLocalModuleConfigDirect(currentModuleConfig)
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        radioController.onStandaloneModuleConfig = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(
+                config = currentConfig.copy(display = DisplayConfig(compass_north_top = true)),
+                module_config =
+                currentModuleConfig.copy(
+                    serial = SerialConfig(enabled = true),
+                    mesh_beacon = MeshBeaconConfig(broadcast_message = "new beacon"),
+                ),
+            ),
+            User(),
+            isLocal = true,
+        )
+
+        assertEquals(
+            listOf(DisplayConfig(compass_north_top = true)),
+            radioController.localConfigs.mapNotNull { it.display },
+        )
+        assertEquals(
+            listOf(MeshBeaconConfig(broadcast_message = "new beacon"), SerialConfig(enabled = true)),
+            radioController.moduleConfigs.mapNotNull { it.mesh_beacon ?: it.serial },
+        )
+        assertEquals(
+            listOf("begin", "config:update", "module:update", "commit", "module:update"),
+            radioController.adminOperations,
+        )
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `mesh beacon profile is restored inside the ordinary transaction`() = runTest(testDispatcher) {
+        val meshBeacon = MeshBeaconConfig(broadcast_message = "restored beacon")
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(module_config = LocalModuleConfig(mesh_beacon = meshBeacon)),
+            User(),
+            isLocal = true,
+        )
+
+        assertTrue(radioController.editSettingsCalled)
+        assertEquals(meshBeacon, radioController.moduleConfigs.single().mesh_beacon)
+        assertEquals(listOf("begin", "module:update", "commit"), radioController.adminOperations)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `traffic management profile is restored inside the ordinary transaction`() = runTest(testDispatcher) {
+        val trafficManagement = TrafficManagementConfig(position_min_interval_secs = 30)
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(module_config = LocalModuleConfig(traffic_management = trafficManagement)),
+            User(),
+            isLocal = true,
+        )
+
+        assertTrue(radioController.editSettingsCalled)
+        assertEquals(trafficManagement, radioController.moduleConfigs.single().traffic_management)
+        assertEquals(listOf("begin", "module:update", "commit"), radioController.adminOperations)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `matching channel profile still rewrites every firmware slot authoritatively`() = runTest(testDispatcher) {
+        val settings = listOf(ChannelSettings(name = "Existing", psk = byteArrayOf(1).toByteString()))
+        radioConfigRepository.setChannelSet(ChannelSet(settings = settings))
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        val profile = DeviceProfile(channel_url = ChannelSet(settings = settings).getChannelUrl().toString())
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(
+            (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(),
+            radioController.localChannels.map(Channel::index),
+        )
+        assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `TCP profile restores network last after reconnecting from earlier stages`() = runTest(testDispatcher) {
+        val mqtt = MQTTConfig(enabled = true)
+        val serial = SerialConfig(enabled = true)
+        val bluetooth = BluetoothConfig(enabled = true)
+        val network = NetworkConfig(wifi_enabled = true, wifi_ssid = "new-network")
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(network = network, bluetooth = bluetooth),
+                module_config = LocalModuleConfig(mqtt = mqtt, serial = serial),
+            )
+        radioInterfaceService.setDeviceAddress("t192.0.2.1")
+        radioController.onStandaloneModuleConfig = { emitRestartCycle() }
+        radioController.onEditSettingsCommitted = { emitDeparture() }
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(listOf(mqtt, serial), radioController.moduleConfigs.mapNotNull { it.mqtt ?: it.serial })
+        assertEquals(bluetooth, radioController.localConfigs.first().bluetooth)
+        assertEquals(network, radioController.localConfigs.last().network)
+        assertEquals(
+            listOf("module:update", "module:update", "begin", "config:update", "config:update", "commit"),
+            radioController.adminOperations,
+        )
+        assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `USB profile restores serial last after reconnecting from earlier stages`() = runTest(testDispatcher) {
+        val mqtt = MQTTConfig(enabled = true)
+        val serial = SerialConfig(enabled = true)
+        val bluetooth = BluetoothConfig(enabled = true)
+        val network = NetworkConfig(wifi_enabled = true, wifi_ssid = "new-network")
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(bluetooth = bluetooth, network = network),
+                module_config = LocalModuleConfig(mqtt = mqtt, serial = serial),
+            )
+        radioInterfaceService.setDeviceAddress("s/dev/ttyUSB0")
+        radioController.onStandaloneModuleConfig = { config ->
+            if (config.serial != null) emitDeparture() else emitRestartCycle()
+        }
+        radioController.onStandaloneConfig = { emitRestartCycle() }
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(listOf(mqtt, serial), radioController.moduleConfigs.mapNotNull { it.mqtt ?: it.serial })
+        assertEquals(listOf(bluetooth, null), radioController.localConfigs.map { it.bluetooth })
+        assertEquals(listOf(null, network), radioController.localConfigs.map { it.network })
+        assertEquals(
+            listOf("module:update", "config:update", "config:update", "module:update"),
+            radioController.adminOperations,
+        )
+        assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `BLE terminal transport settings commit together before the connection ends`() = runTest(testDispatcher) {
+        val bluetooth = BluetoothConfig(enabled = false)
+        val network = NetworkConfig(wifi_enabled = true, wifi_ssid = "new-network")
+        radioController.onEditSettingsCommitted = { emitDeparture() }
+
+        useCase(
+            1234,
+            DeviceProfile(config = LocalConfig(bluetooth = bluetooth, network = network)),
+            User(),
+            isLocal = true,
+        )
+
+        assertEquals(listOf(bluetooth, null), radioController.localConfigs.map { it.bluetooth })
+        assertEquals(listOf(null, network), radioController.localConfigs.map { it.network })
+        assertEquals(listOf("begin", "config:update", "config:update", "commit"), radioController.adminOperations)
+        assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `rejected standalone module config fails after the bounded departure wait`() = runTest(testDispatcher) {
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                useCase(
+                    1234,
+                    DeviceProfile(module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true))),
+                    User(),
+                    isLocal = true,
+                )
+            }
+
+        assertEquals("Device did not begin the mqtt profile restart", failure.message)
+        assertEquals(20_000L, testScheduler.currentTime)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `full profile commits ordinary settings before transport disruptive stages`() = runTest(testDispatcher) {
+        val importedChannels =
+            listOf(
+                ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()),
+                ChannelSettings(name = "Private", psk = byteArrayOf(2).toByteString()),
+            )
+        val channelUrl =
+            ChannelSet(settings = importedChannels, lora_config = LoRaConfig(region = LoRaConfig.RegionCode.US))
+                .getChannelUrl()
+                .toString()
+        radioConfigRepository.setChannelSet(
+            ChannelSet(settings = listOf(ChannelSettings(name = "Old"), ChannelSettings(name = "Stale"))),
+        )
+        radioConfigRepository.setLocalConfigDirect(
+            LocalConfig(lora = LoRaConfig(region = LoRaConfig.RegionCode.EU_868)),
+        )
+
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        radioController.onStandaloneModuleConfig = {
+            assertEquals(importedChannels, radioConfigRepository.currentChannelSet.settings)
+            emitRestartCycle()
+        }
+        radioController.onStandaloneConfig = { emitRestartCycle() }
+
         val profile =
             DeviceProfile(
                 long_name = "Full Node",
                 short_name = "FULL",
+                channel_url = channelUrl,
                 config =
-                org.meshtastic.proto.LocalConfig(
+                LocalConfig(
                     device = DeviceConfig(),
                     position = PositionConfig(),
                     power = PowerConfig(),
                     network = NetworkConfig(),
                     display = DisplayConfig(),
-                    lora = LoRaConfig(),
-                    bluetooth = BluetoothConfig(),
+                    lora = LoRaConfig(region = LoRaConfig.RegionCode.US),
+                    bluetooth = BluetoothConfig(enabled = true),
                     security = SecurityConfig(),
                 ),
                 module_config =
-                org.meshtastic.proto.LocalModuleConfig(
-                    mqtt = MQTTConfig(),
-                    serial = SerialConfig(),
-                    external_notification = ExternalNotificationConfig(),
-                    store_forward = StoreForwardConfig(),
-                    range_test = RangeTestConfig(),
-                    telemetry = TelemetryConfig(),
-                    canned_message = CannedMessageConfig(),
-                    audio = AudioConfig(),
-                    remote_hardware = RemoteHardwareConfig(),
-                    neighbor_info = NeighborInfoConfig(),
-                    ambient_lighting = AmbientLightingConfig(),
-                    detection_sensor = DetectionSensorConfig(),
-                    paxcounter = PaxcounterConfig(),
-                    statusmessage = StatusMessageConfig(),
-                    tak = TAKConfig(),
+                LocalModuleConfig(
+                    mqtt = MQTTConfig(enabled = true),
+                    serial = SerialConfig(enabled = true),
+                    external_notification = ExternalNotificationConfig(enabled = true),
+                    mesh_beacon = MeshBeaconConfig(broadcast_message = "restored beacon"),
                 ),
-                fixed_position = org.meshtastic.proto.Position(),
+                fixed_position = org.meshtastic.proto.Position(latitude_i = 1, longitude_i = 2),
             )
 
-        useCase(1234, profile, org.meshtastic.proto.User(long_name = "Old"))
+        useCase(1234, profile, User(long_name = "Old"), isLocal = true)
 
-        assertTrue(radioController.editSettingsCalled)
+        assertEquals(listOf("begin", "owner"), radioController.adminOperations.take(2))
+        assertTrue(
+            radioController.adminOperations.indexOf("commit") >
+                radioController.adminOperations.indexOf("fixed-position"),
+        )
+        assertEquals(
+            listOf(
+                ExternalNotificationConfig(enabled = true),
+                MeshBeaconConfig(broadcast_message = "restored beacon"),
+                MQTTConfig(enabled = true),
+                SerialConfig(enabled = true),
+            ),
+            radioController.moduleConfigs.mapNotNull {
+                it.external_notification ?: it.mesh_beacon ?: it.mqtt ?: it.serial
+            },
+        )
+        val commitIndex = radioController.adminOperations.indexOf("commit")
+        val moduleOperationIndexes =
+            radioController.adminOperations.mapIndexedNotNull { index, operation ->
+                index.takeIf { operation.startsWith("module:") }
+            }
+        val firstTransportSensitiveModuleIndex =
+            radioController.moduleConfigs.indexOfFirst { it.mqtt != null || it.serial != null }
+        assertTrue(firstTransportSensitiveModuleIndex > 0)
+        assertTrue(moduleOperationIndexes.take(firstTransportSensitiveModuleIndex).all { it < commitIndex })
+        assertTrue(moduleOperationIndexes.drop(firstTransportSensitiveModuleIndex).all { it > commitIndex })
+        assertEquals(
+            BluetoothConfig(enabled = true),
+            radioController.localConfigs.mapNotNull { it.bluetooth }.last(),
+        )
+        assertEquals(NetworkConfig(), radioController.localConfigs.mapNotNull { it.network }.last())
+        assertEquals(1e-7, radioController.fixedPositions.single().latitude, absoluteTolerance = 1e-12)
+        assertEquals(2e-7, radioController.fixedPositions.single().longitude, absoluteTolerance = 1e-12)
+        assertEquals(
+            (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(),
+            radioController.localChannels.map(Channel::index),
+        )
+        assertEquals(importedChannels, radioConfigRepository.currentChannelSet.settings)
+        assertFalse(restartTracker.restartExpected.value)
     }
 
     @Test
-    fun `invoke installs is_unmessagable but never auto-installs is_licensed`() = runTest {
+    fun `channel cache remains unchanged when the first transactional channel write fails`() = runTest(testDispatcher) {
+        val original = listOf(ChannelSettings(name = "Original", psk = byteArrayOf(9).toByteString()))
+        val imported = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        radioConfigRepository.setChannelSet(ChannelSet(settings = original))
+        radioController.failChannelWriteAfter = 0
+        val profile = DeviceProfile(channel_url = ChannelSet(settings = imported).getChannelUrl().toString())
+
+        assertFails { useCase(1234, profile, User(), isLocal = true) }
+
+        assertTrue(radioController.localChannels.isEmpty())
+        assertTrue("commit" in radioController.adminOperations)
+        assertEquals(original, radioConfigRepository.currentChannelSet.settings)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `channel cache reconciles the authoritative import after a partial transaction failure`() =
+        runTest(testDispatcher) {
+            val original = listOf(ChannelSettings(name = "Original", psk = byteArrayOf(9).toByteString()))
+            val imported =
+                listOf(
+                    ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()),
+                    ChannelSettings(name = "Private", psk = byteArrayOf(2).toByteString()),
+                )
+            radioConfigRepository.setChannelSet(ChannelSet(settings = original))
+            radioController.failChannelWriteAfter = 2
+            val profile = DeviceProfile(channel_url = ChannelSet(settings = imported).getChannelUrl().toString())
+
+            assertFails { useCase(1234, profile, User(), isLocal = true) }
+
+            assertEquals(listOf(0, 1), radioController.localChannels.map(Channel::index))
+            assertTrue("commit" in radioController.adminOperations)
+            assertEquals(imported, radioConfigRepository.currentChannelSet.settings)
+            assertFalse(restartTracker.restartExpected.value)
+        }
+
+    @Test
+    fun `transaction failure remains primary when channel cache reconciliation also fails`() = runTest(testDispatcher) {
+        val imported = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        radioController.failChannelWriteAfter = 1
+        radioConfigRepository.replaceAllSettingsFailure = IllegalStateException("cache reconciliation failed")
+        val profile = DeviceProfile(channel_url = ChannelSet(settings = imported).getChannelUrl().toString())
+
+        val failure = assertFailsWith<IllegalStateException> { useCase(1234, profile, User(), isLocal = true) }
+
+        assertEquals("Fake channel write failure", failure.message)
+        assertEquals(listOf("cache reconciliation failed"), failure.suppressedExceptions.map(Throwable::message))
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `transport stages retarget the current local identity after each reconnect`() = runTest(testDispatcher) {
+        radioController.onEditSettingsCommitted = {
+            nodeRepository.setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = 5678))
+            emitRestartCycle()
+        }
+        radioController.onStandaloneModuleConfig = { moduleConfig ->
+            val nextNodeNum = if (moduleConfig.mqtt != null) 9012 else 3456
+            nodeRepository.setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = nextNodeNum))
+            emitRestartCycle()
+        }
+        radioController.onStandaloneConfig = { emitRestartCycle() }
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(security = SecurityConfig(), bluetooth = BluetoothConfig(enabled = true)),
+                module_config =
+                LocalModuleConfig(mqtt = MQTTConfig(enabled = true), serial = SerialConfig(enabled = true)),
+            )
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(listOf(0), radioController.editSettingsDestinations)
+        assertEquals(listOf(5678, 9012), radioController.moduleConfigDestinations.takeLast(2))
+        assertEquals(3456, radioController.configWrites.last().destination)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `profile install rejects a stale local destination before writes`() = runTest(testDispatcher) {
+        nodeRepository.setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = 5678))
+
+        assertFailsWith<IllegalArgumentException> {
+            useCase(1234, DeviceProfile(long_name = "Stale"), User(), isLocal = true)
+        }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `bluetooth disable is the final stage and does not wait for an impossible reconnect`() =
+        runTest(testDispatcher) {
+            radioController.onEditSettingsCommitted = { emitRestartCycle() }
+            radioController.onStandaloneConfig = {
+                radioController.setConnectionState(ConnectionState.Disconnected)
+                yield()
+            }
+            val profile =
+                DeviceProfile(
+                    config = LocalConfig(device = DeviceConfig(), bluetooth = BluetoothConfig(enabled = false)),
+                )
+
+            useCase(1234, profile, User(), isLocal = true)
+
+            assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+            assertEquals(BluetoothConfig(enabled = false), radioController.localConfigs.last().bluetooth)
+            assertFalse(restartTracker.restartExpected.value)
+        }
+
+    @Test
+    fun `unchanged explicit profile LoRa still overrides channel URL LoRa`() = runTest(testDispatcher) {
+        val currentLora = LoRaConfig(region = LoRaConfig.RegionCode.US, hop_limit = 3)
+        val channelLora = LoRaConfig(region = LoRaConfig.RegionCode.EU_868, hop_limit = 5)
+        val settings = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        val channelUrl = ChannelSet(settings = settings, lora_config = channelLora).getChannelUrl().toString()
+        radioConfigRepository.setLocalConfigDirect(LocalConfig(lora = currentLora))
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(config = LocalConfig(lora = currentLora), channel_url = channelUrl),
+            User(),
+            isLocal = true,
+        )
+
+        assertTrue(radioController.localConfigs.none { it.lora != null })
+        assertEquals(
+            (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(),
+            radioController.localChannels.map(Channel::index),
+        )
+        assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `channel URL without profile LoRa restores its channel LoRa config`() = runTest(testDispatcher) {
+        val channelLora = LoRaConfig(region = LoRaConfig.RegionCode.US, hop_limit = 4)
+        val settings = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        val channelUrl = ChannelSet(settings = settings, lora_config = channelLora).getChannelUrl().toString()
+        val profile = DeviceProfile(channel_url = channelUrl)
+        radioConfigRepository.setLocalConfigDirect(
+            LocalConfig(lora = LoRaConfig(region = LoRaConfig.RegionCode.EU_868)),
+        )
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(channelLora, radioController.localConfigs.single().lora)
+        assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
+    }
+
+    @Test
+    fun `owner fields fail before writes when current owner is unavailable`() = runTest(testDispatcher) {
+        val profile = DeviceProfile(long_name = "Restored")
+
+        assertFailsWith<IllegalArgumentException> { useCase(1234, profile, currentUser = null, isLocal = true) }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `malformed channel URL fails before any device write`() = runTest(testDispatcher) {
+        val profile = DeviceProfile(channel_url = "https://example.com/not-a-channel")
+
+        assertFailsWith<MalformedMeshtasticUrlException> { useCase(1234, profile, User(), isLocal = true) }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `channel URL without payload fails before any device write`() = runTest(testDispatcher) {
+        val profile = DeviceProfile(channel_url = ChannelSet().getChannelUrl().toString())
+
+        assertFailsWith<MalformedMeshtasticUrlException> { useCase(1234, profile, User(), isLocal = true) }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `profile install rejects remote administration`() = runTest(testDispatcher) {
+        assertFailsWith<IllegalArgumentException> {
+            useCase(1234, DeviceProfile(long_name = "Remote"), User(), isLocal = false)
+        }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `invoke installs is_unmessagable but never auto-installs is_licensed`() = runTest(testDispatcher) {
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
         val profile = DeviceProfile(is_unmessagable = true, is_licensed = true)
 
-        useCase(1234, profile, User(long_name = "Old"))
+        useCase(1234, profile, User(long_name = "Old"), isLocal = true)
 
         assertEquals(true, radioController.lastSetOwnerUser?.is_unmessagable)
         assertEquals(false, radioController.lastSetOwnerUser?.is_licensed)
+    }
+
+    private fun assertNoDeviceWrites() {
+        assertFalse(radioController.editSettingsCalled)
+        assertTrue(radioController.adminOperations.isEmpty())
+        assertTrue(radioController.configWrites.isEmpty())
+        assertTrue(radioController.localChannels.isEmpty())
+        assertTrue(radioController.moduleConfigs.isEmpty())
+        assertTrue(radioController.fixedPositions.isEmpty())
+        assertEquals(null, radioController.lastSetOwnerUser)
+    }
+
+    private suspend fun emitRestartCycle() {
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        yield()
+        radioController.setConnectionState(ConnectionState.Connecting)
+        yield()
+        radioController.setConnectionState(ConnectionState.Connected)
+        yield()
+    }
+
+    private fun emitFastRestartCycle() {
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        radioController.setConnectionState(ConnectionState.Connecting)
+        radioController.setConnectionState(ConnectionState.Connected)
+    }
+
+    private suspend fun emitDeparture() {
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        yield()
     }
 }

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ConnectionState.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ConnectionState.kt
@@ -29,3 +29,37 @@ sealed interface ConnectionState {
     /** The device is in a light sleep state, and we are waiting for it to wake up and reconnect to us. */
     data object DeviceSleep : ConnectionState
 }
+
+/**
+ * Monotonic counters for connection lifecycle events that cannot be inferred reliably from transient [ConnectionState]
+ * values. A fast disconnect/reconnect may be observed only as the final state, while these counters retain both
+ * lifecycle boundaries.
+ *
+ * @property departures Number of transitions away from [ConnectionState.Connected].
+ * @property completedHandshakes Number of transitions into [ConnectionState.Connected].
+ * @property handshakesAtLastDeparture Completed-handshake count captured at the most recent departure. This preserves
+ *   event ordering when a fast departure/reconnect pair is conflated into one observed state-flow value.
+ * @property lastDepartureState State entered by the most recent departure. Consumers that react after a fast reconnect
+ *   can use this event evidence instead of rereading the already-advanced live connection state.
+ */
+data class ConnectionEpochs(
+    val departures: Long = 0,
+    val completedHandshakes: Long = 0,
+    val handshakesAtLastDeparture: Long = 0,
+    val lastDepartureState: ConnectionState? = null,
+) {
+    /** Returns the counters after applying one canonical connection-state transition. */
+    fun advance(previous: ConnectionState, current: ConnectionState): ConnectionEpochs = when {
+        previous is ConnectionState.Connected && current !is ConnectionState.Connected ->
+            copy(
+                departures = departures + 1,
+                handshakesAtLastDeparture = completedHandshakes,
+                lastDepartureState = current,
+            )
+
+        previous !is ConnectionState.Connected && current is ConnectionState.Connected ->
+            copy(completedHandshakes = completedHandshakes + 1)
+
+        else -> this
+    }
+}

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelReplacement.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelReplacement.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model.util
+
+import okio.ByteString
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.core.model.Channel as ModelChannel
+
+/** Firmware channel files expose one primary plus seven secondary slots. */
+const val CHANNEL_REPLACEMENT_SLOT_COUNT = 8
+
+/**
+ * Builds the authoritative channel writes needed to replace a radio's complete channel set.
+ *
+ * Every imported slot is written, and any remaining firmware slots are explicitly disabled so stale channels cannot
+ * survive a restore. A blank primary means the firmware's default primary; blank secondary entries are disabled. Values
+ * in [currentSettings] are intentionally ignored; only its size contributes to the number of trailing slots that must
+ * be cleared. Inputs larger than [maximumSlotCount] are rejected rather than silently truncated.
+ */
+fun getChannelReplacementList(
+    new: List<ChannelSettings>,
+    currentSettings: List<ChannelSettings> = emptyList(),
+    minimumSlotCount: Int = 0,
+    maximumSlotCount: Int = Int.MAX_VALUE,
+): List<Channel> = buildList {
+    require(minimumSlotCount <= maximumSlotCount) { "minimumSlotCount must be <= maximumSlotCount" }
+    require(new.size <= maximumSlotCount.coerceAtLeast(0)) {
+        "new.size (${new.size}) exceeds maximumSlotCount ($maximumSlotCount)"
+    }
+    val minimumLastIndex = minimumSlotCount.coerceAtLeast(0) - 1
+    val maximumLastIndex = maximumSlotCount.coerceAtLeast(0) - 1
+    val endIndex = maxOf(currentSettings.lastIndex, new.lastIndex, minimumLastIndex).coerceAtMost(maximumLastIndex)
+    if (endIndex < 0) return@buildList
+
+    for (index in 0..endIndex) {
+        val settings = new.getOrNull(index)?.takeUnless { it.isPlaceholder() }
+        add(
+            Channel(
+                role =
+                when {
+                    index == 0 -> Channel.Role.PRIMARY
+                    settings == null -> Channel.Role.DISABLED
+                    else -> Channel.Role.SECONDARY
+                },
+                index = index,
+                settings = settings ?: ChannelSettings(),
+            ),
+        )
+    }
+}
+
+/**
+ * Removes blank secondary placeholders and semantic duplicates from an authoritative channel replacement.
+ *
+ * The primary slot is always retained. Secondary channels are compared using their effective name and expanded PSK
+ * under [loraConfig], matching the identity used by firmware.
+ */
+fun normalizeReplacementSettings(
+    settings: List<ChannelSettings>,
+    loraConfig: Config.LoRaConfig?,
+): List<ChannelSettings> = buildList {
+    if (settings.isNotEmpty()) {
+        val effectiveLora = loraConfig ?: Config.LoRaConfig()
+        val primary = settings.first().takeUnless { it.isPlaceholder() } ?: ChannelSettings()
+        val seen = mutableSetOf<ChannelIdentity>()
+        if (!primary.isPlaceholder()) seen.add(primary.channelIdentity(effectiveLora))
+
+        add(primary)
+        for (index in 1..settings.lastIndex) {
+            val candidate = settings[index]
+            val identity = candidate.takeUnless { it.isPlaceholder() }?.channelIdentity(effectiveLora)
+            if (identity != null && seen.add(identity)) add(candidate)
+        }
+    }
+}
+
+/**
+ * Returns incoming channels that are neither blank placeholders nor semantic duplicates of existing or earlier entries.
+ *
+ * Blank existing slots are ignored when seeding identities so a disabled slot cannot suppress a real incoming channel.
+ * Identity uses each channel's effective name and expanded PSK under [loraConfig], matching firmware behavior.
+ */
+fun getUniqueChannelAdditions(
+    existing: List<ChannelSettings>,
+    incoming: List<ChannelSettings>,
+    loraConfig: Config.LoRaConfig,
+): List<ChannelSettings> {
+    val seen = existing.filterNot { it.isPlaceholder() }.map { it.channelIdentity(loraConfig) }.toMutableSet()
+    return incoming.filter { candidate ->
+        !candidate.isPlaceholder() && seen.add(candidate.channelIdentity(loraConfig))
+    }
+}
+
+private fun ChannelSettings.isPlaceholder(): Boolean = name.isNullOrBlank() && psk.size == 0
+
+private data class ChannelIdentity(val name: String, val psk: ByteString) {
+    override fun toString(): String = "ChannelIdentity(name=$name, psk=<redacted>)"
+}
+
+private fun ChannelSettings.channelIdentity(loraConfig: Config.LoRaConfig): ChannelIdentity {
+    val channel = ModelChannel(settings = this, loraConfig = loraConfig)
+    return ChannelIdentity(name = channel.name, psk = channel.psk)
+}

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelReplacementTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelReplacementTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model.util
+
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.meshtastic.core.model.Channel as ModelChannel
+
+class ChannelReplacementTest {
+
+    @Test
+    fun `replacement rejects imported channels beyond the maximum slot count`() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                getChannelReplacementList(
+                    new = List(3) { index -> ChannelSettings(name = "Channel $index") },
+                    currentSettings = emptyList(),
+                    maximumSlotCount = 2,
+                )
+            }
+
+        assertEquals("new.size (3) exceeds maximumSlotCount (2)", error.message)
+    }
+
+    @Test
+    fun `replacement accepts an imported set exactly at the maximum slot count`() {
+        val imported = List(2) { index -> ChannelSettings(name = "Channel $index") }
+
+        val replacement =
+            getChannelReplacementList(new = imported, currentSettings = emptyList(), maximumSlotCount = imported.size)
+
+        assertEquals(listOf(Channel.Role.PRIMARY, Channel.Role.SECONDARY), replacement.map { it.role })
+        assertEquals(imported, replacement.map { it.settings })
+    }
+
+    @Test
+    fun `zero maximum slot count accepts only an empty replacement`() {
+        assertEquals(
+            emptyList(),
+            getChannelReplacementList(new = emptyList(), currentSettings = emptyList(), maximumSlotCount = 0),
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            getChannelReplacementList(
+                new = listOf(ChannelSettings(name = "Primary")),
+                currentSettings = emptyList(),
+                maximumSlotCount = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `blank primary is emitted as the firmware default primary`() {
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(ChannelSettings()),
+                currentSettings = listOf(ChannelSettings(name = "Old primary")),
+            )
+
+        assertEquals(Channel.Role.PRIMARY, replacement.single().role)
+        assertEquals(ChannelSettings(), replacement.single().settings)
+    }
+
+    @Test
+    fun `blank imported secondary is emitted as a disabled slot`() {
+        val primary = ChannelSettings(name = "Primary")
+
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(primary, ChannelSettings()),
+                currentSettings = listOf(primary, ChannelSettings(name = "Old secondary")),
+            )
+
+        assertEquals(Channel.Role.PRIMARY, replacement[0].role)
+        assertEquals(Channel.Role.DISABLED, replacement[1].role)
+        assertEquals(ChannelSettings(), replacement[1].settings)
+    }
+
+    @Test
+    fun `dirty default-primary placeholders are canonicalized for firmware and cache`() {
+        val dirtyPlaceholder = ChannelSettings(uplink_enabled = true, downlink_enabled = true)
+
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(dirtyPlaceholder),
+                currentSettings = listOf(ChannelSettings(name = "Old primary")),
+            )
+        val normalized = normalizeReplacementSettings(listOf(dirtyPlaceholder), loraConfig = null)
+
+        assertEquals(Channel.Role.PRIMARY, replacement.single().role)
+        assertEquals(ChannelSettings(), replacement.single().settings)
+        assertEquals(listOf(ChannelSettings()), normalized)
+    }
+
+    @Test
+    fun `blank existing slot does not suppress a meaningful incoming channel`() {
+        val incoming = ChannelSettings(name = "LongFast")
+
+        val additions =
+            getUniqueChannelAdditions(
+                existing = listOf(ChannelSettings()),
+                incoming = listOf(incoming),
+                loraConfig = ModelChannel.default.loraConfig,
+            )
+
+        assertEquals(listOf(incoming), additions)
+    }
+
+    @Test
+    fun `replacement disables stale trailing slots`() {
+        val primary = ChannelSettings(name = "Primary")
+
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(primary),
+                currentSettings = listOf(primary, ChannelSettings(name = "Old")),
+            )
+
+        assertEquals(listOf(Channel.Role.PRIMARY, Channel.Role.DISABLED), replacement.map(Channel::role))
+        assertEquals(ChannelSettings(), replacement.last().settings)
+    }
+
+    @Test
+    fun `empty authoritative set restores a default primary and disables trailing slots`() {
+        val replacement =
+            getChannelReplacementList(
+                new = emptyList(),
+                currentSettings = listOf(ChannelSettings(name = "Old primary"), ChannelSettings(name = "Old chat")),
+            )
+
+        assertEquals(listOf(Channel.Role.PRIMARY, Channel.Role.DISABLED), replacement.map(Channel::role))
+        assertEquals(listOf(ChannelSettings(), ChannelSettings()), replacement.map(Channel::settings))
+    }
+
+    @Test
+    fun `replacement rejects an invalid slot range`() {
+        assertFailsWith<IllegalArgumentException> {
+            getChannelReplacementList(
+                new = listOf(ChannelSettings(name = "Primary")),
+                currentSettings = emptyList(),
+                minimumSlotCount = 2,
+                maximumSlotCount = 1,
+            )
+        }
+    }
+
+    @Test
+    fun `normalization removes blank and duplicate secondaries while retaining primary`() {
+        val primary = ChannelSettings(name = "Primary", psk = byteArrayOf(1).toByteString())
+        val secondary = ChannelSettings(name = "Secondary", psk = byteArrayOf(2).toByteString())
+
+        val normalized =
+            normalizeReplacementSettings(
+                listOf(primary, ChannelSettings(), primary, secondary),
+                ModelChannel.default.loraConfig,
+            )
+
+        assertEquals(listOf(primary, secondary), normalized)
+    }
+
+    @Test
+    fun `normalization preserves a blank default primary without suppressing a public secondary`() {
+        val blankPrimary = ChannelSettings()
+        val publicSecondary = ChannelSettings(psk = byteArrayOf(1).toByteString())
+
+        val normalized =
+            normalizeReplacementSettings(listOf(blankPrimary, publicSecondary), ModelChannel.default.loraConfig)
+
+        assertEquals(listOf(blankPrimary, publicSecondary), normalized)
+    }
+
+    @Test
+    fun `normalization handles empty input and a missing LoRa config`() {
+        assertEquals(emptyList(), normalizeReplacementSettings(emptyList(), loraConfig = null))
+        val primary = ChannelSettings(name = "Primary")
+        assertEquals(listOf(primary), normalizeReplacementSettings(listOf(primary), loraConfig = null))
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
@@ -145,7 +145,9 @@ interface AdminController {
      * SDK's `AdminApi.editSettings { }`.
      *
      * All admin packets for the session — begin, the [block]'s writes, and commit — are issued from the calling
-     * coroutine, which is required for the firmware to associate them with one transaction.
+     * coroutine, which is required for the firmware to associate them with one transaction. The implementation waits
+     * for radio queue acceptance at both boundaries, so callers cannot start a later rebooting stage while this
+     * transaction is still queued or uncommitted.
      */
     suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit)
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
@@ -14,27 +14,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+package org.meshtastic.core.repository
 
-plugins {
-    alias(libs.plugins.meshtastic.kmp.library)
-    alias(libs.plugins.meshtastic.koin)
+/** Outcome of a packet whose caller waited for radio acceptance. */
+enum class AwaitedSendStatus {
+    ACCEPTED,
+    REJECTED,
+    TIMED_OUT,
+    TRANSPORT_STOPPED,
+    SEND_FAILED,
 }
 
-kotlin {
-    android { withHostTest {} }
-
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.core.model)
-            api(libs.meshtastic.protobufs)
-            implementation(projects.core.common)
-            implementation(projects.core.database)
-
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.atomicfu)
-            implementation(libs.kermit)
-            implementation(libs.androidx.paging.common)
-        }
-        commonTest.dependencies { implementation(projects.core.testing) }
-    }
+/**
+ * Detailed result for an awaited send. [dispatched] is true only when an active transport accepted the outbound bytes
+ * for asynchronous delivery.
+ */
+data class AwaitedSendResult(val status: AwaitedSendStatus, val dispatched: Boolean) {
+    val accepted: Boolean
+        get() = status == AwaitedSendStatus.ACCEPTED
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -52,7 +52,8 @@ interface CommandSender {
      * Sends an admin message and suspends until the radio acknowledges it.
      *
      * This is used when the caller needs to guarantee a packet has been accepted by the radio before proceeding, such
-     * as sending a shared contact before the first DM to a node.
+     * as sending a shared contact before the first DM to a node. Time spent behind existing FIFO entries does not count
+     * against the radio-response timeout.
      *
      * @return `true` if the radio accepted the packet, `false` on timeout or failure.
      */
@@ -61,7 +62,15 @@ interface CommandSender {
         requestId: Int = generatePacketId(),
         wantResponse: Boolean = false,
         initFn: () -> AdminMessage,
-    ): Boolean
+    ): Boolean = sendAdminAwaitResult(destNum, requestId, wantResponse, initFn).accepted
+
+    /** Detailed form of [sendAdminAwait], including whether an active transport admitted the packet. */
+    suspend fun sendAdminAwaitResult(
+        destNum: Int,
+        requestId: Int = generatePacketId(),
+        wantResponse: Boolean = false,
+        initFn: () -> AdminMessage,
+    ): AwaitedSendResult
 
     /** Sends our current position to the mesh. */
     suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int? = null, wantResponse: Boolean = false)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionState
+
+/**
+ * Owns canonical connection state and its lifecycle epochs as one serialized transition.
+ *
+ * [MutableStateFlow] makes individual reads and writes thread-safe, but a state transition is a read-modify-write
+ * across two flows. This holder prevents concurrent writers from losing or double-counting an epoch while preserving
+ * duplicate transitions as no-ops.
+ */
+class ConnectionStateHolder(
+    initialState: ConnectionState = ConnectionState.Disconnected,
+    initialEpochs: ConnectionEpochs = ConnectionEpochs(),
+) : ConnectionStateProvider {
+    private val transitionLock = SynchronizedObject()
+    private val mutableConnectionState = MutableStateFlow(initialState)
+    private val mutableConnectionEpochs = MutableStateFlow(initialEpochs)
+
+    override val connectionState: StateFlow<ConnectionState> = mutableConnectionState.asStateFlow()
+    override val connectionEpochs: StateFlow<ConnectionEpochs> = mutableConnectionEpochs.asStateFlow()
+
+    /** Applies [newState] and advances epochs exactly once when the state changes. */
+    fun setConnectionState(newState: ConnectionState) {
+        synchronized(transitionLock) {
+            val previous = mutableConnectionState.value
+            if (previous == newState) return
+
+            mutableConnectionEpochs.value = mutableConnectionEpochs.value.advance(previous, newState)
+            // Publish durable event evidence first. A collector that reacts to the state transition can then observe
+            // the matching epochs immediately, even when a rapid reconnect follows before it resumes.
+            mutableConnectionState.value = newState
+        }
+    }
+
+    /** Restores a known baseline, primarily for reusable test fakes. */
+    fun reset(state: ConnectionState = ConnectionState.Disconnected, epochs: ConnectionEpochs = ConnectionEpochs()) {
+        synchronized(transitionLock) {
+            mutableConnectionEpochs.value = epochs
+            mutableConnectionState.value = state
+        }
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateProvider.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateProvider.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.core.repository
 
 import kotlinx.coroutines.flow.StateFlow
+import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionState
 
 /**
@@ -37,4 +38,10 @@ interface ConnectionStateProvider {
      * @see ServiceRepository.connectionState
      */
     val connectionState: StateFlow<ConnectionState>
+
+    /**
+     * Monotonic departures and completed handshakes. Use these counters when every lifecycle boundary matters, because
+     * rapid intermediate [connectionState] values may be conflated before a collector observes them.
+     */
+    val connectionEpochs: StateFlow<ConnectionEpochs>
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -25,8 +25,13 @@ interface PacketHandler {
     /** Sends a command/packet directly to the radio. */
     fun sendToRadio(p: ToRadio)
 
-    /** Adds a mesh packet to the queue for sending. */
-    suspend fun sendToRadio(packet: MeshPacket)
+    /**
+     * Adds a mesh packet to the queue for sending.
+     *
+     * @return `true` when the packet's non-zero ID was reserved and queued, or `false` when the packet was invalid or
+     *   its ID was already queued/in flight.
+     */
+    suspend fun sendToRadio(packet: MeshPacket): Boolean
 
     /**
      * Adds a mesh packet to the queue and suspends until the radio acknowledges it via [QueueStatus].
@@ -35,9 +40,15 @@ interface PacketHandler {
      * packet has been accepted by the radio before proceeding. This is critical for operations where ordering matters
      * (e.g., sending a shared contact before the first DM).
      *
+     * Time spent behind packets already in the FIFO is not part of the response timeout. The timeout begins when this
+     * packet reaches the head of the queue and is transmitted.
+     *
      * @return `true` if the radio accepted the packet, `false` on timeout or failure.
      */
-    suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean
+    suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean = sendToRadioAndAwaitResult(packet).accepted
+
+    /** Detailed form of [sendToRadioAndAwait], including whether an active transport admitted the packet. */
+    suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult
 
     /** Processes queue status updates from the radio. */
     fun handleQueueStatus(queueStatus: QueueStatus)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -72,6 +72,20 @@ interface RadioSessionAuthority {
         runWithSessionLease(session) { block() }
 }
 
+/** Writes raw protocol frames to the currently admitted transport. */
+interface RadioTransportWriter {
+    /** Sends [bytes] when a transport is available; callers that need admission evidence use [trySendToRadio]. */
+    fun sendToRadio(bytes: ByteArray)
+
+    /**
+     * Attempts to dispatch [bytes] to the active transport.
+     *
+     * @return `true` when an active transport accepted the bytes for asynchronous delivery, or `false` when no send
+     *   could be scheduled or confirmed.
+     */
+    fun trySendToRadio(bytes: ByteArray): Boolean
+}
+
 /**
  * Interface for the low-level radio interface that handles raw byte communication.
  *
@@ -89,7 +103,8 @@ interface RadioSessionAuthority {
  */
 interface RadioInterfaceService :
     RadioTransportCallback,
-    RadioSessionAuthority {
+    RadioSessionAuthority,
+    RadioTransportWriter {
     /** The device types supported by this platform's radio interface. */
     val supportedDeviceTypes: List<DeviceType>
 
@@ -144,9 +159,6 @@ interface RadioInterfaceService :
      * collector was attached do not get replayed ahead of the next session's handshake.
      */
     fun resetReceivedBuffer()
-
-    /** Sends a raw byte array to the radio. */
-    fun sendToRadio(bytes: ByteArray)
 
     /** Initiates the connection to the radio. */
     fun connect()

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConnectionStateHolderTest {
+    @Test
+    fun `transitions advance matching epochs exactly once`() {
+        val holder = ConnectionStateHolder()
+
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connecting)
+        holder.setConnectionState(ConnectionState.Disconnected)
+        holder.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            holder.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `concurrent duplicate transitions advance each lifecycle edge once`() = runTest {
+        val holder = ConnectionStateHolder()
+
+        suspend fun fanOut(state: ConnectionState) = coroutineScope {
+            List(100) { async(Dispatchers.Default) { holder.setConnectionState(state) } }.awaitAll()
+        }
+
+        fanOut(ConnectionState.Connected)
+        fanOut(ConnectionState.Connecting)
+        fanOut(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            holder.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `reset restores an explicit state and epoch baseline`() {
+        val holder = ConnectionStateHolder()
+        holder.setConnectionState(ConnectionState.Connected)
+
+        holder.reset(
+            state = ConnectionState.DeviceSleep,
+            epochs = ConnectionEpochs(departures = 7, completedHandshakes = 11, handshakesAtLastDeparture = 10),
+        )
+
+        assertEquals(ConnectionState.DeviceSleep, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(departures = 7, completedHandshakes = 11, handshakesAtLastDeparture = 10),
+            holder.connectionEpochs.value,
+        )
+    }
+}

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -816,6 +816,7 @@
     <string name="ignore_remove">Remove '%1$s' from ignore list?</string>
     <!-- IMPORT -->
     <string name="import_configuration">Import configuration</string>
+    <string name="import_configuration_failed">Unable to import the selected configuration</string>
     <string name="import_export_label">Import/Export</string>
     <string name="import_known_shared_contact_text">Warning: This contact is known, importing will overwrite the previous contact information.</string>
     <string name="import_label">Import</string>
@@ -829,6 +830,8 @@
     <string name="insert_link_message">Enter the URL for the selected text</string>
     <string name="insert_link_title">Insert Link</string>
     <string name="insert_link_url_hint">https://</string>
+    <string name="install_configuration_bluetooth_repair_hint">Configuration restored. If Bluetooth does not reconnect, forget this device in Android Bluetooth settings and pair it again.</string>
+    <string name="install_configuration_failed">Unable to apply the selected configuration to the device</string>
     <string name="installed_firmware_version">Currently Installed</string>
     <string name="internal">Internal</string>
     <string name="interval_always_on">Always On</string>

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
@@ -18,15 +18,22 @@ package org.meshtastic.core.service
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowSeconds
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
+import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.proto.AdminMessage
@@ -36,6 +43,7 @@ import org.meshtastic.proto.HamParameters
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.OTAMode
 import org.meshtastic.proto.User
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [AdminController] implementation: local/remote configuration, channels, owner, device lifecycle, and the
@@ -51,6 +59,7 @@ internal class AdminControllerImpl(
     private val commandSender: CommandSender,
     private val nodeManager: NodeManager,
     private val radioConfigRepository: RadioConfigRepository,
+    private val connectionStateProvider: ConnectionStateProvider,
     private val scope: CoroutineScope,
 ) : AdminController {
 
@@ -219,9 +228,18 @@ internal class AdminControllerImpl(
     // ── Edit Settings (transactional) ───────────────────────────────────────
 
     override suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit) {
-        commandSender.sendAdmin(destNum) { AdminMessage(begin_edit_settings = true) }
-        EditSettingsSession(destNum).block()
-        commandSender.sendAdmin(destNum) { AdminMessage(commit_edit_settings = true) }
+        requireEditBoundaryAccepted(destNum, "begin") { AdminMessage(begin_edit_settings = true) }
+
+        // Firmware has no abort boundary. Preserve any block failure, including cancellation, only long enough to
+        // attempt the commit that closes the accepted session; the original failure is restored below.
+        val blockResult = runCatching { EditSettingsSession(destNum).block() }
+        val commitResult = runCatching { withContext(NonCancellable) { requireCommitBoundaryAccepted(destNum) } }
+
+        blockResult.exceptionOrNull()?.let { blockFailure ->
+            commitResult.exceptionOrNull()?.takeUnless { it === blockFailure }?.let(blockFailure::addSuppressed)
+            throw blockFailure
+        }
+        commitResult.getOrThrow()
     }
 
     override suspend fun editLocalSettings(block: suspend AdminEditScope.() -> Unit) = editSettings(myNodeNum, block)
@@ -235,10 +253,9 @@ internal class AdminControllerImpl(
         override suspend fun setModuleConfig(config: ModuleConfig) =
             setModuleConfig(destNum, config, commandSender.generatePacketId())
 
-        // Unlike the one-shot setRemoteChannel, a transactional channel write does NOT mirror to the local cache per
-        // slot: importChannelSet owns the cache and writes it once after commit (replaceAllSettings), so an import
-        // interrupted before commit leaves the local channel cache untouched. (Firmware still writes each set_channel
-        // into its in-memory channel table on arrival; only disk persist/reload/reboot is deferred to commit.)
+        // Unlike the one-shot setRemoteChannel, transactional writes do not mirror individual slots into the cache.
+        // Profile installation owns one authoritative cache reconciliation after any channel write is issued, including
+        // failure paths, while the next handshake can still overlay the device's actual non-disabled slots.
         override suspend fun setChannel(channel: Channel) =
             commandSender.sendAdmin(destNum) { AdminMessage(set_channel = channel) }
 
@@ -246,7 +263,44 @@ internal class AdminControllerImpl(
             this@AdminControllerImpl.setFixedPosition(destNum, position)
     }
 
+    /**
+     * Applies back-pressure at transaction boundaries. Ordinary writes are already queued FIFO by [CommandSender], so
+     * waiting for the commit's queue acceptance keeps the caller suspended until the sender has processed every
+     * preceding write. This prevents a rebooting transport write from overtaking an uncommitted profile transaction.
+     */
+    private suspend fun requireEditBoundaryAccepted(destNum: Int, boundary: String, message: () -> AdminMessage) {
+        check(commandSender.sendAdminAwait(destNum, initFn = message)) {
+            "Device rejected or timed out while sending edit-settings $boundary"
+        }
+    }
+
+    private suspend fun requireCommitBoundaryAccepted(destNum: Int) {
+        val isLocalDestination = destNum == myNodeNum
+        val departureBaseline = connectionStateProvider.connectionEpochs.value.departures
+        val result = commandSender.sendAdminAwaitResult(destNum) { AdminMessage(commit_edit_settings = true) }
+        val stoppedAfterDispatch =
+            isLocalDestination && result.dispatched && result.status == AwaitedSendStatus.TRANSPORT_STOPPED
+        val departureEpochs =
+            if (stoppedAfterDispatch) {
+                withTimeoutOrNull(COMMIT_DEPARTURE_TIMEOUT) {
+                    connectionStateProvider.connectionEpochs.first { it.departures > departureBaseline }
+                }
+            } else {
+                null
+            }
+        val committedBeforeLocalDeparture =
+            stoppedAfterDispatch && departureEpochs?.lastDepartureState is ConnectionState.Disconnected
+
+        check(result.accepted || committedBeforeLocalDeparture) {
+            "Device rejected or timed out while sending edit-settings commit"
+        }
+        if (committedBeforeLocalDeparture) {
+            Logger.i { "Edit-settings commit dispatched before expected local transport departure" }
+        }
+    }
+
     private companion object {
         private const val DEFAULT_DELAY_SECONDS = 5
+        private val COMMIT_DEPARTURE_TIMEOUT = 2.seconds
     }
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.common.database.DatabaseManager
+import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.CommandSender
@@ -95,7 +96,7 @@ class RadioControllerImpl(
     scope: CoroutineScope,
     private val onDeviceAddressChanged: (() -> Unit)? = null,
 ) : RadioController,
-    AdminController by AdminControllerImpl(commandSender, nodeManager, radioConfigRepository, scope),
+    AdminController by AdminControllerImpl(commandSender, nodeManager, radioConfigRepository, serviceRepository, scope),
     MessagingController by MessagingControllerImpl(
         commandSender,
         nodeManager,
@@ -197,6 +198,9 @@ class RadioControllerImpl(
 
     override val connectionState: StateFlow<ConnectionState>
         get() = serviceRepository.connectionState
+
+    override val connectionEpochs: StateFlow<ConnectionEpochs>
+        get() = serviceRepository.connectionEpochs
 
     override val clientNotification: StateFlow<ClientNotification?>
         get() = serviceRepository.clientNotification

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/ServiceRepositoryImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/ServiceRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.service.LockdownTokenInfo
 import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.MeshPacket
@@ -42,13 +43,12 @@ import org.meshtastic.proto.MeshPacket
 open class ServiceRepositoryImpl : ServiceRepository {
 
     // Canonical app-level connection state — written exclusively by MeshConnectionManager.
-    private val _connectionState: MutableStateFlow<ConnectionState> = MutableStateFlow(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState>
-        get() = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
-    override fun setConnectionState(connectionState: ConnectionState) {
-        _connectionState.value = connectionState
-    }
+    override fun setConnectionState(connectionState: ConnectionState) =
+        connectionStateHolder.setConnectionState(connectionState)
 
     private val _clientNotification = MutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?>

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -54,9 +54,9 @@ import okio.ByteString.Companion.toByteString
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.ble.BluetoothRepository
-import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.ignoreExceptionSuspend
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
@@ -206,7 +206,7 @@ class SharedRadioInterfaceService(
     /** Guarded by [sessionCallbackLock]. New work is rejected immediately when teardown closes this gate. */
     private var sessionAdmissionOpen = false
 
-    /** Number of suspend operations admitted for [activeTransportSession], guarded by [sessionCallbackLock]. */
+    /** Number of operations admitted for [activeTransportSession], guarded by [sessionCallbackLock]. */
     private var admittedSessionOperations = 0
 
     /** Completed by the last admitted operation after teardown closes admission. Guarded by [sessionCallbackLock]. */
@@ -252,25 +252,41 @@ class SharedRadioInterfaceService(
             block(lease)
             return true
         } finally {
-            val drainWaiter =
-                synchronized(sessionCallbackLock) {
-                    check(activeTransportSession === admittedSession) {
-                        "Session changed before an admitted operation released its lease"
-                    }
-                    check(admittedSessionOperations > 0) { "Session operation count underflow" }
-                    admittedSessionOperations--
-                    if (admittedSessionOperations == 0) {
-                        sessionDrainWaiter.also { sessionDrainWaiter = null }
-                    } else {
-                        null
-                    }
-                }
-            drainWaiter?.complete(Unit)
+            releaseSessionOperation(admittedSession)
         }
     }
 
     override suspend fun runWhileSessionActive(session: RadioSessionContext, block: suspend () -> Unit): Boolean =
         sessionOperationMutex.withLock { runWithSessionLease(session) { block() } }
+
+    private fun releaseSessionOperation(admittedSession: RadioTransportSession) {
+        val drainWaiter =
+            synchronized(sessionCallbackLock) {
+                check(activeTransportSession === admittedSession) {
+                    "Session changed before an admitted operation released its lease"
+                }
+                check(admittedSessionOperations > 0) { "Session operation count underflow" }
+                admittedSessionOperations--
+                if (admittedSessionOperations == 0) {
+                    sessionDrainWaiter.also { sessionDrainWaiter = null }
+                } else {
+                    null
+                }
+            }
+        drainWaiter?.complete(Unit)
+    }
+
+    private data class AdmittedTransportSend(val session: RadioTransportSession, val transport: RadioTransport)
+
+    /** Admits one synchronous transport handoff under the same gate drained by [revokeTransportSession]. */
+    private fun admitTransportSend(): AdmittedTransportSend? = synchronized(sessionCallbackLock) admission@{
+        if (!sessionAdmissionOpen || isStopping) return@admission null
+        val session = activeTransportSession ?: return@admission null
+        val transport = radioTransport ?: return@admission null
+
+        admittedSessionOperations++
+        AdmittedTransportSend(session = session, transport = transport)
+    }
 
     /** Runs a callback only while [session] still owns admission, atomically with session teardown. */
     private inline fun runIfTransportSessionActive(session: RadioTransportSession, block: () -> Unit): Boolean =
@@ -733,7 +749,12 @@ class SharedRadioInterfaceService(
                 _connectionState.value = connectionStateBeforeStart
                 throw failure
             }
-        radioTransport = newTransport
+        synchronized(sessionCallbackLock) {
+            check(activeTransportSession === session && sessionAdmissionOpen) {
+                "Transport session was revoked before its transport could be published"
+            }
+            radioTransport = newTransport
+        }
         runningTransportId = address.firstOrNull()?.let { InterfaceId.forIdChar(it) }
         isStarted = true
         startHeartbeat()
@@ -894,24 +915,27 @@ class SharedRadioInterfaceService(
     }
 
     override fun sendToRadio(bytes: ByteArray) {
-        if (isStopping) {
-            Logger.d { "sendToRadio: transport stopping, dropping ${bytes.size} bytes" }
-            return
-        }
-        // Snapshot the transport to avoid calling handleSendToRadio on a null reference.
-        // There is still a benign race: stopTransportLocked() may cancel _serviceScope
-        // between the null-check and the launch, causing the coroutine to be silently
-        // dropped. This is acceptable — if the transport is shutting down, dropping the
-        // send is the correct behavior.
-        val currentTransport =
-            radioTransport
+        trySendToRadio(bytes)
+    }
+
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
+        // Admission and teardown share one session gate. Once accepted, teardown must drain this handoff before it can
+        // revoke the session or close the transport, so a true result cannot describe work discarded by a racing stop.
+        val admitted =
+            admitTransportSend()
                 ?: run {
-                    Logger.w { "sendToRadio: no active radio transport, dropping ${bytes.size} bytes" }
-                    return
+                    Logger.w { "sendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
+                    return false
                 }
-        _serviceScope.handledLaunch {
-            currentTransport.handleSendToRadio(bytes)
-            _meshActivity.tryEmit(MeshActivity.Send)
+        return try {
+            safeCatching {
+                admitted.transport.handleSendToRadio(bytes)
+                _meshActivity.tryEmit(MeshActivity.Send)
+            }
+                .onFailure { Logger.e(it) { "sendToRadio: active transport rejected ${bytes.size} bytes" } }
+                .isSuccess
+        } finally {
+            releaseSessionOperation(admitted.session)
         }
     }
 

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -41,6 +41,8 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.ConnectionIdentity
 import org.meshtastic.core.repository.MeshDataHandler
@@ -70,6 +72,7 @@ import org.meshtastic.proto.User
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -739,9 +742,13 @@ class RadioControllerImplTest {
         verifySuspend { commandSender.sendAdmin(any(), any(), any(), any()) }
     }
 
+    private fun acceptedSendResult() = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
     @Test
     fun editLocalSettingsChannelWritesDoNotMirrorToLocalCache() = runTest {
         val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
 
         controller.editLocalSettings {
             setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "A")))
@@ -749,14 +756,297 @@ class RadioControllerImplTest {
         }
         advanceUntilIdle()
 
-        // Exactly 4 admin packets: begin + 2 channel writes + commit. The tight count also catches a duplicated
-        // begin/commit or an accidental double-write per channel.
-        verifySuspend(exactly(4)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+        // Exactly four packets: awaited begin + 2 channel writes + awaited commit. The tight count also catches a
+        // duplicated boundary or an accidental double-write per channel.
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(2)) { commandSender.sendAdmin(any(), any(), any(), any()) }
         // A transactional channel write must NOT eagerly mirror to the local cache the way one-shot
         // setRemoteChannel does for the local node. importChannelSet owns the cache and writes it once after commit
         // (replaceAllSettings), so an interrupted import can't leave partial channels cached. A regression to
         // per-slot mirroring inside the session would make this call count non-zero.
         verifySuspend(exactly(0)) { radioConfigRepository.updateChannelSettings(any()) }
+    }
+
+    @Test
+    fun editSettingsAwaitsBoundariesAroundOrderedWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        val sentMessages = mutableListOf<AdminMessage>()
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+                true
+            }
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+                acceptedSendResult()
+            }
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+            }
+
+        controller.editLocalSettings {
+            setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "Primary")))
+            setChannel(
+                Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "Secondary")),
+            )
+        }
+
+        assertEquals(true, sentMessages[0].begin_edit_settings)
+        assertEquals(0, sentMessages[1].set_channel?.index)
+        assertEquals(1, sentMessages[2].set_channel?.index)
+        assertEquals(true, sentMessages[3].commit_edit_settings)
+    }
+
+    @Test
+    fun editSettingsRejectsFailedBeginBeforeRunningWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns false
+        var blockRan = false
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { blockRan = true } }
+
+        assertEquals("Device rejected or timed out while sending edit-settings begin", failure.message)
+        assertFalse(blockRan)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(0)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(0)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsReportsFailedCommitAfterOrderedWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
+            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                controller.editLocalSettings {
+                    setChannel(
+                        Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "Primary")),
+                    )
+                }
+            }
+
+        assertEquals("Device rejected or timed out while sending edit-settings commit", failure.message)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsCommitsAfterWriteFailureAndRethrowsOriginal() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        val writeFailure = IllegalArgumentException("profile write failed")
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } throws writeFailure
+
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                controller.editLocalSettings {
+                    setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "A")))
+                }
+            }
+
+        assertSame(writeFailure, failure)
+        assertTrue(failure.suppressedExceptions.isEmpty())
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsSuppressesCommitFailureOnBlockFailure() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
+            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+        val blockFailure = IllegalArgumentException("profile write failed")
+
+        val failure = assertFailsWith<IllegalArgumentException> { controller.editLocalSettings { throw blockFailure } }
+
+        assertSame(blockFailure, failure)
+        assertEquals(
+            listOf("Device rejected or timed out while sending edit-settings commit"),
+            failure.suppressedExceptions.map(Throwable::message),
+        )
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsAcceptsDispatchedCommitWhenLocalTransportDeparts() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsWaitsForCanonicalDepartureAfterTransportStops() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                backgroundScope.launch { serviceRepository.setConnectionState(ConnectionState.Disconnected) }
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
+    }
+
+    @Test
+    fun editSettingsAcceptsCapturedDisconnectAfterFastReconnect() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                serviceRepository.setConnectionState(ConnectionState.Connecting)
+                serviceRepository.setConnectionState(ConnectionState.Connected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        assertEquals(ConnectionState.Connected, serviceRepository.connectionState.value)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsRejectsTransportStopBeforeCommitTransmission() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals("Device rejected or timed out while sending edit-settings commit", failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsTransportStopWithoutObservedDeparture() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
+            AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals("Device rejected or timed out while sending edit-settings commit", failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsTimeoutEvenWhenLocalTransportDeparts() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TIMED_OUT, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals("Device rejected or timed out while sending edit-settings commit", failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsDeviceSleepAsCommitAcceptance() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                serviceRepository.setConnectionState(ConnectionState.DeviceSleep)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals("Device rejected or timed out while sending edit-settings commit", failure.message)
+    }
+
+    @Test
+    fun editSettingsDoesNotTreatLocalDepartureAsRemoteCommitAcceptance() = runTest {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller =
+            createController(scope = backgroundScope, myNodeNum = 1234, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 5678) {} }
+
+        assertEquals("Device rejected or timed out while sending edit-settings commit", failure.message)
+    }
+
+    @Test
+    fun editSettingsCommitsWhenCallerIsCancelled() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
+        val blockStarted = CompletableDeferred<Unit>()
+        val keepBlockOpen = CompletableDeferred<Unit>()
+
+        val job = launch {
+            controller.editLocalSettings {
+                blockStarted.complete(Unit)
+                keepBlockOpen.await()
+            }
+        }
+        blockStarted.await()
+        job.cancel(CancellationException("cancel profile restore"))
+        job.join()
+
+        assertTrue(job.isCancelled)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
+import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.TracerouteResponse
 import kotlin.test.Test
@@ -39,6 +40,7 @@ class ServiceRepositoryImplTest {
         val repository = ServiceRepositoryImpl()
 
         assertEquals(ConnectionState.Disconnected, repository.connectionState.value)
+        assertEquals(ConnectionEpochs(), repository.connectionEpochs.value)
         assertNull(repository.clientNotification.value)
         assertNull(repository.errorMessage.value)
         assertNull(repository.connectionProgress.value)
@@ -63,6 +65,33 @@ class ServiceRepositoryImplTest {
 
         assertEquals(ConnectionState.Connecting, emittedState.await())
         assertEquals(ConnectionState.Connecting, repository.connectionState.value)
+    }
+
+    @Test
+    fun connectionEpochsPreserveRapidDepartureAndHandshakeTransitions() = runTest {
+        val repository = ServiceRepositoryImpl()
+        repository.setConnectionState(ConnectionState.Connected)
+        val baseline = repository.connectionEpochs.value
+
+        repository.setConnectionState(ConnectionState.Disconnected)
+        repository.setConnectionState(ConnectionState.Connecting)
+        repository.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, repository.connectionState.value)
+        assertEquals(baseline.departures + 1, repository.connectionEpochs.value.departures)
+        assertEquals(baseline.completedHandshakes + 1, repository.connectionEpochs.value.completedHandshakes)
+    }
+
+    @Test
+    fun duplicateConnectionStatesDoNotAdvanceEpochs() = runTest {
+        val repository = ServiceRepositoryImpl()
+        repository.setConnectionState(ConnectionState.Connected)
+        val afterHandshake = repository.connectionEpochs.value
+
+        repository.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), afterHandshake)
+        assertEquals(afterHandshake, repository.connectionEpochs.value)
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -220,6 +220,33 @@ class SharedRadioInterfaceServiceLivenessTest {
         }
     }
 
+    /** Triggers a liveness restart from inside one synchronous send handoff. */
+    private class ReentrantRestartTransport(private val requestRestart: () -> Unit) : RadioTransport {
+        var handoffCompleted = false
+            private set
+
+        var closeCalled = false
+            private set
+
+        var closeObservedBeforeHandoff = false
+            private set
+
+        private var restartRequested = false
+
+        override fun handleSendToRadio(p: ByteArray) {
+            if (!restartRequested) {
+                restartRequested = true
+                requestRestart()
+            }
+            handoffCompleted = true
+        }
+
+        override suspend fun close() {
+            closeCalled = true
+            closeObservedBeforeHandoff = !handoffCompleted
+        }
+    }
+
     /** Controllable clock — tests advance this manually so all time comparisons are deterministic. */
     private var clock: Long = 0L
 
@@ -656,6 +683,46 @@ class SharedRadioInterfaceServiceLivenessTest {
 
             val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
             assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    @Test
+    fun `transport teardown drains a synchronously admitted send before close`() = runTest(testDispatcher) {
+        val transports = mutableListOf<RadioTransport>()
+        lateinit var service: SharedRadioInterfaceService
+        lateinit var initialTransport: ReentrantRestartTransport
+        val transportProvider: () -> RadioTransport = {
+            if (transports.isEmpty()) {
+                ReentrantRestartTransport {
+                    clock = 65_000L
+                    service.checkLiveness()
+                }
+                    .also {
+                        initialTransport = it
+                        transports += it
+                    }
+            } else {
+                FakeRadioTransport().also { transports += it }
+            }
+        }
+
+        clock = 0L
+        service = createConnectedService("xAA:BB:CC:DD:EE:FF", transportProvider)
+        try {
+            val accepted = service.trySendToRadio(byteArrayOf(1, 2, 3))
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(accepted)
+            assertTrue(initialTransport.handoffCompleted)
+            assertTrue(initialTransport.closeCalled)
+            assertFalse(
+                initialTransport.closeObservedBeforeHandoff,
+                "teardown must wait until the admitted handoff releases its session lease",
+            )
+            assertEquals(2, transports.size, "the liveness restart should publish one replacement transport")
         } finally {
             service.disconnect()
             advanceTimeBy(1_000L)

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -16,7 +16,6 @@
  */
 package org.meshtastic.core.takserver
 
-import co.touchlab.kermit.Severity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,24 +27,21 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
-import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeSortOption
 import org.meshtastic.core.model.Position
-import org.meshtastic.core.model.service.LockdownState
-import org.meshtastic.core.model.service.LockdownTokenInfo
-import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.MeshConfigHandler
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioSessionContext
-import org.meshtastic.core.repository.ServiceRepository
+import org.meshtastic.core.testing.FakeServiceRepository
 import org.meshtastic.proto.AdminMessage
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
-import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Data
 import org.meshtastic.proto.DeviceMetadata
@@ -134,12 +130,12 @@ class TAKMeshIntegrationTest {
             initFn: () -> AdminMessage,
         ) {}
 
-        override suspend fun sendAdminAwait(
+        override suspend fun sendAdminAwaitResult(
             destNum: Int,
             requestId: Int,
             wantResponse: Boolean,
             initFn: () -> AdminMessage,
-        ): Boolean = true
+        ): AwaitedSendResult = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
 
         override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) {}
 
@@ -164,61 +160,6 @@ class TAKMeshIntegrationTest {
         ) {}
 
         override fun sendLockNow() {}
-    }
-
-    private class FakeServiceRepository : ServiceRepository {
-        private val _meshPacketFlow = MutableSharedFlow<MeshPacket>(replay = 1, extraBufferCapacity = 64)
-        override val meshPacketFlow: Flow<MeshPacket> = _meshPacketFlow
-
-        override val connectionState: StateFlow<ConnectionState> = MutableStateFlow(ConnectionState.Disconnected)
-
-        override fun setConnectionState(connectionState: ConnectionState) {}
-
-        override val clientNotification: StateFlow<ClientNotification?> = MutableStateFlow(null)
-
-        override fun setClientNotification(notification: ClientNotification?) {}
-
-        override fun clearClientNotification() {}
-
-        override val errorMessage: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setErrorMessage(text: String, severity: Severity) {}
-
-        override fun clearErrorMessage() {}
-
-        override val connectionProgress: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setConnectionProgress(text: String) {}
-
-        override suspend fun emitMeshPacket(packet: MeshPacket) {
-            _meshPacketFlow.emit(packet)
-        }
-
-        override val tracerouteResponse: StateFlow<TracerouteResponse?> = MutableStateFlow(null)
-
-        override fun setTracerouteResponse(value: TracerouteResponse?) {}
-
-        override fun clearTracerouteResponse() {}
-
-        override val neighborInfoResponse: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setNeighborInfoResponse(value: String?) {}
-
-        override fun clearNeighborInfoResponse() {}
-
-        override val lockdownState: StateFlow<LockdownState> = MutableStateFlow(LockdownState.None)
-
-        override fun setLockdownState(state: LockdownState) {}
-
-        override fun clearLockdownState() {}
-
-        override val lockdownTokenInfo: StateFlow<LockdownTokenInfo?> = MutableStateFlow(null)
-
-        override fun setLockdownTokenInfo(info: LockdownTokenInfo?) {}
-
-        override val sessionAuthorized: StateFlow<Boolean> = MutableStateFlow(false)
-
-        override fun setSessionAuthorized(authorized: Boolean) {}
     }
 
     private class FakeMeshConfigHandler : MeshConfigHandler {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioConfigRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioConfigRepository.kt
@@ -93,10 +93,14 @@ class FakeRadioConfigRepository :
     var lastSetModuleConfig: ModuleConfig? = null
         private set
 
+    /** Optional failure thrown by [replaceAllSettings], for exercising reconciliation error paths. */
+    var replaceAllSettingsFailure: Exception? = null
+
     init {
         registerResetAction {
             lastSetLocalConfig = null
             lastSetModuleConfig = null
+            replaceAllSettingsFailure = null
         }
     }
 
@@ -105,6 +109,7 @@ class FakeRadioConfigRepository :
     }
 
     override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+        replaceAllSettingsFailure?.let { throw it }
         channelSetBacking.value = channelSetBacking.value.copy(settings = settingsList)
     }
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -16,11 +16,15 @@
  */
 package org.meshtastic.core.testing
 
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ClientNotification
@@ -38,8 +42,9 @@ class FakeRadioController :
     RadioController {
 
     /** Canonical app-level connection state, mirroring [ServiceRepository][connectionState] semantics. */
-    private val _connectionState = mutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState> = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
     private val _clientNotification = mutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?> = _clientNotification
@@ -48,13 +53,55 @@ class FakeRadioController :
     val favoritedNodes = mutableListOf<Int>()
     val sentSharedContacts = mutableListOf<Int>()
 
-    /** Every [setLocalConfig] call, in order — lets tests assert e.g. that a scan restored the home LoRa preset. */
-    val localConfigs = mutableListOf<Config>()
-    val lastLocalConfig: Config?
-        get() = localConfigs.lastOrNull()
+    /** One local or admin configuration write. Local writes have no destination. */
+    data class ConfigWrite(val destination: Int?, val config: Config)
 
-    /** Every [setLocalChannel] call, in order. */
+    /** One module configuration write, preserving its destination and payload as a single observation. */
+    data class ModuleConfigWrite(val destination: Int, val config: ModuleConfig)
+
+    /** Every local or admin configuration write, preserving destination and call order together. */
+    val configWrites = mutableListOf<ConfigWrite>()
+
+    /** Configuration payloads in call order. Prefer [configWrites] when destination identity matters. */
+    val localConfigs: List<Config>
+        get() = configWrites.map(ConfigWrite::config)
+
+    val lastLocalConfig: Config?
+        get() = configWrites.lastOrNull()?.config
+
+    /** Every local or admin channel write, in call order. */
     val localChannels = mutableListOf<Channel>()
+
+    /** Every [setFixedPosition] call, in order. */
+    val fixedPositions = mutableListOf<Position>()
+
+    /** Every module configuration write, preserving destination and call order together. */
+    val moduleConfigWrites = mutableListOf<ModuleConfigWrite>()
+
+    /** Module configuration payloads in call order. Prefer [moduleConfigWrites] when destination identity matters. */
+    val moduleConfigs: List<ModuleConfig>
+        get() = moduleConfigWrites.map(ModuleConfigWrite::config)
+
+    /** Destination node for every module configuration write, in order. */
+    val moduleConfigDestinations: List<Int>
+        get() = moduleConfigWrites.map(ModuleConfigWrite::destination)
+
+    /** Destination node for every edit transaction, in order. Local edits use the fake's sentinel value of zero. */
+    val editSettingsDestinations = mutableListOf<Int>()
+
+    /** High-level admin operation order, including edit transaction boundaries. */
+    val adminOperations = mutableListOf<String>()
+
+    /** Test hook invoked after an edit transaction commits. */
+    var onEditSettingsCommitted: suspend () -> Unit = {}
+
+    /** Test hook invoked after a standalone module-config write. */
+    var onStandaloneModuleConfig: suspend (ModuleConfig) -> Unit = {}
+
+    /** Test hook invoked after a standalone general-config write. */
+    var onStandaloneConfig: suspend (Config) -> Unit = {}
+
+    private val editSettingsDepth = atomic(0)
 
     var throwOnSend: Boolean = false
 
@@ -81,11 +128,20 @@ class FakeRadioController :
 
     init {
         registerResetAction {
+            connectionStateHolder.reset()
             sentPackets.clear()
             favoritedNodes.clear()
             sentSharedContacts.clear()
-            localConfigs.clear()
+            configWrites.clear()
             localChannels.clear()
+            fixedPositions.clear()
+            moduleConfigWrites.clear()
+            editSettingsDestinations.clear()
+            adminOperations.clear()
+            onEditSettingsCommitted = {}
+            onStandaloneModuleConfig = {}
+            onStandaloneConfig = {}
+            editSettingsDepth.value = 0
             throwOnSend = false
             throwOnSetLocalConfig = false
             failChannelWriteAfter = null
@@ -129,7 +185,7 @@ class FakeRadioController :
 
     override suspend fun setLocalConfig(config: Config) {
         if (throwOnSetLocalConfig) error("Fake local config write failure")
-        localConfigs.add(config)
+        configWrites.add(ConfigWrite(destination = null, config = config))
     }
 
     override suspend fun setLocalChannel(channel: Channel) {
@@ -138,22 +194,33 @@ class FakeRadioController :
 
     override suspend fun setOwner(destNum: Int, user: User, packetId: Int) {
         lastSetOwnerUser = user
+        adminOperations.add("owner")
     }
 
     override suspend fun setHamMode(destNum: Int, hamParameters: HamParameters, packetId: Int) {}
 
     override suspend fun setConfig(destNum: Int, config: Config, packetId: Int) {
-        localConfigs.add(config)
+        configWrites.add(ConfigWrite(destination = destNum, config = config))
+        adminOperations.add("config:update")
+        if (editSettingsDepth.value == 0) onStandaloneConfig(config)
     }
 
-    override suspend fun setModuleConfig(destNum: Int, config: ModuleConfig, packetId: Int) {}
+    override suspend fun setModuleConfig(destNum: Int, config: ModuleConfig, packetId: Int) {
+        moduleConfigWrites.add(ModuleConfigWrite(destination = destNum, config = config))
+        adminOperations.add("module:update")
+        if (editSettingsDepth.value == 0) onStandaloneModuleConfig(config)
+    }
 
     override suspend fun setRemoteChannel(destNum: Int, channel: Channel, packetId: Int) {
         failChannelWriteAfter?.let { if (localChannels.size >= it) error("Fake channel write failure") }
         localChannels.add(channel)
+        adminOperations.add("channel:${channel.index}")
     }
 
-    override suspend fun setFixedPosition(destNum: Int, position: Position) {}
+    override suspend fun setFixedPosition(destNum: Int, position: Position) {
+        fixedPositions.add(position)
+        adminOperations.add("fixed-position")
+    }
 
     override suspend fun setRingtone(destNum: Int, ringtone: String) {}
 
@@ -202,23 +269,42 @@ class FakeRadioController :
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {}
 
     override suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit) {
+        editSettingsDestinations.add(destNum)
         editSettingsCalled = true
-        val scope =
-            object : AdminEditScope {
-                override suspend fun setOwner(user: User) = setOwner(destNum, user, generatePacketId())
+        adminOperations.add("begin")
+        editSettingsDepth.incrementAndGet()
+        try {
+            val scope =
+                object : AdminEditScope {
+                    override suspend fun setOwner(user: User) = setOwner(destNum, user, generatePacketId())
 
-                override suspend fun setConfig(config: Config) = setConfig(destNum, config, generatePacketId())
+                    override suspend fun setConfig(config: Config) = setConfig(destNum, config, generatePacketId())
 
-                override suspend fun setModuleConfig(config: ModuleConfig) =
-                    setModuleConfig(destNum, config, generatePacketId())
+                    override suspend fun setModuleConfig(config: ModuleConfig) =
+                        setModuleConfig(destNum, config, generatePacketId())
 
-                override suspend fun setChannel(channel: Channel) =
-                    setRemoteChannel(destNum, channel, generatePacketId())
+                    override suspend fun setChannel(channel: Channel) =
+                        setRemoteChannel(destNum, channel, generatePacketId())
 
-                override suspend fun setFixedPosition(position: Position) =
-                    this@FakeRadioController.setFixedPosition(destNum, position)
+                    override suspend fun setFixedPosition(position: Position) =
+                        this@FakeRadioController.setFixedPosition(destNum, position)
+                }
+            val blockResult = runCatching { scope.block() }
+            val commitResult = runCatching {
+                withContext(NonCancellable) {
+                    adminOperations.add("commit")
+                    onEditSettingsCommitted()
+                }
             }
-        scope.block()
+
+            blockResult.exceptionOrNull()?.let { blockFailure ->
+                commitResult.exceptionOrNull()?.takeUnless { it === blockFailure }?.let(blockFailure::addSuppressed)
+                throw blockFailure
+            }
+            commitResult.getOrThrow()
+        } finally {
+            editSettingsDepth.decrementAndGet()
+        }
     }
 
     override suspend fun editLocalSettings(block: suspend AdminEditScope.() -> Unit) = editSettings(0, block)
@@ -243,9 +329,7 @@ class FakeRadioController :
 
     // --- Helper methods for testing ---
 
-    fun setConnectionState(state: ConnectionState) {
-        _connectionState.value = state
-    }
+    fun setConnectionState(state: ConnectionState) = connectionStateHolder.setConnectionState(state)
 
     fun setClientNotification(notification: ClientNotification?) {
         _clientNotification.value = notification

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -91,16 +91,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
         session: RadioSessionContext,
         block: suspend (RadioSessionLease) -> Unit,
     ): Boolean {
-        val admittedSession =
-            synchronized(sessionAdmissionLock) {
-                val active = _activeSession.value
-                if (!sessionAdmissionOpen || active != session) {
-                    null
-                } else {
-                    admittedSessionOperations++
-                    active
-                }
-            } ?: return false
+        val admittedSession = admitSessionOperation(session) ?: return false
 
         val lease =
             object : RadioSessionLease {
@@ -114,20 +105,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
             block(lease)
             return true
         } finally {
-            val waiter =
-                synchronized(sessionAdmissionLock) {
-                    check(_activeSession.value == admittedSession) {
-                        "Fake session changed before an admitted operation released its lease"
-                    }
-                    check(admittedSessionOperations > 0) { "Session operation count underflow" }
-                    admittedSessionOperations--
-                    if (admittedSessionOperations == 0) {
-                        sessionDrainWaiter.also { sessionDrainWaiter = null }
-                    } else {
-                        null
-                    }
-                }
-            waiter?.complete(Unit)
+            releaseSessionOperation(admittedSession)
         }
     }
 
@@ -153,7 +131,17 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
     override fun isMockTransport(): Boolean = true
 
     override fun sendToRadio(bytes: ByteArray) {
-        sentToRadio.add(bytes)
+        trySendToRadio(bytes)
+    }
+
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
+        val admittedSession = admitSessionOperation() ?: return false
+        return try {
+            synchronized(sessionAdmissionLock) { sentToRadio.add(bytes) }
+            true
+        } finally {
+            releaseSessionOperation(admittedSession)
+        }
     }
 
     override fun connect() {
@@ -179,6 +167,34 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
     override fun setDeviceAddress(deviceAddr: String?): Boolean {
         _currentDeviceAddressFlow.value = deviceAddr
         return true
+    }
+
+    private fun admitSessionOperation(expectedSession: RadioSessionContext? = null): RadioSessionContext? =
+        synchronized(sessionAdmissionLock) {
+            val active = _activeSession.value
+            if (!sessionAdmissionOpen || active == null || (expectedSession != null && active != expectedSession)) {
+                null
+            } else {
+                admittedSessionOperations++
+                active
+            }
+        }
+
+    private fun releaseSessionOperation(admittedSession: RadioSessionContext) {
+        val waiter =
+            synchronized(sessionAdmissionLock) {
+                check(_activeSession.value == admittedSession) {
+                    "Fake session changed before an admitted operation released its lease"
+                }
+                check(admittedSessionOperations > 0) { "Session operation count underflow" }
+                admittedSessionOperations--
+                if (admittedSessionOperations == 0) {
+                    sessionDrainWaiter.also { sessionDrainWaiter = null }
+                } else {
+                    null
+                }
+            }
+        waiter?.complete(Unit)
     }
 
     private fun admitSelectedSession() {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeServiceRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeServiceRepository.kt
@@ -26,6 +26,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.service.LockdownTokenInfo
 import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.MeshPacket
@@ -33,12 +34,12 @@ import org.meshtastic.proto.MeshPacket
 @Suppress("TooManyFunctions")
 class FakeServiceRepository : ServiceRepository {
     /** Canonical app-level connection state — the single source of truth for UI/feature tests. */
-    private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState> = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
-    override fun setConnectionState(connectionState: ConnectionState) {
-        _connectionState.value = connectionState
-    }
+    override fun setConnectionState(connectionState: ConnectionState) =
+        connectionStateHolder.setConnectionState(connectionState)
 
     private val _clientNotification = MutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?> = _clientNotification

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
@@ -63,6 +63,24 @@ class FakeRadioInterfaceServiceSessionTest {
     }
 
     @Test
+    fun `trySendToRadio records bytes only while a session is admitted`() = runTest {
+        val service = FakeRadioInterfaceService(serviceScope = backgroundScope)
+        val bytes = byteArrayOf(1, 2, 3)
+
+        assertFalse(service.trySendToRadio(bytes))
+        assertTrue(service.sentToRadio.isEmpty())
+
+        service.setDeviceAddress("ble:test")
+        service.connect()
+        assertTrue(service.trySendToRadio(bytes))
+        assertEquals(1, service.sentToRadio.size)
+
+        service.disconnect()
+        assertFalse(service.trySendToRadio(bytes))
+        assertEquals(1, service.sentToRadio.size)
+    }
+
+    @Test
     fun `disconnect closes admission and waits for admitted fake session work`() = runTest {
         val service = FakeRadioInterfaceService(serviceScope = backgroundScope)
         service.setDeviceAddress("ble:test")

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -21,14 +21,22 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.QuickChatAction
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.Position
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.meshtastic.core.model.Position as ModelPosition
 
 class RepositoryFakesTest {
 
@@ -130,6 +138,98 @@ class RepositoryFakesTest {
         assertEquals("active", manager.lastAssociatedAddress)
         assertEquals(3, manager.lastAssociatedNode)
         assertEquals("fresh", manager.lastAssociatedDeviceId)
+    }
+
+    @Test
+    fun `service repository fake preserves connection epoch semantics`() {
+        val repository = FakeServiceRepository()
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), repository.connectionEpochs.value)
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), repository.connectionEpochs.value)
+
+        repository.setConnectionState(ConnectionState.Connecting)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 1,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            repository.connectionEpochs.value,
+        )
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            repository.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `FakeRadioController preserves configuration and fixed-position evidence until reset`() = runTest {
+        val controller = FakeRadioController()
+        val local = Config(device = Config.DeviceConfig())
+        val admin = Config(lora = Config.LoRaConfig(hop_limit = 5))
+        val module = ModuleConfig(serial = ModuleConfig.SerialConfig(enabled = true))
+        val position = ModelPosition(latitude = 1.0, longitude = 2.0, altitude = 3)
+
+        controller.setLocalConfig(local)
+        controller.setConfig(destNum = 7, config = admin, packetId = 8)
+        controller.setModuleConfig(destNum = 7, config = module, packetId = 9)
+        controller.setFixedPosition(destNum = 7, position = position)
+        controller.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(
+            listOf(
+                FakeRadioController.ConfigWrite(destination = null, config = local),
+                FakeRadioController.ConfigWrite(destination = 7, config = admin),
+            ),
+            controller.configWrites,
+        )
+        assertEquals(listOf(local, admin), controller.localConfigs)
+        assertEquals(
+            listOf(FakeRadioController.ModuleConfigWrite(destination = 7, config = module)),
+            controller.moduleConfigWrites,
+        )
+        assertEquals(listOf(module), controller.moduleConfigs)
+        assertEquals(listOf(7), controller.moduleConfigDestinations)
+        assertEquals(listOf(position), controller.fixedPositions)
+        assertEquals(ConnectionState.Connected, controller.connectionState.value)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), controller.connectionEpochs.value)
+
+        controller.reset()
+
+        assertTrue(controller.configWrites.isEmpty())
+        assertTrue(controller.localConfigs.isEmpty())
+        assertTrue(controller.moduleConfigWrites.isEmpty())
+        assertTrue(controller.moduleConfigs.isEmpty())
+        assertTrue(controller.moduleConfigDestinations.isEmpty())
+        assertTrue(controller.fixedPositions.isEmpty())
+        assertEquals(ConnectionState.Disconnected, controller.connectionState.value)
+        assertEquals(ConnectionEpochs(), controller.connectionEpochs.value)
+    }
+
+    @Test
+    fun `FakeRadioController commits after block failure and preserves failure precedence`() = runTest {
+        val controller = FakeRadioController()
+        val blockFailure = IllegalStateException("write failed")
+        val commitFailure = IllegalArgumentException("commit failed")
+        controller.onEditSettingsCommitted = { throw commitFailure }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { throw blockFailure } }
+
+        assertSame(blockFailure, failure)
+        val suppressedCommitFailure = assertIs<IllegalArgumentException>(failure.suppressedExceptions.single())
+        assertEquals(commitFailure.message, suppressedCommitFailure.message)
+        assertEquals(listOf("begin", "commit"), controller.adminOperations)
     }
 
     @Test

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -21,10 +21,13 @@ import co.touchlab.kermit.Logger
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import okio.ByteString
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.DateFormatter
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.model.util.CHANNEL_REPLACEMENT_SLOT_COUNT
+import org.meshtastic.core.model.util.getChannelReplacementList
+import org.meshtastic.core.model.util.getUniqueChannelAdditions
+import org.meshtastic.core.model.util.normalizeReplacementSettings
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.resources.Res
@@ -36,12 +39,8 @@ import org.meshtastic.proto.Config
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.Position
 import kotlin.time.Duration.Companion.days
-import org.meshtastic.core.model.Channel as ModelChannel
 
 private const val SECONDS_TO_MILLIS = 1000L
-
-// Firmware channel files expose eight slots: one primary plus up to seven secondary channels.
-private const val CHANNEL_REPLACEMENT_SLOT_COUNT = 8
 
 @Composable
 fun Position.formatPositionTime(): String {
@@ -94,114 +93,17 @@ fun getChannelList(new: List<ChannelSettings>, old: List<ChannelSettings>): List
 }
 
 /**
- * Builds an authoritative [Channel] list for a full REPLACE import. Every position in [new] is emitted (PRIMARY at
- * index 0, SECONDARY for 1..new.lastIndex) and any trailing positions beyond [new]'s range are emitted as DISABLED so
- * the radio stops using them.
- *
- * Unlike [getChannelList], this does NOT skip positions where `currentSettings[i] == new[i]`: the imported set is
- * authoritative, the local cache must not gate the writes, and silent diff-skips during REPLACE were the source of
- * stale channels.
- *
- * [currentSettings] is consulted only for its size (to determine trailing DISABLED writes); its values are never
- * compared against [new]. Callers should read it from `radioConfigRepository.channelSetFlow.first().settings`, not from
- * a `stateInWhileSubscribed` StateFlow's `.value` — the StateFlow placeholder window can return an empty list and
- * suppress trailing DISABLED writes.
- *
- * Edge case: if [new] is empty, every emitted slot (including index 0) is DISABLED rather than wrongly promoting an
- * empty [ChannelSettings] to PRIMARY.
- *
- * @param new The imported [ChannelSettings] list. Every index becomes a write to the radio.
- * @param currentSettings The current [ChannelSettings] list. Only its size is used; trailing indices past [new] become
- *   DISABLED writes so leftover slots are cleared.
- * @param minimumSlotCount The minimum slot count to emit. Full replacement callers can use this to disable firmware
- *   slots even when the local cache is stale or shorter than the radio's actual channel list.
- * @param maximumSlotCount The maximum slot count to emit. Full replacement callers use this to avoid unsupported
- *   firmware channel indices even if an imported or cached list is longer than expected.
- * @return A [Channel] list covering every slot the radio needs written to materialize [new] and clear leftover slots.
- */
-fun getChannelReplacementList(
-    new: List<ChannelSettings>,
-    currentSettings: List<ChannelSettings>,
-    minimumSlotCount: Int = 0,
-    maximumSlotCount: Int = Int.MAX_VALUE,
-): List<Channel> = buildList {
-    require(minimumSlotCount <= maximumSlotCount) { "minimumSlotCount must be <= maximumSlotCount" }
-    val minimumLastIndex = minimumSlotCount.coerceAtLeast(0) - 1
-    val maximumLastIndex = maximumSlotCount.coerceAtLeast(0) - 1
-    val endIndex = maxOf(currentSettings.lastIndex, new.lastIndex, minimumLastIndex).coerceAtMost(maximumLastIndex)
-    if (endIndex < 0) return@buildList
-    for (i in 0..endIndex) {
-        add(
-            Channel(
-                role =
-                when (i) {
-                    // Empty-new is a degenerate import: every slot (including 0) must be DISABLED.
-                    0 -> if (new.isEmpty()) Channel.Role.DISABLED else Channel.Role.PRIMARY
-
-                    in 1..new.lastIndex -> Channel.Role.SECONDARY
-
-                    else -> Channel.Role.DISABLED
-                },
-                index = i,
-                settings = new.getOrNull(i) ?: ChannelSettings(),
-            ),
-        )
-    }
-}
-
-/**
- * Normalizes an imported REPLACE-mode [ChannelSettings] list so firmware only materializes real, distinct channels.
- *
- * Imported replacement sets can carry blank placeholder secondaries (trailing empty [ChannelSettings] padding) and
- * semantic duplicates (two slots resolving to the same effective channel under the active LoRa preset). Both produce
- * invalid LongFast-looking slots on the radio that cause route failures (`QueueStatus res=6` / `routeErr=6`).
- * - Slot 0 (primary) is always preserved as-is, even if blank (a blank primary is a deliberate disable signal).
- * - A blank placeholder primary does not participate in duplicate tracking.
- * - Blank placeholder secondaries (no name AND no PSK) are dropped.
- * - Semantic duplicates (same effective name + effective PSK as an earlier kept slot) are dropped.
- * - Remaining valid secondaries compact into sequential slots 1..n.
- *
- * @param settings Raw imported settings list.
- * @param loraConfig Active LoRa config used to resolve effective channel identity. Null falls back to defaults.
- * @return Compacted, deduplicated list safe to write to the radio.
- */
-fun normalizeReplacementSettings(
-    settings: List<ChannelSettings>,
-    loraConfig: Config.LoRaConfig?,
-): List<ChannelSettings> {
-    if (settings.size <= 1) return settings
-    val effectiveLora = loraConfig ?: Config.LoRaConfig()
-    val primary = settings.first()
-    val seen = mutableSetOf<ChannelIdentity>()
-    if (!primary.isPlaceholder()) {
-        seen.add(primary.channelIdentity(effectiveLora))
-    }
-    val compact = mutableListOf(primary)
-    for (index in 1..settings.lastIndex) {
-        val candidate = settings[index]
-        val identity = if (candidate.isPlaceholder()) null else candidate.channelIdentity(effectiveLora)
-        if (identity != null && seen.add(identity)) {
-            compact.add(candidate)
-        }
-    }
-    return compact
-}
-
-/** True when a [ChannelSettings] carries no name and no PSK — a placeholder, not an intended channel. */
-private fun ChannelSettings.isPlaceholder(): Boolean = name.isNullOrBlank() && psk.size == 0
-
-/**
  * Imports a [ChannelSet] as an authoritative REPLACE: writes every channel and — when present and actually different —
  * the imported LoRa config, all inside one [RadioController.editLocalSettings] transaction, then replaces the local
  * channel cache.
  *
- * Reads the current LoRa config and channel set from [radioConfigRepository]'s flows (avoiding the StateFlow
- * placeholder window) and builds the authoritative replacement list via [getChannelReplacementList]. The edit-settings
- * transaction defers disk persistence, radio reload/reconfiguration, and reboot until the closing commit, so channels +
- * LoRa land in a single reboot with no per-slot reconfigure to pace against. (Firmware still writes each `set_channel`
- * into its in-memory channel table as it arrives — the transaction is not a full staging of channel state — but the
- * expensive persist/reload path runs once at commit.) Writing LoRa inside the same session mirrors
- * `InstallProfileUseCase` and is why the old pre/post settle delays are gone: the begin/commit boundary is the settle.
+ * Reads the current LoRa config from [radioConfigRepository]'s flow and builds the authoritative replacement list via
+ * [getChannelReplacementList]. The edit-settings transaction defers disk persistence, radio reload/reconfiguration, and
+ * reboot until the closing commit, so channels + LoRa land in a single reboot with no per-slot reconfigure to pace
+ * against. (Firmware still writes each `set_channel` into its in-memory channel table as it arrives — the transaction
+ * is not a full staging of channel state — but the expensive persist/reload path runs once at commit.) Writing LoRa
+ * inside the same session mirrors `InstallProfileUseCase` and is why the old pre/post settle delays are gone: the
+ * begin/commit boundary is the settle.
  *
  * The local channel cache is commit-shaped: transactional channel writes deliberately do not mirror per slot (see
  * `AdminControllerImpl.EditSettingsSession.setChannel`), and this function replaces the cached channel list once, after
@@ -231,11 +133,9 @@ suspend fun importChannelSet(
     require(normalizedSettings.size <= CHANNEL_REPLACEMENT_SLOT_COUNT) {
         "Imported channel set exceeds supported channel slot count"
     }
-    val currentSettings = radioConfigRepository.channelSetFlow.first().settings
     val replacements =
         getChannelReplacementList(
             new = normalizedSettings,
-            currentSettings = currentSettings,
             minimumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
             maximumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
         )
@@ -267,7 +167,7 @@ suspend fun importChannelSet(
  * incoming channel are omitted from the preview. Unique incoming channels are appended in scanned order and selected by
  * default while firmware channel capacity remains; unique channels beyond [maxChannels] stay visible but unchecked.
  *
- * Semantic identity is resolved via the [Channel] domain model so preset/default channels match correctly across modem
+ * Semantic identity is resolved by [getUniqueChannelAdditions] so preset/default channels match correctly across modem
  * presets: empty names resolve to the preset display name, and 1-byte PSK markers expand to the full default key.
  *
  * @param existing The current [ChannelSettings] list on the radio. Always shown, always selected.
@@ -282,36 +182,17 @@ fun getChannelPreviewForAdd(
     loraConfig: Config.LoRaConfig,
     maxChannels: Int,
 ): ChannelAddPreview {
-    val seen = existing.map { it.channelIdentity(loraConfig) }.toMutableSet()
     val previewSettings = existing.toMutableList()
     val previewSelections = MutableList(existing.size) { true }
     var remaining = (maxChannels - existing.size).coerceAtLeast(0)
-    for (channel in incoming) {
-        val shouldShow = !channel.isPlaceholder()
-        val identity = if (shouldShow) channel.channelIdentity(loraConfig) else null
-        // Omit blank placeholders and semantic duplicates entirely — they are not shown to the user.
-        if (identity != null && seen.add(identity)) {
-            previewSettings += channel
-            val shouldSelect = remaining > 0
-            previewSelections += shouldSelect
-            if (shouldSelect) remaining--
-        }
+    for (channel in getUniqueChannelAdditions(existing, incoming, loraConfig)) {
+        previewSettings += channel
+        val shouldSelect = remaining > 0
+        previewSelections += shouldSelect
+        if (shouldSelect) remaining--
     }
     return ChannelAddPreview(settings = previewSettings, selections = previewSelections)
 }
 
 /** Filtered ADD-mode preview: the visible channel list paired with its default selections (always size-matched). */
 data class ChannelAddPreview(val settings: List<ChannelSettings>, val selections: List<Boolean>)
-
-/** Semantic channel identity based on effective name and effective PSK. */
-private data class ChannelIdentity(val name: String, val psk: ByteString) {
-    // Redact the effective PSK from auto-generated diagnostics so a cryptographic key never leaks
-    // via toString() in exception messages, debug logs, or stack traces.
-    override fun toString(): String = "ChannelIdentity(name=$name, psk=<redacted>)"
-}
-
-/** Resolves the [ChannelIdentity] of this [ChannelSettings] under the given [Config.LoRaConfig]. */
-private fun ChannelSettings.channelIdentity(loraConfig: Config.LoRaConfig): ChannelIdentity {
-    val channel = ModelChannel(settings = this, loraConfig = loraConfig)
-    return ChannelIdentity(name = channel.name, psk = channel.psk)
-}

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ui.util
 
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.model.util.CHANNEL_REPLACEMENT_SLOT_COUNT
 import org.meshtastic.core.testing.FakeRadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioController
 import org.meshtastic.proto.Channel
@@ -32,137 +33,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.meshtastic.core.model.Channel as ModelChannel
 
-/**
- * Coverage for [getChannelReplacementList]. The REPLACE helper must emit an authoritative slot list for QR imports:
- * every imported index becomes a write (PRIMARY at 0, SECONDARY thereafter), and any trailing slots present in the
- * cached set are emitted as DISABLED so the radio stops using them. Critically, positions where the cache already
- * matches the import are NOT skipped — the diff-skip was the source of stale channels.
- */
+/** Coverage for the channel import and preview surfaces owned by core:ui. */
 class ProtoExtensionsTest {
-    @Test
-    fun index_zero_emits_primary_with_new_settings_even_when_unchanged_from_old() {
-        val same = ChannelSettings(name = "Main", psk = byteArrayOf(1, 2, 3).toByteString())
-
-        val result = getChannelReplacementList(new = listOf(same), currentSettings = listOf(same))
-
-        assertEquals(1, result.size)
-        assertEquals(Channel.Role.PRIMARY, result.single().role)
-        assertEquals(0, result.single().index)
-        assertEquals(same, result.single().settings)
-    }
-
-    @Test
-    fun secondary_indices_emit_secondary_with_new_settings_even_when_unchanged_from_old() {
-        val primary = ChannelSettings(name = "Main")
-        val secondary = ChannelSettings(name = "Chat")
-
-        val result =
-            getChannelReplacementList(new = listOf(primary, secondary), currentSettings = listOf(primary, secondary))
-
-        assertEquals(2, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(primary, result[0].settings)
-        assertEquals(Channel.Role.SECONDARY, result[1].role)
-        assertEquals(1, result[1].index)
-        assertEquals(secondary, result[1].settings)
-    }
-
-    @Test
-    fun old_trailing_indices_beyond_new_are_emitted_as_disabled_with_empty_settings() {
-        val primary = ChannelSettings(name = "Main")
-
-        val result =
-            getChannelReplacementList(
-                new = listOf(primary),
-                currentSettings = listOf(primary, ChannelSettings(name = "Old")),
-            )
-
-        // index 0 PRIMARY (new), index 1 DISABLED (trailing old slot)
-        assertEquals(2, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(primary, result[0].settings)
-        assertEquals(Channel.Role.DISABLED, result[1].role)
-        assertEquals(1, result[1].index)
-        assertEquals(ChannelSettings(), result[1].settings)
-    }
-
-    @Test
-    fun empty_new_and_empty_old_produces_empty_list() {
-        val result = getChannelReplacementList(new = emptyList(), currentSettings = emptyList())
-
-        assertTrue(result.isEmpty())
-    }
-
-    @Test
-    fun empty_new_with_non_empty_current_emits_disabled_for_every_current_index() {
-        val currentSettings =
-            listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"), ChannelSettings(name = "C"))
-
-        val result = getChannelReplacementList(new = emptyList(), currentSettings = currentSettings)
-
-        assertEquals(3, result.size)
-        result.forEachIndexed { i, channel ->
-            assertEquals(Channel.Role.DISABLED, channel.role, "index $i should be DISABLED")
-            assertEquals(i, channel.index)
-            assertEquals(ChannelSettings(), channel.settings, "index $i should carry empty settings")
-        }
-    }
-
-    @Test
-    fun single_entry_new_with_multi_entry_current_emits_primary_then_disabled_trailing() {
-        val newPrimary = ChannelSettings(name = "Imported")
-        val currentSettings =
-            listOf(
-                ChannelSettings(name = "CurrentPrimary"),
-                ChannelSettings(name = "CurrentSecondary"),
-                ChannelSettings(name = "CurrentTertiary"),
-            )
-
-        val result = getChannelReplacementList(new = listOf(newPrimary), currentSettings = currentSettings)
-
-        assertEquals(3, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(0, result[0].index)
-        assertEquals(newPrimary, result[0].settings)
-        assertEquals(Channel.Role.DISABLED, result[1].role)
-        assertEquals(Channel.Role.DISABLED, result[2].role)
-        assertEquals(ChannelSettings(), result[1].settings)
-        assertEquals(ChannelSettings(), result[2].settings)
-    }
-
-    @Test
-    fun new_larger_than_old_emits_primary_plus_secondaries_for_every_new_index() {
-        val primary = ChannelSettings(name = "Main")
-        val secondaryA = ChannelSettings(name = "Chat")
-        val secondaryB = ChannelSettings(name = "Data")
-
-        val result =
-            getChannelReplacementList(new = listOf(primary, secondaryA, secondaryB), currentSettings = listOf(primary))
-
-        assertEquals(3, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(0, result[0].index)
-        assertEquals(primary, result[0].settings)
-        assertEquals(Channel.Role.SECONDARY, result[1].role)
-        assertEquals(1, result[1].index)
-        assertEquals(secondaryA, result[1].settings)
-        assertEquals(Channel.Role.SECONDARY, result[2].role)
-        assertEquals(2, result[2].index)
-        assertEquals(secondaryB, result[2].settings)
-    }
-
-    @Test
-    fun replacement_list_rejects_minimum_slot_count_above_maximum_slot_count() {
-        assertFailsWith<IllegalArgumentException> {
-            getChannelReplacementList(
-                new = listOf(ChannelSettings(name = "Main")),
-                currentSettings = emptyList(),
-                minimumSlotCount = 2,
-                maximumSlotCount = 1,
-            )
-        }
-    }
-
     @Test
     fun import_writes_all_eight_slots_with_replacement_roles() = runTest {
         val radioController = FakeRadioController()
@@ -182,7 +54,7 @@ class ProtoExtensionsTest {
             radioConfigRepository = radioConfigRepository,
         )
 
-        assertEquals((0..7).toList(), radioController.localChannels.map { it.index })
+        assertEquals((0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(), radioController.localChannels.map { it.index })
         assertEquals(
             listOf(
                 Channel.Role.PRIMARY,
@@ -259,7 +131,7 @@ class ProtoExtensionsTest {
             radioConfigRepository = radioConfigRepository,
         )
 
-        assertEquals((0..7).toList(), radioController.localChannels.map { it.index })
+        assertEquals((0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(), radioController.localChannels.map { it.index })
         assertEquals(importedSettings, radioConfigRepository.currentChannelSet.settings)
     }
 
@@ -417,6 +289,23 @@ class ProtoExtensionsTest {
             getChannelPreviewForAdd(listOf(channel), listOf(channel), ModelChannel.default.loraConfig, maxChannels = 8)
 
         assertEquals(listOf(channel), preview.settings)
+    }
+
+    @Test
+    fun preview_blank_existing_slot_does_not_suppress_meaningful_incoming_channel() {
+        val blank = ChannelSettings()
+        val incoming = ChannelSettings(name = "LongFast")
+
+        val preview =
+            getChannelPreviewForAdd(
+                existing = listOf(blank),
+                incoming = listOf(incoming),
+                loraConfig = ModelChannel.default.loraConfig,
+                maxChannels = 8,
+            )
+
+        assertEquals(listOf(blank, incoming), preview.settings)
+        assertTrue(preview.selections[1])
     }
 
     @Test
@@ -585,128 +474,5 @@ class ProtoExtensionsTest {
 
         assertTrue(preview.settings.isEmpty())
         assertTrue(preview.selections.isEmpty())
-    }
-
-    // --- normalizeReplacementSettings tests ---
-
-    @Test
-    fun normalize_empty_list_passes_through() {
-        assertEquals(emptyList(), normalizeReplacementSettings(emptyList(), ModelChannel.default.loraConfig))
-    }
-
-    @Test
-    fun normalize_single_element_passes_through() {
-        val primary = ChannelSettings(name = "Solo", psk = byteArrayOf(1).toByteString())
-
-        assertEquals(listOf(primary), normalizeReplacementSettings(listOf(primary), ModelChannel.default.loraConfig))
-    }
-
-    @Test
-    fun normalize_drops_blank_placeholder_secondary() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1, 2).toByteString())
-        val real = ChannelSettings(name = "Chat", psk = byteArrayOf(3).toByteString())
-
-        val result =
-            normalizeReplacementSettings(listOf(primary, ChannelSettings(), real), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary, real), result)
-    }
-
-    @Test
-    fun normalize_preserves_blank_primary() {
-        val blankPrimary = ChannelSettings()
-        val real = ChannelSettings(name = "Chat", psk = byteArrayOf(3).toByteString())
-
-        // Slot 0 is always preserved, even when blank (deliberate disable signal).
-        val result = normalizeReplacementSettings(listOf(blankPrimary, real), ModelChannel.default.loraConfig)
-
-        assertEquals(2, result.size)
-        assertEquals(blankPrimary, result[0])
-        assertEquals(real, result[1])
-    }
-
-    @Test
-    fun normalize_blank_primary_does_not_seed_duplicate_tracking() {
-        val blankPrimary = ChannelSettings()
-        val publicSecondary = ChannelSettings(psk = byteArrayOf(1).toByteString())
-
-        val result =
-            normalizeReplacementSettings(listOf(blankPrimary, publicSecondary), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(blankPrimary, publicSecondary), result)
-    }
-
-    @Test
-    fun normalize_drops_semantic_duplicate_secondary() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-        val dup = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-
-        val result = normalizeReplacementSettings(listOf(primary, dup), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary), result)
-    }
-
-    @Test
-    fun normalize_keeps_same_name_different_psk() {
-        val primary = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
-        val other = ChannelSettings(name = "A", psk = byteArrayOf(2).toByteString())
-
-        val result = normalizeReplacementSettings(listOf(primary, other), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary, other), result)
-    }
-
-    @Test
-    fun normalize_keeps_same_psk_different_name() {
-        val psk = byteArrayOf(1, 2).toByteString()
-        val primary = ChannelSettings(name = "A", psk = psk)
-        val other = ChannelSettings(name = "B", psk = psk)
-
-        val result = normalizeReplacementSettings(listOf(primary, other), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary, other), result)
-    }
-
-    @Test
-    fun normalize_compacts_valid_secondaries_into_sequential_slots() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-        val b = ChannelSettings(name = "B", psk = byteArrayOf(2).toByteString())
-        val c = ChannelSettings(name = "C", psk = byteArrayOf(3).toByteString())
-
-        // blank + duplicate mixed in; valid B and C must compact to slots 1 and 2 with no gap
-        val result =
-            normalizeReplacementSettings(
-                listOf(
-                    primary,
-                    ChannelSettings(),
-                    b,
-                    ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString()),
-                    c,
-                ),
-                ModelChannel.default.loraConfig,
-            )
-
-        assertEquals(listOf(primary, b, c), result)
-    }
-
-    @Test
-    fun normalize_null_lora_falls_back_to_defaults_without_crashing() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-
-        val result = normalizeReplacementSettings(listOf(primary, ChannelSettings()), loraConfig = null)
-
-        assertEquals(listOf(primary), result)
-    }
-
-    @Test
-    fun normalize_all_blank_input_preserves_only_primary() {
-        // Primary is always preserved (even blank); both blank placeholder secondaries are dropped.
-        val result =
-            normalizeReplacementSettings(
-                listOf(ChannelSettings(), ChannelSettings(), ChannelSettings()),
-                ModelChannel.default.loraConfig,
-            )
-
-        assertEquals(1, result.size)
     }
 }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -90,7 +90,12 @@ class NoopRadioInterfaceService : RadioInterfaceService {
     override val connectionError: Flow<String> = MutableSharedFlow<String>()
 
     override fun sendToRadio(bytes: ByteArray) {
+        trySendToRadio(bytes)
+    }
+
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
         logWarn("NoopRadioInterfaceService.sendToRadio(${bytes.size} bytes)")
+        return false
     }
 
     override fun resetReceivedBuffer() {

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
@@ -58,6 +58,9 @@ import org.meshtastic.core.resources.export_configuration
 import org.meshtastic.core.resources.filter_settings
 import org.meshtastic.core.resources.help_and_documentation
 import org.meshtastic.core.resources.import_configuration
+import org.meshtastic.core.resources.import_configuration_failed
+import org.meshtastic.core.resources.install_configuration_bluetooth_repair_hint
+import org.meshtastic.core.resources.install_configuration_failed
 import org.meshtastic.core.resources.node_layout_section_title
 import org.meshtastic.core.resources.preferences_language
 import org.meshtastic.core.resources.remotely_administrating
@@ -73,6 +76,7 @@ import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.PermScanWifi
 import org.meshtastic.core.ui.icon.SettingsRemote
 import org.meshtastic.core.ui.icon.Wifi
+import org.meshtastic.core.ui.util.SnackbarManager
 import org.meshtastic.feature.settings.component.AppInfoSection
 import org.meshtastic.feature.settings.component.AppearanceSection
 import org.meshtastic.feature.settings.component.ExpressiveSection
@@ -84,6 +88,7 @@ import org.meshtastic.feature.settings.navigation.ModuleRoute
 import org.meshtastic.feature.settings.radio.RadioConfigItemList
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.radio.component.EditDeviceProfileDialog
+import org.meshtastic.feature.settings.radio.shouldSuggestBluetoothRepair
 import org.meshtastic.feature.settings.util.LanguageUtils
 import org.meshtastic.feature.settings.util.LanguageUtils.languageMap
 import org.meshtastic.proto.DeviceProfile
@@ -99,6 +104,10 @@ fun SettingsScreen(
     onBack: (() -> Unit)? = null,
 ) {
     val appFunctionsAvailable: Boolean = koinInject(qualifier = named("googleServicesAvailable"))
+    val snackbarManager: SnackbarManager = koinInject()
+    val importFailureMessage = stringResource(Res.string.import_configuration_failed)
+    val installFailureMessage = stringResource(Res.string.install_configuration_failed)
+    val bluetoothRepairHint = stringResource(Res.string.install_configuration_bluetooth_repair_hint)
     val hiddenFeaturesUnlocked by settingsViewModel.hiddenFeaturesUnlocked.collectAsStateWithLifecycle()
     val localConfig by settingsViewModel.localConfig.collectAsStateWithLifecycle()
     val ourNode by settingsViewModel.ourNodeInfo.collectAsStateWithLifecycle()
@@ -111,11 +120,20 @@ fun SettingsScreen(
     var showEditDeviceProfileDialog by remember { mutableStateOf(false) }
 
     val importConfigLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            if (it.resultCode == Activity.RESULT_OK) {
-                showEditDeviceProfileDialog = true
-                it.data?.data?.let { uri ->
-                    viewModel.importProfile(uri.toKmpUri()) { profile -> deviceProfile = profile }
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val uri = result.data?.data
+                if (uri == null) {
+                    snackbarManager.showSnackbar(importFailureMessage)
+                } else {
+                    viewModel.importProfile(uri.toKmpUri()) { importResult ->
+                        importResult
+                            .onSuccess { profile ->
+                                deviceProfile = profile
+                                showEditDeviceProfileDialog = true
+                            }
+                            .onFailure { snackbarManager.showSnackbar(importFailureMessage) }
+                    }
                 }
             }
         }
@@ -139,7 +157,16 @@ fun SettingsScreen(
             onConfirm = {
                 showEditDeviceProfileDialog = false
                 if (deviceProfile != null) {
-                    viewModel.installProfile(it)
+                    val selectedProfile = it
+                    viewModel.installProfile(selectedProfile) { result ->
+                        result
+                            .onSuccess {
+                                if (selectedProfile.shouldSuggestBluetoothRepair()) {
+                                    snackbarManager.showSnackbar(bluetoothRepairHint)
+                                }
+                            }
+                            .onFailure { snackbarManager.showSnackbar(installFailureMessage) }
+                    }
                 } else {
                     deviceProfile = it
                     val nodeName = (it.short_name ?: "").ifBlank { "node" }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHints.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHints.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio
+
+import org.meshtastic.proto.DeviceProfile
+
+/** Whether a successful restore may require Android to establish a new Bluetooth bond. */
+internal fun DeviceProfile.shouldSuggestBluetoothRepair(): Boolean = config?.bluetooth?.enabled == true

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -568,6 +568,7 @@ open class RadioConfigViewModel(
                         paxcounter = config.paxcounter ?: state.moduleConfig.paxcounter,
                         statusmessage = config.statusmessage ?: state.moduleConfig.statusmessage,
                         tak = config.tak ?: state.moduleConfig.tak,
+                        mesh_beacon = config.mesh_beacon ?: state.moduleConfig.mesh_beacon,
                     ),
                 )
             }
@@ -643,13 +644,19 @@ open class RadioConfigViewModel(
         safeLaunch(tag = "removeFixedPosition") { radioConfigUseCase.removeFixedPosition(destNum) }
     }
 
-    fun importProfile(uri: CommonUri, onResult: (DeviceProfile) -> Unit) {
-        safeLaunch(tag = "importProfile") {
-            var profile: DeviceProfile? = null
-            fileService.read(uri) { source ->
-                importProfileUseCase(source).onSuccess { profile = it }.onFailure { throw it }
+    fun importProfile(uri: CommonUri, onResult: (Result<DeviceProfile>) -> Unit) {
+        viewModelScope.launch {
+            val result = safeCatching {
+                var profile: DeviceProfile? = null
+                val wasRead = fileService.read(uri) { source -> profile = importProfileUseCase(source).getOrThrow() }
+                check(wasRead) { "Unable to read the selected configuration profile" }
+                checkNotNull(profile) { "The selected configuration profile was empty" }
             }
-            profile?.let { onResult(it) }
+            // Do not attach the exception: parser messages can quote profile bytes containing credentials.
+            result.onFailure { error ->
+                Logger.e { "[importProfile] Failed to import profile; cause=${error.safeLogType()}" }
+            }
+            onResult(result)
         }
     }
 
@@ -720,9 +727,28 @@ open class RadioConfigViewModel(
         }
     }
 
-    fun installProfile(protobuf: DeviceProfile) {
-        val destNum = destNum ?: destNode.value?.num ?: return
-        safeLaunch(tag = "installProfile") { installProfileUseCase(destNum, protobuf, destNode.value?.user) }
+    fun installProfile(protobuf: DeviceProfile, onResult: (Result<Unit>) -> Unit = {}) {
+        val destNum = destNum ?: destNode.value?.num
+        if (destNum == null) {
+            onResult(Result.failure(IllegalStateException("No destination is available for profile installation")))
+            return
+        }
+        viewModelScope.launch {
+            val result = safeCatching {
+                installProfileUseCase(
+                    destNum = destNum,
+                    profile = protobuf,
+                    currentUser = destNode.value?.user,
+                    isLocal = radioConfigState.value.isLocal,
+                )
+                Unit
+            }
+            // Keep device/profile identifiers and exception messages out of logs while retaining the failure type.
+            result.onFailure { error ->
+                Logger.e { "[installProfile] Failed to install profile; cause=${error.safeLogType()}" }
+            }
+            onResult(result)
+        }
     }
 
     fun clearPacketResponse() {
@@ -1103,6 +1129,7 @@ open class RadioConfigViewModel(
                             paxcounter = response.paxcounter ?: state.moduleConfig.paxcounter,
                             statusmessage = response.statusmessage ?: state.moduleConfig.statusmessage,
                             tak = response.tak ?: state.moduleConfig.tak,
+                            mesh_beacon = response.mesh_beacon ?: state.moduleConfig.mesh_beacon,
                         ),
                     )
                 }
@@ -1235,3 +1262,6 @@ internal fun Config.saveRebootBehavior(): RebootBehavior = when {
 /** Firmware `AdminModule::handleSetModuleConfig` reboots for every module section except status message. */
 internal fun ModuleConfig.saveRebootBehavior(): RebootBehavior =
     if (statusmessage != null) RebootBehavior.NEVER else RebootBehavior.ALWAYS
+
+/** Returns diagnostic type information without logging a potentially sensitive exception message. */
+private fun Throwable.safeLogType(): String = this::class.simpleName ?: "Throwable"

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialog.kt
@@ -42,18 +42,27 @@ import org.meshtastic.core.ui.component.MeshtasticDialog
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.proto.DeviceProfile
 
-private const val UNMESSAGABLE_TAG = 9
-private const val LICENSED_TAG = 10
+private enum class ProfileField(val labelRes: StringResource) {
+    LONG_NAME(Res.string.long_name),
+    SHORT_NAME(Res.string.short_name),
+    CHANNEL_URL(Res.string.channel_url),
+    CONFIG(Res.string.radio_configuration),
+    MODULE_CONFIG(Res.string.module_settings),
+    FIXED_POSITION(Res.string.fixed_position),
+    UNMESSAGABLE(Res.string.unmessageable),
+    LICENSED(Res.string.licensed_amateur_radio),
+    ;
 
-private enum class ProfileField(val tag: Int, val labelRes: StringResource) {
-    LONG_NAME(1, Res.string.long_name),
-    SHORT_NAME(2, Res.string.short_name),
-    CHANNEL_URL(3, Res.string.channel_url),
-    CONFIG(4, Res.string.radio_configuration),
-    MODULE_CONFIG(5, Res.string.module_settings),
-    FIXED_POSITION(6, Res.string.fixed_position),
-    UNMESSAGABLE(UNMESSAGABLE_TAG, Res.string.unmessageable),
-    LICENSED(LICENSED_TAG, Res.string.licensed_amateur_radio),
+    fun isPresent(profile: DeviceProfile): Boolean = when (this) {
+        LONG_NAME -> profile.long_name != null
+        SHORT_NAME -> profile.short_name != null
+        CHANNEL_URL -> profile.channel_url != null
+        CONFIG -> profile.config != null
+        MODULE_CONFIG -> profile.module_config != null
+        FIXED_POSITION -> profile.fixed_position != null
+        UNMESSAGABLE -> profile.is_unmessagable != null
+        LICENSED -> profile.is_licensed != null
+    }
 }
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -65,24 +74,12 @@ fun EditDeviceProfileDialog(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val state = remember {
-        mutableStateMapOf<ProfileField, Boolean>().apply {
-            putAll(
-                ProfileField.entries.associateWith { field ->
-                    when (field) {
-                        ProfileField.LONG_NAME -> deviceProfile.long_name != null
-                        ProfileField.SHORT_NAME -> deviceProfile.short_name != null
-                        ProfileField.CHANNEL_URL -> deviceProfile.channel_url != null
-                        ProfileField.CONFIG -> deviceProfile.config != null
-                        ProfileField.MODULE_CONFIG -> deviceProfile.module_config != null
-                        ProfileField.FIXED_POSITION -> deviceProfile.fixed_position != null
-                        ProfileField.UNMESSAGABLE -> deviceProfile.is_unmessagable != null
-                        ProfileField.LICENSED -> deviceProfile.is_licensed != null
-                    }
-                },
-            )
+    val state =
+        remember(deviceProfile) {
+            mutableStateMapOf<ProfileField, Boolean>().apply {
+                putAll(ProfileField.entries.associateWith { field -> field.isPresent(deviceProfile) })
+            }
         }
-    }
 
     MeshtasticDialog(
         title = title,
@@ -119,21 +116,10 @@ fun EditDeviceProfileDialog(
             Column(modifier = Modifier.fillMaxWidth()) {
                 HorizontalDivider()
                 ProfileField.entries.forEach { field ->
-                    val isAvailable =
-                        when (field) {
-                            ProfileField.LONG_NAME -> deviceProfile.long_name != null
-                            ProfileField.SHORT_NAME -> deviceProfile.short_name != null
-                            ProfileField.CHANNEL_URL -> deviceProfile.channel_url != null
-                            ProfileField.CONFIG -> deviceProfile.config != null
-                            ProfileField.MODULE_CONFIG -> deviceProfile.module_config != null
-                            ProfileField.FIXED_POSITION -> deviceProfile.fixed_position != null
-                            ProfileField.UNMESSAGABLE -> deviceProfile.is_unmessagable != null
-                            ProfileField.LICENSED -> deviceProfile.is_licensed != null
-                        }
                     SwitchPreference(
                         title = stringResource(field.labelRes),
                         checked = state[field] == true,
-                        enabled = isAvailable,
+                        enabled = field.isPresent(deviceProfile),
                         onCheckedChange = { state[field] = it },
                         padding = PaddingValues(0.dp),
                     )

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHintsTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHintsTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio
+
+import org.meshtastic.proto.Config.BluetoothConfig
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProfileRestoreHintsTest {
+    @Test
+    fun `enabled Bluetooth restore suggests repair troubleshooting`() {
+        val profile = DeviceProfile(config = LocalConfig(bluetooth = BluetoothConfig(enabled = true)))
+
+        assertTrue(profile.shouldSuggestBluetoothRepair())
+    }
+
+    @Test
+    fun `absent or disabled Bluetooth restore does not suggest repair troubleshooting`() {
+        assertFalse(DeviceProfile().shouldSuggestBluetoothRepair())
+        assertFalse(
+            DeviceProfile(config = LocalConfig(bluetooth = BluetoothConfig(enabled = false)))
+                .shouldSuggestBluetoothRepair(),
+        )
+    }
+}

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
@@ -221,15 +221,15 @@ class ProfileRoundTripTest {
     private suspend fun TestScope.assertRoundTrip(profile: DeviceProfile) {
         val exportUri = CommonUri.parse("content://test/profile.bin")
         val reExportUri = CommonUri.parse("content://test/profile-reexport.bin")
-        var importedProfile: DeviceProfile? = null
+        var importResult: Result<DeviceProfile>? = null
 
         viewModel.exportProfile(exportUri, profile)
         runCurrent()
 
-        viewModel.importProfile(exportUri) { importedProfile = it }
+        viewModel.importProfile(exportUri) { importResult = it }
         runCurrent()
 
-        val actualImportedProfile = assertNotNull(importedProfile)
+        val actualImportedProfile = assertNotNull(importResult).getOrThrow()
         assertEquals(profile, actualImportedProfile)
         assertContentEquals(profile.encode(), fileService.readBytes(exportUri))
         assertContentEquals(profile.encode(), actualImportedProfile.encode())

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -20,6 +20,7 @@ import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -42,6 +43,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import okio.ByteString.Companion.encodeUtf8
+import org.meshtastic.core.common.util.CommonUri
 import org.meshtastic.core.domain.usecase.settings.AdminActionsUseCase
 import org.meshtastic.core.domain.usecase.settings.ExportProfileUseCase
 import org.meshtastic.core.domain.usecase.settings.ImportProfileUseCase
@@ -85,6 +87,7 @@ import org.meshtastic.proto.LoRaRegionPresetMap
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.ModuleConfig.MeshBeaconConfig
 import org.meshtastic.proto.User
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -125,6 +128,7 @@ class RadioConfigViewModelTest {
     private val snackbarManager: SnackbarManager = mock(MockMode.autofill)
     private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
 
+    private lateinit var serviceConnectionState: MutableStateFlow<ConnectionState>
     private lateinit var viewModel: RadioConfigViewModel
 
     @BeforeTest
@@ -143,8 +147,8 @@ class RadioConfigViewModelTest {
         every { homoglyphEncodingPrefs.homoglyphEncodingEnabled } returns MutableStateFlow(false)
 
         every { serviceRepository.meshPacketFlow } returns MutableSharedFlow()
-        every { serviceRepository.connectionState } returns
-            MutableStateFlow(org.meshtastic.core.model.ConnectionState.Connected)
+        serviceConnectionState = MutableStateFlow(ConnectionState.Connected)
+        every { serviceRepository.connectionState } returns serviceConnectionState
 
         every { mqttManager.mqttConnectionState } returns
             MutableStateFlow(org.meshtastic.core.model.MqttConnectionState.Inactive)
@@ -185,6 +189,35 @@ class RadioConfigViewModelTest {
         mqttManager = mqttManager,
         lockdownCoordinator = FakeLockdownCoordinator(),
     )
+
+    @Test
+    fun `importProfile reports unreadable file instead of silently dropping result`() = runTest {
+        everySuspend { fileService.read(any(), any()) } returns false
+        var result: Result<DeviceProfile>? = null
+
+        viewModel.importProfile(CommonUri.parse("content://test/missing.cfg")) { result = it }
+        advanceUntilIdle()
+
+        assertFalse(assertNotNull(result).isSuccess)
+    }
+
+    @Test
+    fun `importProfile reports decoder failure exactly once`() = runTest {
+        everySuspend { fileService.read(any(), any()) } calls
+            { args ->
+                val block = args.arg<suspend (okio.BufferedSource) -> Unit>(1)
+                block(okio.Buffer().writeUtf8("not a profile"))
+                true
+            }
+        everySuspend { importProfileUseCase(any()) } returns Result.failure(IllegalArgumentException("bad profile"))
+        val results = mutableListOf<Result<DeviceProfile>>()
+
+        viewModel.importProfile(CommonUri.parse("content://test/bad.cfg"), results::add)
+        advanceUntilIdle()
+
+        assertEquals(1, results.size)
+        assertFalse(results.single().isSuccess)
+    }
 
     @Test
     fun `setConfig calls useCase`() = runTest {
@@ -1029,11 +1062,45 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val profile = DeviceProfile()
-        everySuspend { installProfileUseCase(any(), any(), any()) } returns Unit
+        everySuspend { installProfileUseCase(any(), any(), any(), any()) } returns Unit
 
-        viewModel.installProfile(profile)
+        var result: Result<Unit>? = null
+        viewModel.installProfile(profile) { result = it }
+        advanceUntilIdle()
 
-        verifySuspend { installProfileUseCase(123, profile, any()) }
+        verifySuspend { installProfileUseCase(123, profile, any(), true) }
+        assertTrue(assertNotNull(result).isSuccess)
+    }
+
+    @Test
+    fun `installProfile reports missing destination`() = runTest {
+        viewModel = createViewModel()
+        var result: Result<Unit>? = null
+
+        viewModel.installProfile(DeviceProfile()) { result = it }
+
+        assertFalse(assertNotNull(result).isSuccess)
+        verifySuspend(exactly(0)) { installProfileUseCase(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `installProfile reports staged restore failure`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val profile = DeviceProfile()
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
+        nodeRepository.setNodes(listOf(node))
+        serviceConnectionState.value = ConnectionState.Connected
+        viewModel = createViewModel()
+        runCurrent()
+        everySuspend { installProfileUseCase(123, profile, node.user, true) } throws
+            IllegalStateException("restore interrupted")
+        var result: Result<Unit>? = null
+
+        viewModel.installProfile(profile) { result = it }
+        advanceUntilIdle()
+
+        verifySuspend { installProfileUseCase(123, profile, node.user, true) }
+        assertFalse(assertNotNull(result).isSuccess)
     }
 
     @Test
@@ -1053,14 +1120,22 @@ class RadioConfigViewModelTest {
         assertEquals(5, viewModel.radioConfigState.value.radioConfig.lora?.hop_limit)
 
         // ModuleConfigResponse
-        val moduleResponse =
+        val telemetryResponse =
             org.meshtastic.proto.ModuleConfig(
                 telemetry = org.meshtastic.proto.ModuleConfig.TelemetryConfig(device_update_interval = 300),
             )
         every { processRadioResponseUseCase(any(), 123, any()) } returns
-            RadioResponseResult.ModuleConfigResponse(moduleResponse)
+            RadioResponseResult.ModuleConfigResponse(telemetryResponse)
         packetFlow.emit(MeshPacket())
         assertEquals(300, viewModel.radioConfigState.value.moduleConfig.telemetry?.device_update_interval)
+
+        val meshBeacon = MeshBeaconConfig(broadcast_message = "response beacon")
+        val meshBeaconResponse = org.meshtastic.proto.ModuleConfig(mesh_beacon = meshBeacon)
+        every { processRadioResponseUseCase(any(), 123, any()) } returns
+            RadioResponseResult.ModuleConfigResponse(meshBeaconResponse)
+        packetFlow.emit(MeshPacket())
+        assertEquals(300, viewModel.radioConfigState.value.moduleConfig.telemetry?.device_update_interval)
+        assertEquals(meshBeacon, viewModel.radioConfigState.value.moduleConfig.mesh_beacon)
 
         // Owner
         val user = User(long_name = "New Name")

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialogTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialogTest.kt
@@ -16,6 +16,9 @@
  */
 package org.meshtastic.feature.settings.radio.component
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
@@ -81,6 +84,29 @@ class EditDeviceProfileDialogTest {
 
         // Verify onDismiss is called
         assertTrue(onDismissClicked)
+    }
+
+    @Test
+    fun `selection resets when imported profile replaces initial profile`() = runComposeUiTest {
+        val initial = DeviceProfile(long_name = "Current node")
+        val imported = DeviceProfile(short_name = "IMPT")
+        var displayedProfile by mutableStateOf(initial)
+        var confirmedProfile: DeviceProfile? = null
+
+        setContent {
+            EditDeviceProfileDialog(
+                title = title,
+                deviceProfile = displayedProfile,
+                onConfirm = { confirmedProfile = it },
+                onDismiss = {},
+            )
+        }
+
+        runOnIdle { displayedProfile = imported }
+        waitForIdle()
+        onNodeWithText(getString(Res.string.save)).performClick()
+
+        assertEquals(imported, confirmedProfile)
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes and hardens local device profile import/install. It enforces stricter restart/reconnect-aware sequencing, validates inputs before any radio/admin writes, and makes channel/firmware replacement restoration deterministic—especially around transactional channel writes and failure precedence. It also centralizes REPLACE-channel slot generation/normalization in the model layer, refactors radio/admin “awaited send” plumbing to return richer outcomes, and updates the UI/view-model flow so import/install failures reliably surface to the user (including a Bluetooth-repair hint when applicable).

## Key changes

### Features
- **Restart/reconnect-aware, staged local profile installation**
  - Refactors `InstallProfileUseCase` into a mutex-guarded, restart/reconnect-aware multi-stage installer for locally connected radios.
  - Adds `isLocal` gating and enforces local-only assumptions (radio must be connected; destination must match the local node; validates owner/restore conditions).
  - Prepares an installation plan that separates:
    - ordinary vs transport-sensitive stages,
    - optional MQTT as a dedicated stage,
    - channel/firmware replacement restoration (including optional LoRa override),
    - and defers local channel-cache reconciliation until after authoritative channel writes.
  - Defers/handles channel-cache reconciliation on both normal and exceptional exits, preserving the primary failure when reconciliation also fails.

- **Authoritative channel replacement utilities moved/centralized to the model**
  - Adds `ChannelReplacement.kt` with:
    - bounded REPLACE slot list generation that canonicalizes placeholders to `DISABLED`,
    - replacement normalization/deduplication/compaction,
    - ADD-preview support via `getUniqueChannelAdditions(...)` (semantic dedup using effective name + expanded PSK).
  - Updates UI/PROTO extension logic to reuse these shared utilities.

- **Bluetooth repair troubleshooting hint**
  - Adds `DeviceProfile.shouldSuggestBluetoothRepair()` and surfaces a new localized snackbar hint when Bluetooth restore indicates the device may need repair.

- **Connection lifecycle “epochs”**
  - Introduces `ConnectionEpochs` and a `ConnectionStateHolder` to provide monotonic lifecycle counters (`departures`, `completedHandshakes`) so fast intermediate connection-state updates don’t get conflated.
  - Exposes `connectionEpochs` through repository/controller interfaces and updates fakes/tests.

### Fixes
- **Fail-before-write validation**
  - `InstallProfileUseCase` rejects early (before any device/admin writes) for cases like stale/mismatched local destination, missing required owner/user restoration context, malformed/empty `channel_url`, and remote administration rejection.

- **Transactional channel failure precedence**
  - Ensures reconciliation behavior correctly preserves the primary transactional failure when channel-related transactional writes fail, while still attempting authoritative reconciliation when possible.

- **Awaited send / queue boundary correctness**
  - Strengthens admin/edit-settings transaction handling:
    - `AdminController.editSettings` now explicitly awaits edit “begin” and “commit” acceptance boundaries.
    - Failure handling preserves the block failure and properly suppresses/report commit failure when appropriate.
  - Introduces a richer awaited-send outcome model:
    - Adds `AwaitedSendStatus` / `AwaitedSendResult`.
    - Refactors packet/queue sending so callers can distinguish accepted/rejected/timeouts/transport-stopped/send-failed and whether a packet was actually dispatched.
    - Adds `trySendToRadio(bytes): Boolean` for transport send attempts.

- **UI feedback matches actual outcomes**
  - `SettingsScreen` now:
    - treats only `Activity.RESULT_OK` as success,
    - treats missing `result.data?.data` as an import failure,
    - shows dedicated snackbars for import failure and install failure,
    - shows the Bluetooth-repair hint only after successful install when warranted.
  - View-model import/install APIs updated to propagate `Result` through callbacks rather than dropping failures.

### Refactors
- **Use-case and view-model API shape changes**
  - `InstallProfileUseCase` constructor now injects additional collaborators (radio interface/service, config repository, node repository, restart tracker).
  - `InstallProfileUseCase.invoke` now takes `isLocal: Boolean`.
  - `RadioConfigViewModel.importProfile` now reports `Result<DeviceProfile>`.
  - `RadioConfigViewModel.installProfile` now supports an `onResult: (Result<Unit>) -> Unit` callback.

- **Admin/packet/transport plumbing refactor**
  - Updates interfaces and implementations to support boolean-returning send queuing and awaited results (`PacketHandler`, `CommandSender`, `CommandSenderImpl`, `SharedRadioInterfaceService`, fakes, and No-op stubs).
  - Updates tests accordingly to cover new awaited-send semantics and boundary ordering.

- **Test suite expanded for ordering, restart/reconnect, reconciliation, and validation**
  - `InstallProfileUseCaseTest` is expanded into scenario-based coverage for sequencing, retargeting, channel URL semantics, failure precedence, and pre-write validation.
  - Adds/updates unit tests for channel replacement utilities, connection epoch behavior, awaited-send contracts, and UI hint logic.

## Breaking changes / migration steps
- **`InstallProfileUseCase` constructor signature changed**: requires additional dependencies (`RadioInterfaceService`, `RadioConfigRepository`, `NodeRepository`, `NodeRestartTracker`).
- **`InstallProfileUseCase.invoke` signature changed**: adds `isLocal: Boolean` and enforces local-only installation behavior.
- **Connection state API expanded**: `ConnectionStateProvider` now exposes `connectionEpochs: StateFlow<ConnectionEpochs>`; implementations/fakes/tests updated accordingly.
- **View-model callback contracts changed**:
  - `RadioConfigViewModel.importProfile(...)` callback now receives `Result<DeviceProfile>`.
  - `RadioConfigViewModel.installProfile(...)` now accepts an optional `onResult: (Result<Unit>) -> Unit` and reports installation failures via callbacks.
- **Transport/admin send contracts changed**:
  - Packet sending now returns whether a packet was queued/reserved, and awaited paths return `AwaitedSendResult`; tests and any custom implementations need to align with the updated interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->