### PR TITLE
Suppress region prompt during expected restart and improve status handling

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,149 +1,16 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: en-US
-
+early_access: true
 reviews:
-  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
-  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
-  profile: chill
+  profile: assertive
+  request_changes_workflow: false
   high_level_summary: true
-  poem: false
-  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
-  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
-    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
-    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
-    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
-    auto_incremental_review: false
-    ignore_usernames:
-      - renovate
-      - renovate[bot]
-      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
-      # translation bumps) — machine-generated content, nothing to review.
-      - github-actions
-      - github-actions[bot]
-    ignore_title_keywords:
-      - "chore: Scheduled updates"
-  # Stop reviewing once a PR is closed.
-  abort_on_close: true
-
-  path_filters:
-    # Generated / huge / non-source — don't review, just noise + token burn.
-    - "!**/build/**"
-    - "!**/*.png"
-    - "!**/*.webp"
-    - "!**/firmware_releases.json"
-    - "!**/emoji-data.json"
-    - "!**/flatpak-sources.json"
-    # Crowdin-managed translations — owned upstream, not hand-edited here.
-    - "!**/values-*/strings.xml"
-    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
-    - "!.specify/**"
-
-  path_instructions:
-    - path: "**/commonMain/**"
-      instructions: >
-        KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
-    - path: "**/*.kt"
-      instructions: >
-        Flag leftover // ... existing code ... placeholders, and any logging of PII, location, or cryptographic keys.
-    - path: "**/src/**/strings.xml"
-      instructions: >
-        New string resources must be alphabetically sorted (scripts/sort-strings.py). Flag out-of-order additions.
-    - path: baselineprofile/
-      instructions: Keep baseline profile generation tied to the `google` flavor and connected devices/emulators, and commit the generated profile output to `androidApp/src/google/generated/baselineProfiles/baseline-prof.txt`.
-    - path: docs/
-      instructions: Treat non-English locale folders as Crowdin-managed output; edit the English sources under `docs/en/` and register new pages through `feature/docs/` instead of hand-editing translated locale directories.
-    - path: screenshot-tests/
-      instructions: When updating docs screenshots, keep `docs-screenshots-manifest.txt` and `docs-screenshot-aliases.properties` in sync with the generated files, and rerun `copyDocsScreenshots` after regenerating screenshots.
-    - path: docs-screenshots/
-      instructions: Keep this module generate-only for documentation screenshots; do not add it to the CI validation gate that is reserved for `screenshot-tests`.
-    - path: desktopApp/
-      instructions: Keep desktop release ProGuard rules aligned with `androidApp/proguard-rules.pro`, and preserve the desktop-specific runtime wiring needed for `Dispatchers.Main` on JVM.
-    - path: androidApp/
-      instructions: Keep the Android app’s `MeshService` declaration and manifest wiring in sync with the implementation that lives in `core:service`.
-    - path: core/service/
-      instructions: Keep `RadioControllerImpl` composed from its sub-controllers via interface delegation; admin sends are fire-and-forget, and any config mutation must go through `editSettings { }` transactions.
-    - path: feature/docs/
-      instructions: Treat the Compose resources under `src/commonMain/composeResources/files/` as generated output from `/docs/en/**` and translated docs sync tasks; do not hand-edit those copied files.
-    - path: feature/map/
-      instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
-    - path: feature/car/
-      instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
-
-  # Every CodeRabbit tool is enabled by default, so this block only ever needs to
-  # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
-  # Tolerance gate) and duplicate comments were the noise we removed. The scanners
-  # CI doesn't run — gitleaks, shellcheck, actionlint, zizmor, semgrep, trivy,
-  # presidio (PII), buf (protobuf) — are already on by default; don't re-list them.
-  tools:
-    detekt:
-      enabled: false
-    # Custom AST rules mechanically enforce the recurring defect classes that prose
-    # can't. See .coderabbit/ast-grep-rules/ and .skills/code-review/SKILL.md.
-    # essential_rules stays on (default) — these are additive.
-    ast-grep:
-      rule_dirs:
-        - ".coderabbit/ast-grep-rules"
-
-  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
-  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
-  finishing_touches:
-    docstrings:
-      enabled: false
-    unit_tests:
-      enabled: false
-
-  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR. PR titles are already linted by CI
-  # (.github/workflows/pull-request-target.yml), so no title check here either.
-  pre_merge_checks:
-    docstrings:
-      mode: "off"
-    # The two defect classes that survive review-by-prose because they are about
-    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
-    # would still pass with the fix reverted. Warning, not error: these are
-    # judgment calls and a false positive must not block a merge.
-    custom_checks:
-      - name: "Sibling call sites and presence semantics"
-        mode: "warning"
-        instructions: >-
-          When a diff changes how an absent value is represented — making a field nullable,
-          removing a zero-guard, or adding a presence check — verify EVERY call site of that
-          field was updated, not just the one the bug was reported against. Ambient temperature
-          was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
-          Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
-          a physically reachable value on that scale (RSSI, temperature, current, voltage,
-          particulate concentration). Two exceptions, do NOT flag either: humidity, where 0 %RH
-          is unreachable and the guard is intentional and tested; and the proto `rx_snr`, which
-          has no presence upstream, so its 0f ambiguity cannot be fixed app-side. An app-level
-          SNR field that IS nullable is still in scope.
-      - name: "Tests prove the path, not the end state"
-        mode: "warning"
-        instructions: >-
-          For each added or changed test, decide whether it would still pass if the production
-          code it covers were reverted. Flag tests that seed a fake's backing store and then
-          assert the value comes back, tests that assert only a collection's size rather than
-          which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
-          (not a stable contract). A test must assert the side effect only the intended path
-          produces — a call counter, a request issued, a cache written.
-
-knowledge_base:
-  # Learnings are how a confirmed finding stops recurring on the next PR. Pin the
-  # scope to this repo: the default `auto` already resolves to `local` for public
-  # repos, but being explicit keeps it from shifting if visibility ever changes.
-  learnings:
-    scope: local
-  # Feed CodeRabbit the same guidance human/AI contributors follow, including
-  # the repo-specific .skills/ modules and Copilot path instructions it
-  # wouldn't pick up by default.
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - ".skills/**/SKILL.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/*.instructions.md"
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,7 +18,6 @@ jobs:
   # (folded into this job rather than run standalone: runner-pool slots, not
   # compute, are the scarce resource during queue bursts).
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -73,6 +73,13 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'test.gradle.kts'
+
+  # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
+  verify-check-changes-filter:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
       - name: Verify module roots are represented in check-changes filter
         run: |
           python3 - <<'PY'

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ build-scan-*.scan
 # Python bytecode from scripts/
 __pycache__/
 *.pyc
+.omo/*
+.commandcode

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1086,7 +1086,6 @@ mqtt_status_inactive
 mqtt_status_reconnecting
 mqtt_status_reconnecting_with_attempt
 mqtt_test_connection
-must_set_region
 must_update
 ### MUTE ###
 mute_1_week

--- a/core/resources/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ar/strings.xml
@@ -142,7 +142,6 @@
     <!-- MQTT -->
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_disconnected">انقطع الاتصال</string>
-    <string name="must_set_region">واجب إدخال المنطقة!</string>
     <!-- MUTE -->
     <string name="mute_1_week">أسبوع 1</string>
     <string name="mute_8_hours">8 ساعات</string>

--- a/core/resources/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-be/strings.xml
@@ -161,7 +161,6 @@
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_connected">Злучаны</string>
     <string name="mqtt_status_disconnected">Адлучана</string>
-    <string name="must_set_region">Трэба наладзіць рэгіён!</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 тыдзень</string>
     <string name="mute_8_hours">8 гадзін</string>

--- a/core/resources/src/commonMain/composeResources/values-bg/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-bg/strings.xml
@@ -726,7 +726,6 @@
     <string name="mqtt_status_reconnecting">Повторно свързване…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Повторно свързване (опит %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Тестване на връзката</string>
-    <string name="must_set_region">Трябва да зададете регион!</string>
     <string name="must_update">Трябва да актуализирате това приложение в магазина за приложения (или GitHub). Приложението е твърде старо, за да говори с този фърмуер на радиото. Моля, прочетете нашите <a href="https://meshtastic.org/docs/software/android/installation">документи</a> по тази тема.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 седмица</string>

--- a/core/resources/src/commonMain/composeResources/values-ca/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ca/strings.xml
@@ -134,7 +134,6 @@
     <string name="module_settings">Configuració de mòdul</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Desconnectat</string>
-    <string name="must_set_region">Has de configurar la regió!</string>
     <string name="must_update">Has d'actualitzar aquesta aplicació a la app store (o Github). És massa antiga per comunicar-se amb aquest firmware de la ràdio. Si us plau llegeix el nostre <a href="https://meshtastic.org/docs/software/android/installation">docs</a> sobre aquesta temàtica.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 setmana</string>

--- a/core/resources/src/commonMain/composeResources/values-cs/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-cs/strings.xml
@@ -815,7 +815,6 @@
     <string name="mqtt_status_connected">Připojeno</string>
     <string name="mqtt_status_disconnected">Odpojeno</string>
     <string name="mqtt_test_connection">Test připojení</string>
-    <string name="must_set_region">Musíte nastavit region!</string>
     <string name="must_update">Musíte aktualizovat aplikaci v obchodu Google Play (nebo z Githubu). Je příliš stará pro komunikaci s touto verzí firmware vysílače. Přečtěte si prosím naše <a href="https://meshtastic.org/docs/software/android/installation">dokumenty</a> na toto téma.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 týden</string>

--- a/core/resources/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-de/strings.xml
@@ -860,7 +860,6 @@
     <string name="mqtt_status_reconnecting">Erneut verbinden…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Erneut verbinden (Versuch %1$d) - %2$s</string>
     <string name="mqtt_test_connection">Verbindung testen</string>
-    <string name="must_set_region">Sie müssen eine Region festlegen!</string>
     <string name="must_update">Sie müssen diese App über den App Store (oder Github) aktualisieren. Sie ist zu alt, um mit dieser Funkgeräte Firmware zu kommunizieren. Bitte lesen Sie unsere  <a href="https://meshtastic.org/docs/software/android/installation">Dokumentation</a> zu diesem Thema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">Eine Woche</string>

--- a/core/resources/src/commonMain/composeResources/values-el/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-el/strings.xml
@@ -157,7 +157,6 @@
     <!-- MQTT -->
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_disconnected">Αποσυνδεδεμένο</string>
-    <string name="must_set_region">Πρέπει να ορίσετε μια περιοχή!</string>
     <string name="must_update">Πρέπει να ενημερώσετε την εφαρμογή μέσω Google Play store (ή Github). Είναι πολύ παλαιά ώστε να συνδεθεί με το radio.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 εβδομάδα</string>

--- a/core/resources/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-es/strings.xml
@@ -518,7 +518,6 @@ Estos datos de ubicación pueden ser utilizados para fines como aparecer en un m
     <string name="mqtt_enabled">Activar el MQTT</string>
     <string name="mqtt_status_connected">Conectado</string>
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">¡Debe establecer una región!</string>
     <string name="must_update">Debe actualizar esta aplicación en la tienda de aplicaciones (o en Github). Es demasiado vieja para comunicarse con este firmware de radio. Por favor, lea nuestra <a href="https://meshtastic.org/docs/software/android/installation">documentación</a> sobre este tema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-et/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-et/strings.xml
@@ -1104,7 +1104,6 @@
     <string name="mqtt_status_reconnecting">Taas ühendan…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Ühendan uuesti (katse %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Test ühendus</string>
-    <string name="must_set_region">Pead valima regiooni!</string>
     <string name="must_update">Pead seda rakendust rakenduste poes (või Github) värskendama. See on liiga vana selle raadio püsivara jaoks. Loe selle kohta lisateavet meie <a href="https://meshtastic.org/docs/software/android/installation"> dokumentatsioonist </a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 nädal</string>

--- a/core/resources/src/commonMain/composeResources/values-fi/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-fi/strings.xml
@@ -1108,7 +1108,6 @@
     <string name="mqtt_status_reconnecting">Yhdistetään uudelleen…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Yhdistetään uudelleen (yritys %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Testaa yhteys</string>
-    <string name="must_set_region">Sinun täytyy määrittää alue!</string>
     <string name="must_update">Sinun täytyy päivittää tämä sovellus sovelluskaupassa (tai Githubissa). Sovelluksen versio on liian vanha toimimaan tämän radion ohjelmiston kanssa. Ole hyvä ja lue lisää aiheesta <a href="https://meshtastic.org/docs/software/android/installation">dokumenteistamme</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 viikko</string>

--- a/core/resources/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-fr/strings.xml
@@ -827,7 +827,6 @@
     <string name="mqtt_status_reconnecting">Reconnexion…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Reconnexion (tentative %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Test de la connexion</string>
-    <string name="must_set_region">Vous devez définir une région !</string>
     <string name="must_update">Vous devez mettre à jour cette application sur l'app store (ou Github). Il est trop vieux pour dialoguer avec le micrologiciel de la radio. Veuillez lire nos  <a href="https://meshtastic.org/docs/software/android/installation"> docs</a> sur ce sujet.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semaine</string>

--- a/core/resources/src/commonMain/composeResources/values-ga/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ga/strings.xml
@@ -153,7 +153,6 @@
     <string name="module_settings">Cumraíocht an mhódule</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Na ceangailte</string>
-    <string name="must_set_region">Caithfidh tú réigiún a shocrú!</string>
     <string name="must_update">Caithfidh tú an feidhmchlár seo a nuashonrú ón siopa feidhmchláir (nó Github). Tá sé ró-aois chun cumarsáid a dhéanamh leis an firmware raidió seo. Le do thoil, léigh ár <a href="https://meshtastic.org/docs/software/android/installation">doiciméid</a> ar an ábhar seo.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 seachtain</string>

--- a/core/resources/src/commonMain/composeResources/values-gl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-gl/strings.xml
@@ -133,7 +133,6 @@
     <string name="module_settings">Configuración de módulo</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">Tes que seleccionar rexión!</string>
     <string name="must_update">Debe actualizar esta aplicación na tenda (ou Github).  É moi vella para falar con este firmware de radio. Por favor lea a nosa <a href="https://meshtastic.org/docs/software/android/installation">documentación</a> neste tema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-he/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-he/strings.xml
@@ -133,7 +133,6 @@
     <string name="module_settings">הגדרות מודולות</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">מנותק</string>
-    <string name="must_set_region">חובה לבחור אזור!</string>
     <string name="must_update">נדרש להתקין עדכון לאפליקציה זו דרך חנות האפליקציות (או Github). גרסת האפליקציה ישנה מדי בכדי לתקשר עם מכשיר זה. בבקשה קרא <a href="https://meshtastic.org/docs/software/android/installation">מסמכי עזרה</a> בנושא זה.</string>
     <!-- MUTE -->
     <string name="name">שם</string>

--- a/core/resources/src/commonMain/composeResources/values-hr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-hr/strings.xml
@@ -138,7 +138,6 @@
     <string name="module_settings">Konfiguracija modula</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Odspojeno</string>
-    <string name="must_set_region">Potrebno je postaviti regiju!</string>
     <string name="must_update">Potrebno je ažurirati ovu aplikaciju putem Play Storea (ili Githuba). Aplikacija je prestara za komunikaciju s ovim firmwerom radija. Pročitajte našu <a href="https://meshtastic.org/docs/software/android/installation">dokumentaciju</a> o ovoj temi.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 tjedan</string>

--- a/core/resources/src/commonMain/composeResources/values-ht/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ht/strings.xml
@@ -149,7 +149,6 @@
     <string name="module_settings">Konfigirasyon modil</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Dekonekte</string>
-    <string name="must_set_region">Ou dwe mete yon rejyon!</string>
     <string name="must_update">Ou dwe mete aplikasyon sa ajou nan magazen Google Jwèt. Li twò ansyen pou li kominike ak radyo sa a.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semèn</string>

--- a/core/resources/src/commonMain/composeResources/values-hu/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-hu/strings.xml
@@ -517,7 +517,6 @@
     <string name="mqtt_enabled">MQTT engedélyezve</string>
     <string name="mqtt_status_connected">Csatlakoztatva</string>
     <string name="mqtt_status_disconnected">Szétkapcsolva</string>
-    <string name="must_set_region">Be kell állítania egy régiót</string>
     <string name="must_update">Frissítenie kell ezt az alkalmazást a Google Play áruházban (vagy a GitHub-ról), mert túl régi, hogy kommunikálni tudjob ezzel a rádió firmware-rel. Kérem olvassa el a tudnivalókat ebből a <a href="https://meshtastic.org/docs/software/android/installation">docs</a>-ből.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 hét</string>

--- a/core/resources/src/commonMain/composeResources/values-is/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-is/strings.xml
@@ -121,7 +121,6 @@
     <string name="module_settings">Stillingar aukaeininga</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Aftengd</string>
-    <string name="must_set_region">Þú verður að velja svæði!</string>
     <string name="must_update">Þú verður að uppfæra þetta smáforrit í app store (eða Github). Það er of gamalt til að geta talað við fastbúnað þessa radíó. Vinsamlegast lestu <a href="https://meshtastic.org/docs/software/android/installation">leiðbeiningar </a> okkar um þetta mál.</string>
     <!-- MUTE -->
     <string name="name">Heiti</string>

--- a/core/resources/src/commonMain/composeResources/values-it/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-it/strings.xml
@@ -1102,7 +1102,6 @@
     <string name="mqtt_status_reconnecting">Riconnessione…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Riconnessione (tentativo %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Prova la connessione</string>
-    <string name="must_set_region">Devi impostare una regione!</string>
     <string name="must_update">È necessario aggiornare questa applicazione nell'app store (o Github). È troppo vecchio per parlare con questo firmware radio. Per favore leggi i nostri <a href="https://meshtastic.org/docs/software/android/installation">documenti</a> su questo argomento.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 settimana</string>

--- a/core/resources/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ja/strings.xml
@@ -1100,7 +1100,6 @@
     <string name="mqtt_status_reconnecting">再接続しています…</string>
     <string name="mqtt_status_reconnecting_with_attempt">再接続しています（試行 %1$d）：%2$s</string>
     <string name="mqtt_test_connection">接続をテスト</string>
-    <string name="must_set_region">リージョンを指定する必要があります。</string>
     <string name="must_update">アプリが古く、デバイスと通信ができません。アプリストアまたはGithubでアプリを更新してください。詳細は<a href="https://meshtastic.org/docs/software/android/installation">こちら</a> に記載されています。</string>
     <!-- MUTE -->
     <string name="mute_1_week">1週間</string>

--- a/core/resources/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ko/strings.xml
@@ -333,7 +333,6 @@
     <string name="mqtt_enabled">MQTT 활성화</string>
     <string name="mqtt_status_connected">연결됨</string>
     <string name="mqtt_status_disconnected">연결 끊김</string>
-    <string name="must_set_region">지역을 설정해 주세요!</string>
     <string name="must_update">구글 플레이 스토어 또는 깃허브를 통해서 앱을 업데이트 해야합니다. 앱이 너무 구버전입니다. 이 주제의  <a href="https://meshtastic.org/docs/software/android/installation">docs</a> 를 읽어주세요</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 주</string>

--- a/core/resources/src/commonMain/composeResources/values-lt/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-lt/strings.xml
@@ -153,7 +153,6 @@
     <string name="module_settings">Modulio konfigūracija</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Atsijungta</string>
-    <string name="must_set_region">Turite nustatyti regioną!</string>
     <string name="must_update">Urite atnaujinti šią programą programėlių parduotuvėje (arba Github). Ji per sena, kad galėtų bendrauti su šiuo radijo įrangos programinės įrangos versija. Prašome perskaityti mūsų <a href="https://meshtastic.org/docs/software/android/installation">dokumentaciją</a> šia tema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 savaitė</string>

--- a/core/resources/src/commonMain/composeResources/values-nl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-nl/strings.xml
@@ -263,7 +263,6 @@
     <string name="mqtt_enabled">MQTT ingeschakeld</string>
     <string name="mqtt_status_connected">Verbonden</string>
     <string name="mqtt_status_disconnected">Niet verbonden</string>
-    <string name="must_set_region">Je moet een regio instellen!</string>
     <string name="must_update">Applicatie update noodzakelijk in Google Play store (of Github). Deze versie is te oud om te praten met deze radio.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 week</string>

--- a/core/resources/src/commonMain/composeResources/values-no/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-no/strings.xml
@@ -156,7 +156,6 @@
     <string name="module_settings">Modul konfigurasjon</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Frakoblet</string>
-    <string name="must_set_region">Du må angi en region!</string>
     <string name="must_update">Du må oppdatere denne applikasjonen på Google Play store (eller Github). Den er for gammel til å snakke med denne radioen.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 uke</string>

--- a/core/resources/src/commonMain/composeResources/values-pl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-pl/strings.xml
@@ -492,7 +492,6 @@
     <string name="mqtt_enabled">Włącz MQTT</string>
     <string name="mqtt_status_connected">Połączony</string>
     <string name="mqtt_status_disconnected">Rozłączono</string>
-    <string name="must_set_region">Musisz ustawić region!</string>
     <string name="must_update">Należy zaktualizować aplikację za pomocą Sklepu Play lub z GitHub, ponieważ aplikacja jest zbyt stara, by skomunikować się z oprogramowaniem zainstalowanym na tym urządzeniu. <a href="https://meshtastic.org/docs/software/android/installation">Więcej informacji (ang.)</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 tydzień</string>

--- a/core/resources/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -402,7 +402,6 @@
     <string name="mqtt_enabled">MQTT habilitado</string>
     <string name="mqtt_status_connected">Conectado</string>
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">Você deve informar uma região!</string>
     <string name="must_update">Será necessário atualizar este aplicativo no Google Play (ou Github). Versão muito antiga para comunicar com o firmware do rádio.  Favor consultar <a href="https://meshtastic.org/docs/software/android/installation">docs</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-pt/strings.xml
@@ -323,7 +323,6 @@
     <string name="mqtt_enabled">MQTT ativo</string>
     <string name="mqtt_status_connected">Ligado</string>
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">Você deve informar uma região!</string>
     <string name="must_update">Tem de atualizar esta aplicação no Google Play (ou Github). A versão é muito antiga para ser possível falar com este rádio.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ro/strings.xml
@@ -682,7 +682,6 @@
     <string name="mqtt_enabled">MQTT activat</string>
     <string name="mqtt_status_connected">Conectat</string>
     <string name="mqtt_status_disconnected">Deconectat</string>
-    <string name="must_set_region">Trebuie să alegeți o regiune!</string>
     <string name="must_update">Trebuie să updatezi această aplicație de pe Google Play  (sau Github). Aplicația este prea veche pentru a comunica cu dispozitivul.</string>
     <!-- MUTE -->
     <string name="mute_1_week">O săptămână</string>

--- a/core/resources/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ru/strings.xml
@@ -1115,7 +1115,6 @@
     <string name="mqtt_status_reconnecting">Восстановление связи…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Восстановление (попытка %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Проверить соединение</string>
-    <string name="must_set_region">Вы должны задать регион!</string>
     <string name="must_update">Вам необходимо обновить данное приложение в магазине приложений (или с Github). Оно слишком старо для взаимодействия с прошивкой радиостанции. Пожалуйста, прочитайте нашу <a href="https://meshtastic.org/docs/software/android/installation">документацию</a> по этой теме.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 неделя</string>

--- a/core/resources/src/commonMain/composeResources/values-sk/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sk/strings.xml
@@ -282,7 +282,6 @@
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_connected">Pripojený</string>
     <string name="mqtt_status_disconnected">Odpojené</string>
-    <string name="must_set_region">Musíte nastaviť región!</string>
     <string name="must_update">Musíte aktualizovať aplikáciu na Google Play store (alebo z Github). Je príliš stará pre komunikáciu s touto verziou firmvéru vysielača. Viac informácií k tejto téme nájdete na <a href="https://meshtastic.org/docs/software/android/installation">Meshtastic docs</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 týždeň</string>

--- a/core/resources/src/commonMain/composeResources/values-sl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sl/strings.xml
@@ -158,7 +158,6 @@
     <string name="module_settings">Nastavitev modula</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Prekinjeno</string>
-    <string name="must_set_region">Nastavitev regije!</string>
     <string name="must_update">To aplikacijo morate posodobiti v trgovini Google Play (ali Github). Žal se ne more povezati s tem radiem.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 teden</string>

--- a/core/resources/src/commonMain/composeResources/values-sq/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sq/strings.xml
@@ -155,7 +155,6 @@
     <string name="module_settings">Konfigurimi i modulit</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">I shkëputur</string>
-    <string name="must_set_region">Duhet të vendosni një rajon!</string>
     <string name="must_update">Duhet të përditësoni këtë aplikacion në dyqanin e aplikacioneve (ose Github). Është shumë i vjetër për të komunikuar me këtë firmware radioje. Ju lutemi lexoni dokumentet tona <a href="https://meshtastic.org/docs/software/android/installation">këtu</a> për këtë temë.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 javë</string>

--- a/core/resources/src/commonMain/composeResources/values-sr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sr/strings.xml
@@ -296,7 +296,6 @@
     <string name="mqtt_config">MQTT подешавања</string>
     <string name="mqtt_status_connected">Блутут повезан</string>
     <string name="mqtt_status_disconnected">Raskačeno</string>
-    <string name="must_set_region">Мораш одабрати регион!</string>
     <string name="must_update">Morate da ažurirate ovu aplikaciju na prodavnici aplikacija (ili Github-u). Previše je stara da bi razgovarala sa ovim radio firmverom. Molimo vas da pročitate naše <a href="https://meshtastic.org/docs/software/android/installation">dokumente</a> o ovoj temi.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 седмица</string>

--- a/core/resources/src/commonMain/composeResources/values-srp/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-srp/strings.xml
@@ -296,7 +296,6 @@
     <string name="mqtt_config">MQTT подешавања</string>
     <string name="mqtt_status_connected">Блутут повезан</string>
     <string name="mqtt_status_disconnected">Раскачено</string>
-    <string name="must_set_region">Мораш одабрати регион!</string>
     <string name="must_update">Морате ажурирати ову апликацију у продавници апликација (или на Гитхабу). Превише је стара да би могла комуницирати са овим радио фирмвером. Молимо вас да прочитате наша &lt;a href='https://meshtastic.org/docs/software/android/installation'&gt;документа&lt;/a&gt; на ову тему.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 седмица</string>

--- a/core/resources/src/commonMain/composeResources/values-sv/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sv/strings.xml
@@ -780,7 +780,6 @@
     <string name="mqtt_status_reconnecting">Återansluter…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Återansluter (försök %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Testa anslutningen</string>
-    <string name="must_set_region">Du måste ställa in en region!</string>
     <string name="must_update">Du måste uppdatera detta program i app-butiken (eller Github). Det är för gammalt för att prata med denna radioenhet. Läs vår <a href="https://meshtastic.org/docs/software/android/installation">dokumentation</a> i detta ämne.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 vecka</string>

--- a/core/resources/src/commonMain/composeResources/values-tr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-tr/strings.xml
@@ -348,7 +348,6 @@
     <string name="mqtt_enabled">MQTT etkin</string>
     <string name="mqtt_status_connected">Bağlandı</string>
     <string name="mqtt_status_disconnected">Bağlantı kesildi</string>
-    <string name="must_set_region">Bölge seçmelisin!</string>
     <string name="must_update">Uygulamayı Google Play store (ya da GitHub)'dan güncelleyin. Bu cihaz ile haberleşmek için uygulama çok eski. İlgili <a href="https://meshtastic.org/docs/software/android/installation"> Dokümantasyon</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 hafta</string>

--- a/core/resources/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-uk/strings.xml
@@ -767,7 +767,6 @@
     <string name="mqtt_status_reconnecting">Роз'єднання…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Роз'єднання (спроба %1$d) - %2$s</string>
     <string name="mqtt_test_connection">Перевірка зʼєднання</string>
-    <string name="must_set_region">Ви повинні встановити регіон!</string>
     <string name="must_update">Ви повинні оновити цю програму в App Store (або Github). Він занадто старий, щоб спілкуватися з цією прошивкою радіо. Будь ласка, прочитайте нашу <a href="https://meshtastic.org/docs/software/android/installation">документацію</a> у вказаній темі.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 тиждень</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -1110,7 +1110,6 @@
     <string name="mqtt_status_reconnecting">正在重新连接…</string>
     <string name="mqtt_status_reconnecting_with_attempt">正在重新连接 (尝试 %1$d) — %2$s</string>
     <string name="mqtt_test_connection">连接测试</string>
-    <string name="must_set_region">您必须先选择一个地区</string>
     <string name="must_update">您必须在应用商店或 Github上更新此应用程序。程序太旧了以至于无法与此装置进行通讯。 请阅读有关此主题的 <a href="https://meshtastic.org/docs/software/android/installation">文档</a>。</string>
     <!-- MUTE -->
     <string name="mute_1_week">1周</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -805,7 +805,6 @@
     <string name="mqtt_status_reconnecting">重新連接中…</string>
     <string name="mqtt_status_reconnecting_with_attempt">重新連接中（第 %1$d 次嘗試） — %2$s</string>
     <string name="mqtt_test_connection">測試連線</string>
-    <string name="must_set_region">您必須設定一個區域！</string>
     <string name="must_update">您必須在應用商店(或 Github)更新此應用程式。它太舊無法與此無線電韌體通訊。請閱讀我們關於此主題的<a href="https://meshtastic.org/docs/software/android/installation">文件</a>。</string>
     <!-- MUTE -->
     <string name="mute_1_week">1週</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1119,7 +1119,6 @@
     <string name="mqtt_status_reconnecting">Reconnecting…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Reconnecting (attempt %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Test connection</string>
-    <string name="must_set_region">You must set a region!</string>
     <string name="must_update">You must update this application on the app store (or Github). It is too old to talk to this radio firmware.  Please read our <a href="https://meshtastic.org/docs/software/android/installation">docs</a> on this topic.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 week</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
@@ -41,6 +41,7 @@ import org.meshtastic.core.model.FirmwareUpdateNoticePolicy
 import org.meshtastic.core.model.FirmwareUpdateTransport
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.util.TimeConstants
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
@@ -61,9 +62,8 @@ import org.meshtastic.proto.Config
 import org.meshtastic.proto.LocalConfig
 
 /**
- * Derived, UI-friendly summary of the device connection state. Combines [ServiceRepository.connectionState] with
- * "region unset" and the [ServiceRepository.RECONNECTING_PROGRESS_TEXT] handshake-recovery signal to surface cases
- * (MUST_SET_REGION, RECONNECTING) that otherwise need separate boolean flags in the UI layer.
+ * Derived, UI-friendly summary of the device connection lifecycle. Region configuration is exposed separately through
+ * [ConnectionsViewModel.regionRequired] so the connected card and required-action warning can remain visible together.
  */
 enum class ConnectionStatus {
     /** No device has been selected or we are otherwise disconnected. */
@@ -90,9 +90,6 @@ enum class ConnectionStatus {
 
     /** Connected but the device is in deep sleep. */
     CONNECTED_SLEEPING,
-
-    /** Connected and active, but LoRa region is UNSET — user action required. */
-    MUST_SET_REGION,
 }
 
 @KoinViewModel
@@ -117,6 +114,14 @@ class ConnectionsViewModel(
     val lockdownState = serviceRepository.lockdownState
     val sessionAuthorized = serviceRepository.sessionAuthorized
 
+    /** True when this session may change radio configuration. Legacy/non-lockdown radios report no lockdown state. */
+    val regionConfigurationAllowed: StateFlow<Boolean> =
+        combine(lockdownState, sessionAuthorized) { state, authorized ->
+            authorized || state is LockdownState.None || state is LockdownState.Disabled
+        }
+            .distinctUntilChanged()
+            .stateInWhileSubscribed(initialValue = false)
+
     val myNodeInfo: StateFlow<MyNodeInfo?> = nodeRepository.myNodeInfo
 
     val ourNodeInfo: StateFlow<Node?> = nodeRepository.ourNodeInfo
@@ -136,17 +141,24 @@ class ConnectionsViewModel(
             }
             .stateInWhileSubscribed(initialValue = nodeRepository.ourNodeInfo.value)
 
-    /** Whether the LoRa region is UNSET and needs to be configured. */
-    val regionUnset: StateFlow<Boolean> =
-        radioConfigRepository.localConfigFlow
-            .map { it.lora?.region == Config.LoRaConfig.RegionCode.UNSET }
+    /** True while a connected node still requires a LoRa region after any expected restart completes. */
+    val regionRequired: StateFlow<Boolean> =
+        combine(connectionState, radioConfigRepository.localConfigFlow, nodeRestartTracker.restartExpected) {
+                state,
+                localConfig,
+                restartExpected,
+            ->
+            state is ConnectionState.Connected &&
+                !restartExpected &&
+                localConfig.lora?.region == Config.LoRaConfig.RegionCode.UNSET
+        }
             .distinctUntilChanged()
             .stateInWhileSubscribed(initialValue = false)
 
     /**
-     * Single source of truth for the UI's "connection status" pill/banner. Derived from [connectionState],
-     * [ServiceRepository.connectionProgress], and [regionUnset]; kept here rather than in the composable so the mapping
-     * is observable and testable.
+     * Single source of truth for the UI's connection status. Derived from [connectionState],
+     * [ServiceRepository.connectionProgress], and expected-restart state. The mapping remains here so it is observable
+     * and testable.
      *
      * The [ConnectionStatus.RECONNECTING] case is signalled by the WiFi/TCP handshake watchdog writing
      * [ServiceRepository.RECONNECTING_PROGRESS_TEXT] to [ServiceRepository.connectionProgress] immediately before its
@@ -154,15 +166,14 @@ class ConnectionsViewModel(
      * [ServiceRepository.RECONNECTING_PROGRESS_TEXT] for the cross-track contract.
      */
     val connectionStatus: StateFlow<ConnectionStatus> =
-        combine(
-            connectionState,
-            regionUnset,
-            serviceRepository.connectionProgress,
-            nodeRestartTracker.restartExpected,
-        ) { state, unset, progress, restartExpected ->
+        combine(connectionState, serviceRepository.connectionProgress, nodeRestartTracker.restartExpected) {
+                state,
+                progress,
+                restartExpected,
+            ->
             when (state) {
                 is ConnectionState.Connected ->
-                    if (unset) ConnectionStatus.MUST_SET_REGION else ConnectionStatus.CONNECTED
+                    if (restartExpected) ConnectionStatus.RESTARTING else ConnectionStatus.CONNECTED
 
                 // While an expected node restart is in flight, the drop and the reconnect attempts are the restart
                 // —

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.FirmwareUpdateDestination
+import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
@@ -47,6 +48,7 @@ import org.meshtastic.core.testing.FakeRadioPrefs
 import org.meshtastic.core.testing.FakeServiceRepository
 import org.meshtastic.core.testing.FakeUiPrefs
 import org.meshtastic.core.testing.TestDataFactory
+import org.meshtastic.proto.Config
 import org.meshtastic.proto.HardwareModel
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.User
@@ -62,6 +64,7 @@ class ConnectionsViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var viewModel: ConnectionsViewModel
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
+    private val localConfigFlow = MutableStateFlow(LocalConfig())
     private val serviceRepository = FakeServiceRepository()
     private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
     private val nodeRepository = FakeNodeRepository()
@@ -89,7 +92,9 @@ class ConnectionsViewModelTest {
         dispatchedNotifications.clear()
         notificationsCanBeScheduled = true
 
-        every { radioConfigRepository.localConfigFlow } returns MutableStateFlow(LocalConfig())
+        localConfigFlow.value = LocalConfig()
+        nodeRestartTracker.onConnected()
+        every { radioConfigRepository.localConfigFlow } returns localConfigFlow
         uiPrefs.hasShownNotPairedWarning.value = false
         uiPrefs.firmwareUpdateNotificationKeys.value = emptySet()
 
@@ -123,6 +128,71 @@ class ConnectionsViewModelTest {
 
         assertEquals(true, viewModel.hasShownNotPairedWarning.value)
         assertEquals(true, uiPrefs.hasShownNotPairedWarning.value)
+    }
+
+    @Test
+    fun `region configuration is available when firmware reports no lockdown state`() = runTest {
+        viewModel.regionConfigurationAllowed.test {
+            assertEquals(false, awaitItem())
+            assertEquals(true, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `locked session keeps region configuration disabled until authorized`() = runTest {
+        serviceRepository.setLockdownState(LockdownState.Locked())
+
+        viewModel.regionConfigurationAllowed.test {
+            assertEquals(false, awaitItem())
+
+            serviceRepository.setSessionAuthorized(true)
+            assertEquals(true, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `region configuration becomes available when lockdown is disabled`() = runTest {
+        viewModel.regionConfigurationAllowed.test {
+            assertEquals(false, awaitItem())
+
+            serviceRepository.setLockdownState(LockdownState.Disabled)
+            assertEquals(true, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `expected restart suppresses region warning without replacing connected status`() = runTest {
+        localConfigFlow.value = LocalConfig(lora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.UNSET))
+        nodeRestartTracker.expectRestart()
+
+        viewModel.connectionStatus.test {
+            val connectionStatusItems = this
+            viewModel.regionRequired.test {
+                assertEquals(ConnectionStatus.NOT_CONNECTED, connectionStatusItems.awaitItem())
+                assertEquals(false, awaitItem())
+
+                serviceRepository.setConnectionState(ConnectionState.Connected)
+                assertEquals(ConnectionStatus.RESTARTING, connectionStatusItems.awaitItem())
+                expectNoEvents()
+
+                nodeRestartTracker.onConnected()
+                assertEquals(ConnectionStatus.CONNECTED, connectionStatusItems.awaitItem())
+                assertEquals(true, awaitItem())
+
+                localConfigFlow.value = LocalConfig(lora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.US))
+                assertEquals(false, awaitItem())
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -146,8 +146,8 @@ fun ConnectionsScreen(
     val connectionState by connectionsViewModel.connectionState.collectAsStateWithLifecycle()
     val ourNode by connectionsViewModel.ourNodeForDisplay.collectAsStateWithLifecycle()
     val firmwareUpdateNotice by connectionsViewModel.firmwareUpdateNotice.collectAsStateWithLifecycle()
-    val regionUnset by connectionsViewModel.regionUnset.collectAsStateWithLifecycle()
-    val sessionAuthorized by connectionsViewModel.sessionAuthorized.collectAsStateWithLifecycle()
+    val regionRequired by connectionsViewModel.regionRequired.collectAsStateWithLifecycle()
+    val regionConfigurationAllowed by connectionsViewModel.regionConfigurationAllowed.collectAsStateWithLifecycle()
 
     val selectedDevice by scanModel.selectedNotNullFlow.collectAsStateWithLifecycle()
     val persistedDeviceName by scanModel.persistedDeviceName.collectAsStateWithLifecycle()
@@ -398,17 +398,15 @@ fun ConnectionsScreen(
                         val isPhysicalDevice =
                             selectedDevice != InterfaceId.MOCK.id.toString() &&
                                 selectedDevice != InterfaceId.REPLAY.id.toString()
-                        if (
-                            uiState == ConnectionUiState.CONNECTED_WITH_NODE &&
-                            regionUnset &&
-                            sessionAuthorized &&
-                            isPhysicalDevice
-                        ) {
+                        val showRegionWarning =
+                            connectionState is ConnectionState.Connected && regionRequired && isPhysicalDevice
+                        if (showRegionWarning) {
                             Spacer(modifier = Modifier.height(8.dp))
                             Card(modifier = Modifier.fillMaxWidth()) {
                                 ListItem(
                                     leadingIcon = MeshtasticIcons.Language,
                                     text = stringResource(Res.string.set_your_region),
+                                    enabled = regionConfigurationAllowed,
                                     onClick = {
                                         isWaiting = true
                                         radioConfigViewModel.setResponseStateLoading(ConfigRoute.LORA)

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
@@ -38,7 +38,6 @@ import org.meshtastic.core.resources.connected
 import org.meshtastic.core.resources.connected_sleeping
 import org.meshtastic.core.resources.connecting
 import org.meshtastic.core.resources.disconnect
-import org.meshtastic.core.resources.must_set_region
 import org.meshtastic.core.resources.node_restarting
 import org.meshtastic.core.resources.not_connected
 import org.meshtastic.core.resources.reconnecting
@@ -61,7 +60,6 @@ fun ConnectingDeviceInfo(
     val statusLabel =
         when (connectionStatus) {
             ConnectionStatus.CONNECTED -> stringResource(Res.string.connected)
-            ConnectionStatus.MUST_SET_REGION -> stringResource(Res.string.must_set_region)
             ConnectionStatus.CONNECTING -> connectionProgress ?: stringResource(Res.string.connecting)
             ConnectionStatus.RECONNECTING -> stringResource(Res.string.reconnecting)
             ConnectionStatus.RESTARTING -> stringResource(Res.string.node_restarting)
@@ -75,7 +73,6 @@ fun ConnectingDeviceInfo(
         when (connectionStatus) {
             ConnectionStatus.CONNECTED,
             ConnectionStatus.CONNECTED_SLEEPING,
-            ConnectionStatus.MUST_SET_REGION,
             -> stringResource(Res.string.disconnect)
 
             ConnectionStatus.CONNECTING,


### PR DESCRIPTION
## Summary by Sourcery

Improve connection status handling around expected restarts and region configuration prompts, and gate region configuration on firmware lockdown state or session authorization.

New Features:
- Expose a regionConfigurationAllowed state derived from lockdown state and session authorization to control when radio region configuration is permitted.

Bug Fixes:
- Ensure the connection status prioritizes an expected restart over an unset region while the device is still in the restart window, and only shows the unset-region status after the restart window closes.

Enhancements:
- Derive connectionStatus from the current local radio configuration instead of a separate regionUnset flag to better reflect the firmware state.
- Update the connections screen to use connectionStatus and regionConfigurationAllowed to decide when to show the region configuration prompt.

Tests:
- Add tests covering region configuration availability when lockdown is disabled and the interaction between expected restarts and unset region configuration.