### PR TITLE
fix(ble): bound MTU negotiation and clean failed sessions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,149 +1,16 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: en-US
-
+early_access: true
 reviews:
-  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
-  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
-  profile: chill
+  profile: assertive
+  request_changes_workflow: false
   high_level_summary: true
-  poem: false
-  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
-  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
-    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
-    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
-    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
-    auto_incremental_review: false
-    ignore_usernames:
-      - renovate
-      - renovate[bot]
-      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
-      # translation bumps) — machine-generated content, nothing to review.
-      - github-actions
-      - github-actions[bot]
-    ignore_title_keywords:
-      - "chore: Scheduled updates"
-  # Stop reviewing once a PR is closed.
-  abort_on_close: true
-
-  path_filters:
-    # Generated / huge / non-source — don't review, just noise + token burn.
-    - "!**/build/**"
-    - "!**/*.png"
-    - "!**/*.webp"
-    - "!**/firmware_releases.json"
-    - "!**/emoji-data.json"
-    - "!**/flatpak-sources.json"
-    # Crowdin-managed translations — owned upstream, not hand-edited here.
-    - "!**/values-*/strings.xml"
-    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
-    - "!.specify/**"
-
-  path_instructions:
-    - path: "**/commonMain/**"
-      instructions: >
-        KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
-    - path: "**/*.kt"
-      instructions: >
-        Flag leftover // ... existing code ... placeholders, and any logging of PII, location, or cryptographic keys.
-    - path: "**/src/**/strings.xml"
-      instructions: >
-        New string resources must be alphabetically sorted (scripts/sort-strings.py). Flag out-of-order additions.
-    - path: baselineprofile/
-      instructions: Keep baseline profile generation tied to the `google` flavor and connected devices/emulators, and commit the generated profile output to `androidApp/src/google/generated/baselineProfiles/baseline-prof.txt`.
-    - path: docs/
-      instructions: Treat non-English locale folders as Crowdin-managed output; edit the English sources under `docs/en/` and register new pages through `feature/docs/` instead of hand-editing translated locale directories.
-    - path: screenshot-tests/
-      instructions: When updating docs screenshots, keep `docs-screenshots-manifest.txt` and `docs-screenshot-aliases.properties` in sync with the generated files, and rerun `copyDocsScreenshots` after regenerating screenshots.
-    - path: docs-screenshots/
-      instructions: Keep this module generate-only for documentation screenshots; do not add it to the CI validation gate that is reserved for `screenshot-tests`.
-    - path: desktopApp/
-      instructions: Keep desktop release ProGuard rules aligned with `androidApp/proguard-rules.pro`, and preserve the desktop-specific runtime wiring needed for `Dispatchers.Main` on JVM.
-    - path: androidApp/
-      instructions: Keep the Android app’s `MeshService` declaration and manifest wiring in sync with the implementation that lives in `core:service`.
-    - path: core/service/
-      instructions: Keep `RadioControllerImpl` composed from its sub-controllers via interface delegation; admin sends are fire-and-forget, and any config mutation must go through `editSettings { }` transactions.
-    - path: feature/docs/
-      instructions: Treat the Compose resources under `src/commonMain/composeResources/files/` as generated output from `/docs/en/**` and translated docs sync tasks; do not hand-edit those copied files.
-    - path: feature/map/
-      instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
-    - path: feature/car/
-      instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
-
-  # Every CodeRabbit tool is enabled by default, so this block only ever needs to
-  # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
-  # Tolerance gate) and duplicate comments were the noise we removed. The scanners
-  # CI doesn't run — gitleaks, shellcheck, actionlint, zizmor, semgrep, trivy,
-  # presidio (PII), buf (protobuf) — are already on by default; don't re-list them.
-  tools:
-    detekt:
-      enabled: false
-    # Custom AST rules mechanically enforce the recurring defect classes that prose
-    # can't. See .coderabbit/ast-grep-rules/ and .skills/code-review/SKILL.md.
-    # essential_rules stays on (default) — these are additive.
-    ast-grep:
-      rule_dirs:
-        - ".coderabbit/ast-grep-rules"
-
-  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
-  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
-  finishing_touches:
-    docstrings:
-      enabled: false
-    unit_tests:
-      enabled: false
-
-  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR. PR titles are already linted by CI
-  # (.github/workflows/pull-request-target.yml), so no title check here either.
-  pre_merge_checks:
-    docstrings:
-      mode: "off"
-    # The two defect classes that survive review-by-prose because they are about
-    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
-    # would still pass with the fix reverted. Warning, not error: these are
-    # judgment calls and a false positive must not block a merge.
-    custom_checks:
-      - name: "Sibling call sites and presence semantics"
-        mode: "warning"
-        instructions: >-
-          When a diff changes how an absent value is represented — making a field nullable,
-          removing a zero-guard, or adding a presence check — verify EVERY call site of that
-          field was updated, not just the one the bug was reported against. Ambient temperature
-          was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
-          Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
-          a physically reachable value on that scale (RSSI, temperature, current, voltage,
-          particulate concentration). Two exceptions, do NOT flag either: humidity, where 0 %RH
-          is unreachable and the guard is intentional and tested; and the proto `rx_snr`, which
-          has no presence upstream, so its 0f ambiguity cannot be fixed app-side. An app-level
-          SNR field that IS nullable is still in scope.
-      - name: "Tests prove the path, not the end state"
-        mode: "warning"
-        instructions: >-
-          For each added or changed test, decide whether it would still pass if the production
-          code it covers were reverted. Flag tests that seed a fake's backing store and then
-          assert the value comes back, tests that assert only a collection's size rather than
-          which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
-          (not a stable contract). A test must assert the side effect only the intended path
-          produces — a call counter, a request issued, a cache written.
-
-knowledge_base:
-  # Learnings are how a confirmed finding stops recurring on the next PR. Pin the
-  # scope to this repo: the default `auto` already resolves to `local` for public
-  # repos, but being explicit keeps it from shifting if visibility ever changes.
-  learnings:
-    scope: local
-  # Feed CodeRabbit the same guidance human/AI contributors follow, including
-  # the repo-specific .skills/ modules and Copilot path instructions it
-  # wouldn't pick up by default.
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - ".skills/**/SKILL.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/*.instructions.md"
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,7 +18,6 @@ jobs:
   # (folded into this job rather than run standalone: runner-pool slots, not
   # compute, are the scarce resource during queue bursts).
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -73,6 +73,13 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'test.gradle.kts'
+
+  # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
+  verify-check-changes-filter:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
       - name: Verify module roots are represented in check-changes filter
         run: |
           python3 - <<'PY'

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ build-scan-*.scan
 # Python bytecode from scripts/
 __pycache__/
 *.pyc
+.omo/*
+.commandcode

--- a/core/ble/build.gradle.kts
+++ b/core/ble/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             implementation(projects.core.model)
 
             implementation(libs.kermit)
+            implementation(libs.kotlinx.atomicfu)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kable.core)
         }

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -76,7 +76,7 @@ internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConn
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.w(e) { "[${device.address.anonymize()}] Failed to request MTU" }
+            Logger.w { "[${device.address.anonymize()}] Failed to request MTU (${e::class.simpleName ?: "Exception"})" }
         }
     }
 }
@@ -95,13 +95,17 @@ internal actual fun Peripheral.negotiatedMaxWriteLength(): Int? {
 internal actual fun Peripheral.requestHighConnectionPriority(): Boolean {
     val androidPeripheral = this as? AndroidPeripheral ?: return false
     return runCatching { androidPeripheral.requestConnectionPriority(AndroidPeripheral.Priority.High) }
-        .onFailure { Logger.w(it) { "requestConnectionPriority(High) threw" } }
+        .onFailure { failure ->
+            Logger.w { "requestConnectionPriority(High) threw (${failure::class.simpleName ?: "Exception"})" }
+        }
         .getOrDefault(false)
 }
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean {
     val androidPeripheral = this as? AndroidPeripheral ?: return false
     return runCatching { androidPeripheral.requestConnectionPriority(AndroidPeripheral.Priority.Balanced) }
-        .onFailure { Logger.w(it) { "requestConnectionPriority(Balanced) threw" } }
+        .onFailure { failure ->
+            Logger.w { "requestConnectionPriority(Balanced) threw (${failure::class.simpleName ?: "Exception"})" }
+        }
         .getOrDefault(false)
 }

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -22,7 +22,10 @@ import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
 import com.juul.kable.PooledThreadingStrategy
 import com.juul.kable.toIdentifier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.core.model.util.anonymize
+import kotlin.time.Duration.Companion.seconds
 
 /** Android's scanner filters on address in hardware, so Kable's `Filter.Address` works natively here. */
 internal actual val supportsNativeAddressScanFilter: Boolean = true
@@ -37,6 +40,9 @@ internal actual val supportsNativeAddressScanFilter: Boolean = true
  * A single app-wide instance is used because Kable recommends exactly one pool per application.
  */
 private val sharedThreadingStrategy = PooledThreadingStrategy()
+
+/** Keeps a lost Android MTU callback from blocking the complete GATT connection lifecycle. */
+private val MTU_NEGOTIATION_TIMEOUT = 5.seconds
 
 internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConnect: () -> Boolean) {
     // Bonded devices without a fresh advertisement must use autoConnect = true. Otherwise,
@@ -58,8 +64,17 @@ internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConn
             // Android defaults to 23 bytes MTU. Meshtastic packets can be 512 bytes.
             // Requesting the max MTU is critical for preventing dropped packets and stalls.
             @Suppress("MagicNumber")
-            val negotiatedMtu = requestMtu(512)
-            Logger.i { "[${device.address.anonymize()}] Negotiated MTU: $negotiatedMtu" }
+            val negotiatedMtu = withTimeoutOrNull(MTU_NEGOTIATION_TIMEOUT) { requestMtu(512) }
+            if (negotiatedMtu == null) {
+                Logger.w {
+                    "[${device.address.anonymize()}] MTU callback timed out after $MTU_NEGOTIATION_TIMEOUT; " +
+                        "continuing with the current ATT MTU"
+                }
+            } else {
+                Logger.i { "[${device.address.anonymize()}] Negotiated MTU: $negotiatedMtu" }
+            }
+        } catch (e: CancellationException) {
+            throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             Logger.w(e) { "[${device.address.anonymize()}] Failed to request MTU" }
         }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -40,14 +40,27 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.job
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.model.util.anonymize
 import kotlin.concurrent.Volatile
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
+
+internal fun interface KablePeripheralFactory {
+    suspend fun create(device: MeshtasticBleDevice, builderAction: PeripheralBuilder.() -> Unit): Peripheral
+}
+
+private object DefaultKablePeripheralFactory : KablePeripheralFactory {
+    override suspend fun create(device: MeshtasticBleDevice, builderAction: PeripheralBuilder.() -> Unit): Peripheral =
+        device.advertisement?.let { advertisement -> Peripheral(advertisement, builderAction) }
+            ?: createPeripheral(device.address, builderAction)
+}
 
 /** [BleService] implementation backed by a Kable [Peripheral] for a specific GATT service. */
 class KableBleService(private val peripheral: Peripheral, private val serviceUuid: Uuid) : BleService {
@@ -101,8 +114,18 @@ class KableBleService(private val peripheral: Peripheral, private val serviceUui
  * the `autoConnect` path. At most two attempts are made per [connect] call — the caller ([BleRadioTransport]) owns the
  * macro-level retry/backoff loop.
  */
-class KableBleConnection(private val scope: CoroutineScope, private val loggingConfig: BleLoggingConfig) :
-    BleConnection {
+@Suppress("TooManyFunctions")
+class KableBleConnection
+internal constructor(
+    private val scope: CoroutineScope,
+    private val loggingConfig: BleLoggingConfig,
+    private val peripheralFactory: KablePeripheralFactory,
+) : BleConnection {
+
+    constructor(
+        scope: CoroutineScope,
+        loggingConfig: BleLoggingConfig,
+    ) : this(scope, loggingConfig, DefaultKablePeripheralFactory)
 
     @Volatile private var peripheral: Peripheral? = null
 
@@ -110,9 +133,17 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
 
     @Volatile private var connectionScope: CoroutineScope? = null
 
+    private val lifecycleMutex = Mutex()
+
+    /** Invalidates connect attempts that have not installed ownership yet. Guarded by [lifecycleMutex]. */
+    private var lifecycleGeneration = 0L
+
     companion object {
         /** Settle delay between a direct connect failure and the autoConnect fallback attempt. */
         private val AUTOCONNECT_FALLBACK_DELAY = 1.seconds
+
+        /** Bounds best-effort GATT teardown so a wedged old peripheral cannot stall reconnect indefinitely. */
+        private val PERIPHERAL_TEARDOWN_TIMEOUT = 2.seconds
     }
 
     private val _deviceFlow = MutableStateFlow<BleDevice?>(null)
@@ -125,41 +156,68 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
         MutableStateFlow<BleConnectionState>(BleConnectionState.Disconnected(DisconnectReason.Unknown))
     override val connectionState: StateFlow<BleConnectionState> = _connectionState.asStateFlow()
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
     override suspend fun connect(device: BleDevice) {
+        var owned: Peripheral? = null
+        try {
+            connectInternal(device) { owned = it }
+        } catch (e: CancellationException) {
+            closeAfterCancellation(owned, e)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            closeAfterConnectFailure(owned, e)
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
+    private suspend fun connectInternal(device: BleDevice, onPeripheralCreated: (Peripheral) -> Unit) {
         val meshtasticDevice = device as? MeshtasticBleDevice ?: error("Unsupported BleDevice type: ${device::class}")
+        val attemptGeneration = lifecycleMutex.withLock { ++lifecycleGeneration }
         var autoConnect = meshtasticDevice.advertisement == null
 
         /** Applies logging, observation exception handling, and platform config shared by both peripheral types. */
         fun PeripheralBuilder.commonConfig() {
             logging { applyConfig(loggingConfig, identifier = device.address.anonymize()) }
             observationExceptionHandler { cause ->
-                Logger.w(cause) { "[${device.address.anonymize()}] Observation failure suppressed" }
+                Logger.w {
+                    "[${device.address.anonymize()}] Observation failure suppressed " +
+                        "(${cause::class.simpleName ?: "Exception"})"
+                }
             }
             platformConfig(device) { autoConnect }
         }
 
-        val p =
-            meshtasticDevice.advertisement?.let { adv -> Peripheral(adv) { commonConfig() } }
-                ?: createPeripheral(device.address) { commonConfig() }
+        val p = peripheralFactory.create(meshtasticDevice) { commonConfig() }
+        onPeripheralCreated(p)
+        currentCoroutineContext().ensureActive()
 
-        // Install ownership of the new peripheral atomically. Cancellation between
-        // peripheral construction and field assignment would strand `p` (Kable allocates
-        // a per-peripheral scope + Bluetooth-state observer eagerly), so the cleanup,
-        // assignment, and ActiveBleConnection update must complete as a single unit.
-        // _deviceFlow.emit() is intentionally outside this block — making it
-        // non-cancellable could hang teardown on a slow collector.
-        withContext(NonCancellable) {
-            cleanUpPeripheral(device.address)
-            peripheral = p
-            ActiveBleConnection.active = ActiveConnection(p, device.address)
+        // Install ownership atomically with attempt validation. A disconnect or newer connect that wins first
+        // invalidates the generation, so outer failure cleanup closes this peripheral without replacing the live one.
+        val ownership =
+            withContext(NonCancellable) {
+                lifecycleMutex.withLock {
+                    if (attemptGeneration != lifecycleGeneration) {
+                        OwnershipInstallResult(installed = false, previous = null)
+                    } else {
+                        val old = peripheral
+                        stateJob?.cancel()
+                        connectionScope?.coroutineContext?.job?.cancel()
+                        stateJob = null
+                        connectionScope = null
+                        peripheral = p
+                        _deviceFlow.value = device
+                        ActiveBleConnection.active = ActiveConnection(p, device.address)
+                        OwnershipInstallResult(installed = true, previous = old.takeUnless { it === p })
+                    }
+                }
+            }
+        if (!ownership.installed) throw CancellationException("BLE connection attempt was superseded")
+        closePeripheralBounded(ownership.previous, "replace")
+
+        if (lifecycleMutex.withLock { peripheral !== p || attemptGeneration != lifecycleGeneration }) {
+            throw CancellationException("BLE connection attempt was superseded")
         }
 
-        _deviceFlow.emit(device)
-
-        stateJob?.cancel()
         var hasStartedConnecting = false
-        stateJob =
+        val newStateJob =
             p.state
                 .onEach { kableState ->
                     val mappedState = kableState.toBleConnectionState(hasStartedConnecting) ?: return@onEach
@@ -167,37 +225,78 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
                         hasStartedConnecting = true
                     }
 
-                    meshtasticDevice.updateState(mappedState)
-
-                    _connectionState.emit(mappedState)
+                    publishStateIfOwned(p, attemptGeneration, meshtasticDevice, mappedState)
                 }
                 .launchIn(scope)
+        lifecycleMutex.withLock {
+            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+                stateJob = newStateJob
+            } else {
+                newStateJob.cancel()
+            }
+        }
 
         // Bounded to at most two attempts: direct connect, then autoConnect fallback when a fresh
         // advertisement was available. Advertisement-less devices start on the autoConnect path.
         // The outer reconnect loop (BleRadioTransport) owns the macro retry budget — see class kdoc.
         repeat(2) {
-            if (p.state.value is State.Connected) return
+            if (!isOwned(p, attemptGeneration)) {
+                throw CancellationException("BLE connection attempt was superseded")
+            }
+            if (p.state.value is State.Connected) {
+                if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+                    throw CancellationException("BLE connection attempt was superseded")
+                }
+                return
+            }
             autoConnect =
                 try {
-                    connectionScope?.let { oldScope ->
+                    val oldScope =
+                        lifecycleMutex.withLock {
+                            if (peripheral !== p || attemptGeneration != lifecycleGeneration) {
+                                throw CancellationException("BLE connection attempt was superseded")
+                            }
+                            connectionScope.also { connectionScope = null }
+                        }
+                    oldScope?.let { scopeToCancel ->
                         Logger.d {
                             "[${device.address.anonymize()}] Cancelling previous connectionScope before reconnect"
                         }
-                        oldScope.coroutineContext.job.cancel()
+                        scopeToCancel.coroutineContext.job.cancel()
                     }
-                    connectionScope = p.connect()
+                    val connectedScope = p.connect()
+                    val installed =
+                        lifecycleMutex.withLock {
+                            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+                                connectionScope = connectedScope
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                    if (!installed) {
+                        connectedScope.coroutineContext.job.cancel()
+                        throw CancellationException("BLE connection attempt was superseded")
+                    }
                     false
                 } catch (e: CancellationException) {
                     throw e
                 } catch (@Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception) {
+                    if (!isOwned(p, attemptGeneration)) {
+                        throw CancellationException("BLE connection attempt was superseded")
+                    }
                     if (autoConnect) {
                         // Already on the autoConnect path and still failing: surface a clear Disconnected
                         // and let the outer reconnect loop (BleRadioTransport) own the macro retry budget.
                         Logger.w {
                             "[${device.address.anonymize()}] autoConnect also failed; deferring to outer reconnect loop"
                         }
-                        _connectionState.emit(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed))
+                        publishStateIfOwned(
+                            p,
+                            attemptGeneration,
+                            meshtasticDevice,
+                            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+                        )
                         throw e
                     }
                     Logger.d { "[${device.address.anonymize()}] Direct connect failed, falling back to autoConnect" }
@@ -210,53 +309,120 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
         // would have kept iterating; the bounded loop defers to the outer reconnect policy.
         // Guard against false-positive Connected by verifying state here.
         if (p.state.value !is State.Connected) {
-            _connectionState.emit(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed))
+            if (!isOwned(p, attemptGeneration)) {
+                throw CancellationException("BLE connection attempt was superseded")
+            }
+            publishStateIfOwned(
+                p,
+                attemptGeneration,
+                meshtasticDevice,
+                BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            )
             throw NotConnectedException(
                 "Failed to establish connection after bounded attempts (state=${p.state.value})",
             )
         }
+        if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+            throw CancellationException("BLE connection attempt was superseded")
+        }
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    override suspend fun connectAndAwait(device: BleDevice, timeout: Duration): BleConnectionState = try {
-        withTimeout(timeout) {
-            connect(device)
-            BleConnectionState.Connected
+    override suspend fun connectAndAwait(device: BleDevice, timeout: Duration): BleConnectionState {
+        var owned: Peripheral? = null
+        val result =
+            try {
+                withTimeout(timeout) {
+                    connectInternal(device) { owned = it }
+                    BleConnectionState.Connected
+                }
+            } catch (_: TimeoutCancellationException) {
+                BleConnectionState.Disconnected(DisconnectReason.Timeout)
+            } catch (e: CancellationException) {
+                closeAfterCancellation(owned, e)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.w {
+                    "[${device.address.anonymize()}] connectAndAwait failed (${e::class.simpleName ?: "Exception"})"
+                }
+                BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)
+            }
+
+        if (result is BleConnectionState.Disconnected) {
+            // A failed Kable connect can leave the physical GATT connected. Release this attempt before the outer
+            // reconnect policy starts another scan or connection.
+            closeConnection(owned, result)
         }
-    } catch (_: TimeoutCancellationException) {
-        // Our own timeout expired — treat as a failed attempt so callers can retry.
-        BleConnectionState.Disconnected(DisconnectReason.Timeout)
-    } catch (e: CancellationException) {
-        // External cancellation (scope closed) — must propagate.
-        throw e
-    } catch (_: Exception) {
-        BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)
+        return result
     }
 
-    override suspend fun disconnect() = withContext(NonCancellable) {
-        // Emit Disconnected before cancelling stateJob so downstream collectors see the
-        // state transition. If we cancel stateJob first, the peripheral's state flow
-        // emission of Disconnected is never forwarded to _connectionState.
-        _connectionState.emit(BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect))
+    override suspend fun disconnect() {
+        val owned =
+            lifecycleMutex.withLock {
+                lifecycleGeneration += 1
+                peripheral
+            }
+        if (owned == null) {
+            lifecycleMutex.withLock {
+                _connectionState.value = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
+                _deviceFlow.value = null
+            }
+        } else {
+            closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect))
+        }
+    }
 
-        stateJob?.cancel()
-        stateJob = null
+    private suspend fun publishStateIfOwned(
+        owned: Peripheral,
+        generation: Long,
+        device: MeshtasticBleDevice,
+        state: BleConnectionState,
+    ): Boolean = lifecycleMutex.withLock {
+        if (peripheral !== owned || generation != lifecycleGeneration) return@withLock false
+        device.updateState(state)
+        _connectionState.value = state
+        true
+    }
 
-        // Capture the peripheral we own before clearing it so we can identity-check
-        // ActiveBleConnection below. A stale disconnect from an earlier connection
-        // attempt's exception handler must not clobber a newer connection that has
-        // already installed itself as active.
-        val owned = peripheral
-        safeClosePeripheral("disconnect")
-        peripheral = null
-        connectionScope = null
+    private suspend fun isOwned(owned: Peripheral, generation: Long): Boolean =
+        lifecycleMutex.withLock { peripheral === owned && generation == lifecycleGeneration }
 
-        if (owned != null && ActiveBleConnection.active?.peripheral === owned) {
-            ActiveBleConnection.active = null
+    private suspend fun closeAfterCancellation(owned: Peripheral?, cancellation: CancellationException): Nothing {
+        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.Cancelled)) }
+            .exceptionOrNull()
+            ?.let(cancellation::addSuppressed)
+        throw cancellation
+    }
+
+    private suspend fun closeAfterConnectFailure(owned: Peripheral?, failure: Exception): Nothing {
+        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)) }
+            .exceptionOrNull()
+            ?.let(failure::addSuppressed)
+        throw failure
+    }
+
+    private suspend fun closeConnection(owned: Peripheral?, disconnectedState: BleConnectionState.Disconnected) =
+        withContext(NonCancellable) {
+            lifecycleMutex.withLock {
+                if (owned != null && peripheral === owned) {
+                    // Publish before cancelling the collector so downstream consumers cannot miss the terminal
+                    // state when the peripheral's own Disconnected emission races teardown.
+                    _connectionState.value = disconnectedState
+                    stateJob?.cancel()
+                    connectionScope?.coroutineContext?.job?.cancel()
+                    stateJob = null
+                    connectionScope = null
+                    peripheral = null
+                    if (ActiveBleConnection.active?.peripheral === owned) {
+                        ActiveBleConnection.active = null
+                    }
+                    _deviceFlow.value = null
+                }
+            }
+
+            closePeripheralBounded(owned, "disconnect")
         }
 
-        _deviceFlow.emit(null)
-    }
+    private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?)
 
     @Suppress("ThrowsCount")
     override suspend fun <T> profile(
@@ -305,31 +471,45 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
 
     override fun invalidateServiceCache(): Boolean = peripheral?.refreshGattCache() == true
 
-    /** Ensures the previous peripheral's GATT resources are fully released. */
-    private suspend fun cleanUpPeripheral(tag: String) {
-        withContext(NonCancellable) { safeClosePeripheral(tag) }
-    }
-
     /**
-     * Safely disconnects and closes the current [peripheral], logging any failures.
+     * Safely disconnects and closes [target], logging any failures.
      *
      * Kable requires `close()` to release broadcast receivers on Android (Kable issue #359). Separate try/catch blocks
      * ensure `close()` always runs even if `disconnect()` throws.
      */
+    private suspend fun closePeripheralBounded(target: Peripheral?, tag: String) {
+        if (target == null) return
+        val completed =
+            withContext(NonCancellable) {
+                withTimeoutOrNull(PERIPHERAL_TEARDOWN_TIMEOUT) {
+                    safeClosePeripheral(target, tag)
+                    true
+                } ?: false
+            }
+        if (!completed) Logger.w { "[$tag] Timed out closing peripheral" }
+    }
+
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun safeClosePeripheral(tag: String) {
+    private suspend fun safeClosePeripheral(target: Peripheral, tag: String) {
+        // Deferred rethrow instead of a throw inside finally: detekt forbids exceptions from finally blocks,
+        // and a close() CancellationException must not discard a disconnect() cancellation.
+        var cancellation: CancellationException? = null
         try {
-            peripheral?.disconnect()
+            target.disconnect()
         } catch (_: NotConnectedException) {
             // Silence "Disconnect requested" which Kable throws if already disconnected.
-            // This is a common non-fatal reported in Crashlytics that is safe to ignore here.
+        } catch (e: CancellationException) {
+            cancellation = e
         } catch (e: Exception) {
-            Logger.w(e) { "[$tag] Failed to disconnect peripheral" }
+            Logger.w { "[$tag] Failed to disconnect peripheral (${e::class.simpleName ?: "Exception"})" }
         }
         try {
-            peripheral?.close()
+            target.close()
+        } catch (e: CancellationException) {
+            cancellation = cancellation ?: e
         } catch (e: Exception) {
-            Logger.w(e) { "[$tag] Failed to close peripheral" }
+            Logger.w { "[$tag] Failed to close peripheral (${e::class.simpleName ?: "Exception"})" }
         }
+        cancellation?.let { throw it }
     }
 }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -160,6 +160,8 @@ internal constructor(
         var owned: Peripheral? = null
         try {
             connectInternal(device) { owned = it }
+        } catch (e: SupersededConnectionAttemptException) {
+            closeAfterConnectFailure(owned, e)
         } catch (e: CancellationException) {
             closeAfterCancellation(owned, e)
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -209,11 +211,11 @@ internal constructor(
                     }
                 }
             }
-        if (!ownership.installed) throw CancellationException("BLE connection attempt was superseded")
+        if (!ownership.installed) throw SupersededConnectionAttemptException()
         closePeripheralBounded(ownership.previous, "replace")
 
         if (lifecycleMutex.withLock { peripheral !== p || attemptGeneration != lifecycleGeneration }) {
-            throw CancellationException("BLE connection attempt was superseded")
+            throw SupersededConnectionAttemptException()
         }
 
         var hasStartedConnecting = false
@@ -241,11 +243,11 @@ internal constructor(
         // The outer reconnect loop (BleRadioTransport) owns the macro retry budget — see class kdoc.
         repeat(2) {
             if (!isOwned(p, attemptGeneration)) {
-                throw CancellationException("BLE connection attempt was superseded")
+                throw SupersededConnectionAttemptException()
             }
             if (p.state.value is State.Connected) {
                 if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
-                    throw CancellationException("BLE connection attempt was superseded")
+                    throw SupersededConnectionAttemptException()
                 }
                 return
             }
@@ -254,7 +256,7 @@ internal constructor(
                     val oldScope =
                         lifecycleMutex.withLock {
                             if (peripheral !== p || attemptGeneration != lifecycleGeneration) {
-                                throw CancellationException("BLE connection attempt was superseded")
+                                throw SupersededConnectionAttemptException()
                             }
                             connectionScope.also { connectionScope = null }
                         }
@@ -276,14 +278,16 @@ internal constructor(
                         }
                     if (!installed) {
                         connectedScope.coroutineContext.job.cancel()
-                        throw CancellationException("BLE connection attempt was superseded")
+                        throw SupersededConnectionAttemptException()
                     }
                     false
+                } catch (e: SupersededConnectionAttemptException) {
+                    throw e
                 } catch (e: CancellationException) {
                     throw e
                 } catch (@Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception) {
                     if (!isOwned(p, attemptGeneration)) {
-                        throw CancellationException("BLE connection attempt was superseded")
+                        throw SupersededConnectionAttemptException()
                     }
                     if (autoConnect) {
                         // Already on the autoConnect path and still failing: surface a clear Disconnected
@@ -310,7 +314,7 @@ internal constructor(
         // Guard against false-positive Connected by verifying state here.
         if (p.state.value !is State.Connected) {
             if (!isOwned(p, attemptGeneration)) {
-                throw CancellationException("BLE connection attempt was superseded")
+                throw SupersededConnectionAttemptException()
             }
             publishStateIfOwned(
                 p,
@@ -323,7 +327,7 @@ internal constructor(
             )
         }
         if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
-            throw CancellationException("BLE connection attempt was superseded")
+            throw SupersededConnectionAttemptException()
         }
     }
 
@@ -338,6 +342,8 @@ internal constructor(
                 }
             } catch (_: TimeoutCancellationException) {
                 BleConnectionState.Disconnected(DisconnectReason.Timeout)
+            } catch (_: SupersededConnectionAttemptException) {
+                BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)
             } catch (e: CancellationException) {
                 closeAfterCancellation(owned, e)
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -421,6 +427,8 @@ internal constructor(
 
             closePeripheralBounded(owned, "disconnect")
         }
+
+    private class SupersededConnectionAttemptException : Exception()
 
     private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?)
 

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -24,6 +24,7 @@ import com.juul.kable.State
 import com.juul.kable.WriteType
 import com.juul.kable.characteristicOf
 import com.juul.kable.writeWithoutResponse
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -135,8 +136,11 @@ internal constructor(
 
     private val lifecycleMutex = Mutex()
 
-    /** Invalidates connect attempts that have not installed ownership yet. Guarded by [lifecycleMutex]. */
-    private var lifecycleGeneration = 0L
+    /** Invalidates connect attempts before or after ownership installation. Guarded by [lifecycleMutex]. */
+    private var connectAttemptGeneration = 0L
+
+    /** Identifies the currently installed peripheral without invalidating it for a pending replacement. */
+    private var ownershipGeneration = 0L
 
     companion object {
         /** Settle delay between a direct connect failure and the autoConnect fallback attempt. */
@@ -172,8 +176,8 @@ internal constructor(
     @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
     private suspend fun connectInternal(device: BleDevice, onPeripheralCreated: (Peripheral) -> Unit) {
         val meshtasticDevice = device as? MeshtasticBleDevice ?: error("Unsupported BleDevice type: ${device::class}")
-        val attemptGeneration = lifecycleMutex.withLock { ++lifecycleGeneration }
-        var autoConnect = meshtasticDevice.advertisement == null
+        val attemptGeneration = lifecycleMutex.withLock { ++connectAttemptGeneration }
+        val autoConnect = atomic(meshtasticDevice.advertisement == null)
 
         /** Applies logging, observation exception handling, and platform config shared by both peripheral types. */
         fun PeripheralBuilder.commonConfig() {
@@ -184,7 +188,7 @@ internal constructor(
                         "(${cause::class.simpleName ?: "Exception"})"
                 }
             }
-            platformConfig(device) { autoConnect }
+            platformConfig(device) { autoConnect.value }
         }
 
         val p = peripheralFactory.create(meshtasticDevice) { commonConfig() }
@@ -196,8 +200,8 @@ internal constructor(
         val ownership =
             withContext(NonCancellable) {
                 lifecycleMutex.withLock {
-                    if (attemptGeneration != lifecycleGeneration) {
-                        OwnershipInstallResult(installed = false, previous = null)
+                    if (attemptGeneration != connectAttemptGeneration) {
+                        OwnershipInstallResult(installed = false, previous = null, generation = null)
                     } else {
                         val old = peripheral
                         stateJob?.cancel()
@@ -207,14 +211,20 @@ internal constructor(
                         peripheral = p
                         _deviceFlow.value = device
                         ActiveBleConnection.active = ActiveConnection(p, device.address)
-                        OwnershipInstallResult(installed = true, previous = old.takeUnless { it === p })
+                        ownershipGeneration += 1
+                        OwnershipInstallResult(
+                            installed = true,
+                            previous = old.takeUnless { it === p },
+                            generation = ownershipGeneration,
+                        )
                     }
                 }
             }
         if (!ownership.installed) throw SupersededConnectionAttemptException()
+        val installedGeneration = checkNotNull(ownership.generation)
         closePeripheralBounded(ownership.previous, "replace")
 
-        if (lifecycleMutex.withLock { peripheral !== p || attemptGeneration != lifecycleGeneration }) {
+        if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
             throw SupersededConnectionAttemptException()
         }
 
@@ -227,11 +237,11 @@ internal constructor(
                         hasStartedConnecting = true
                     }
 
-                    publishStateIfOwned(p, attemptGeneration, meshtasticDevice, mappedState)
+                    publishStateIfOwned(p, installedGeneration, meshtasticDevice, mappedState)
                 }
                 .launchIn(scope)
         lifecycleMutex.withLock {
-            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+            if (peripheral === p && installedGeneration == ownershipGeneration) {
                 stateJob = newStateJob
             } else {
                 newStateJob.cancel()
@@ -242,20 +252,24 @@ internal constructor(
         // advertisement was available. Advertisement-less devices start on the autoConnect path.
         // The outer reconnect loop (BleRadioTransport) owns the macro retry budget — see class kdoc.
         repeat(2) {
-            if (!isOwned(p, attemptGeneration)) {
+            if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
                 throw SupersededConnectionAttemptException()
             }
             if (p.state.value is State.Connected) {
-                if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+                if (!publishStateIfOwned(p, installedGeneration, meshtasticDevice, BleConnectionState.Connected)) {
                     throw SupersededConnectionAttemptException()
                 }
                 return
             }
-            autoConnect =
+            autoConnect.value =
                 try {
                     val oldScope =
                         lifecycleMutex.withLock {
-                            if (peripheral !== p || attemptGeneration != lifecycleGeneration) {
+                            if (
+                                peripheral !== p ||
+                                attemptGeneration != connectAttemptGeneration ||
+                                installedGeneration != ownershipGeneration
+                            ) {
                                 throw SupersededConnectionAttemptException()
                             }
                             connectionScope.also { connectionScope = null }
@@ -269,7 +283,11 @@ internal constructor(
                     val connectedScope = p.connect()
                     val installed =
                         lifecycleMutex.withLock {
-                            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+                            if (
+                                peripheral === p &&
+                                attemptGeneration == connectAttemptGeneration &&
+                                installedGeneration == ownershipGeneration
+                            ) {
                                 connectionScope = connectedScope
                                 true
                             } else {
@@ -286,18 +304,18 @@ internal constructor(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (@Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception) {
-                    if (!isOwned(p, attemptGeneration)) {
+                    if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
                         throw SupersededConnectionAttemptException()
                     }
-                    if (autoConnect) {
-                        // Already on the autoConnect path and still failing: surface a clear Disconnected
-                        // and let the outer reconnect loop (BleRadioTransport) own the macro retry budget.
+                    if (autoConnect.value) {
+                        // The autoConnect fallback also failed. Publish Disconnected and let the outer reconnect loop
+                        // own the macro retry budget.
                         Logger.w {
                             "[${device.address.anonymize()}] autoConnect also failed; deferring to outer reconnect loop"
                         }
                         publishStateIfOwned(
                             p,
-                            attemptGeneration,
+                            installedGeneration,
                             meshtasticDevice,
                             BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
                         )
@@ -313,12 +331,12 @@ internal constructor(
         // would have kept iterating; the bounded loop defers to the outer reconnect policy.
         // Guard against false-positive Connected by verifying state here.
         if (p.state.value !is State.Connected) {
-            if (!isOwned(p, attemptGeneration)) {
+            if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
                 throw SupersededConnectionAttemptException()
             }
             publishStateIfOwned(
                 p,
-                attemptGeneration,
+                installedGeneration,
                 meshtasticDevice,
                 BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
             )
@@ -326,7 +344,7 @@ internal constructor(
                 "Failed to establish connection after bounded attempts (state=${p.state.value})",
             )
         }
-        if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+        if (!publishStateIfOwned(p, installedGeneration, meshtasticDevice, BleConnectionState.Connected)) {
             throw SupersededConnectionAttemptException()
         }
     }
@@ -362,18 +380,20 @@ internal constructor(
     }
 
     override suspend fun disconnect() {
+        val localDisconnect = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
         val owned =
             lifecycleMutex.withLock {
-                lifecycleGeneration += 1
-                peripheral
+                connectAttemptGeneration += 1
+                val current = peripheral
+                if (current == null) {
+                    (_deviceFlow.value as? MeshtasticBleDevice)?.updateState(localDisconnect)
+                    _connectionState.value = localDisconnect
+                    _deviceFlow.value = null
+                }
+                current
             }
-        if (owned == null) {
-            lifecycleMutex.withLock {
-                _connectionState.value = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
-                _deviceFlow.value = null
-            }
-        } else {
-            closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect))
+        if (owned != null) {
+            closeConnection(owned, localDisconnect)
         }
     }
 
@@ -383,26 +403,37 @@ internal constructor(
         device: MeshtasticBleDevice,
         state: BleConnectionState,
     ): Boolean = lifecycleMutex.withLock {
-        if (peripheral !== owned || generation != lifecycleGeneration) return@withLock false
+        if (peripheral !== owned || generation != ownershipGeneration) return@withLock false
         device.updateState(state)
         _connectionState.value = state
         true
     }
 
-    private suspend fun isOwned(owned: Peripheral, generation: Long): Boolean =
-        lifecycleMutex.withLock { peripheral === owned && generation == lifecycleGeneration }
+    private suspend fun isCurrentOwnedAttempt(
+        owned: Peripheral,
+        attemptGeneration: Long,
+        installedGeneration: Long,
+    ): Boolean = lifecycleMutex.withLock {
+        peripheral === owned &&
+            attemptGeneration == connectAttemptGeneration &&
+            installedGeneration == ownershipGeneration
+    }
 
     private suspend fun closeAfterCancellation(owned: Peripheral?, cancellation: CancellationException): Nothing {
-        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.Cancelled)) }
-            .exceptionOrNull()
-            ?.let(cancellation::addSuppressed)
+        if (owned != null) {
+            runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.Cancelled)) }
+                .exceptionOrNull()
+                ?.let(cancellation::addSuppressed)
+        }
         throw cancellation
     }
 
     private suspend fun closeAfterConnectFailure(owned: Peripheral?, failure: Exception): Nothing {
-        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)) }
-            .exceptionOrNull()
-            ?.let(failure::addSuppressed)
+        if (owned != null) {
+            runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)) }
+                .exceptionOrNull()
+                ?.let(failure::addSuppressed)
+        }
         throw failure
     }
 
@@ -410,8 +441,10 @@ internal constructor(
         withContext(NonCancellable) {
             lifecycleMutex.withLock {
                 if (owned != null && peripheral === owned) {
+                    ownershipGeneration += 1
                     // Publish before cancelling the collector so downstream consumers cannot miss the terminal
                     // state when the peripheral's own Disconnected emission races teardown.
+                    (_deviceFlow.value as? MeshtasticBleDevice)?.updateState(disconnectedState)
                     _connectionState.value = disconnectedState
                     stateJob?.cancel()
                     connectionScope?.coroutineContext?.job?.cancel()
@@ -428,9 +461,9 @@ internal constructor(
             closePeripheralBounded(owned, "disconnect")
         }
 
-    private class SupersededConnectionAttemptException : Exception()
+    internal class SupersededConnectionAttemptException : Exception("BLE connection attempt was superseded")
 
-    private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?)
+    private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?, val generation: Long?)
 
     @Suppress("ThrowsCount")
     override suspend fun <T> profile(

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -18,11 +18,25 @@ package org.meshtastic.core.ble
 
 import app.cash.turbine.test
 import com.juul.kable.Advertisement
+import com.juul.kable.NotConnectedException
+import com.juul.kable.Peripheral
+import com.juul.kable.State
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -31,11 +45,14 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -43,6 +60,228 @@ import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class KableBleConnectionTest {
+
+    @AfterTest
+    fun tearDown() {
+        ActiveBleConnection.active = null
+    }
+
+    @Test
+    fun `cancelled stale attempt cannot close a newer peripheral`() = runTest {
+        val oldState = MutableStateFlow<State>(State.Connecting.Bluetooth)
+        val newState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val oldPeripheral: Peripheral = mock(MockMode.autofill)
+        val newPeripheral: Peripheral = mock(MockMode.autofill)
+        val oldConnectStarted = CompletableDeferred<Unit>()
+        every { oldPeripheral.state } returns oldState
+        every { newPeripheral.state } returns newState
+        everySuspend { oldPeripheral.connect() } calls
+            {
+                oldConnectStarted.complete(Unit)
+                awaitCancellation()
+            }
+        everySuspend { oldPeripheral.disconnect() } returns Unit
+        everySuspend { newPeripheral.disconnect() } returns Unit
+        every { oldPeripheral.close() } returns Unit
+        every { newPeripheral.close() } returns Unit
+        val peripherals = ArrayDeque(listOf(oldPeripheral, newPeripheral))
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripherals.removeFirst() },
+            )
+        val oldDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val newDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+
+        val oldAttempt = backgroundScope.launch { connection.connectAndAwait(oldDevice, 30.seconds) }
+        oldConnectStarted.await()
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(newDevice, 1.seconds))
+        oldAttempt.cancelAndJoin()
+        runCurrent()
+
+        assertSame(newPeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(newDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verifySuspend(exactly(0)) { newPeripheral.disconnect() }
+        verify(exactly(0)) { newPeripheral.close() }
+    }
+
+    @Test
+    fun `disconnect cleanup cannot clear a replacement device`() = runTest {
+        val oldState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val newState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val oldPeripheral: Peripheral = mock(MockMode.autofill)
+        val newPeripheral: Peripheral = mock(MockMode.autofill)
+        val oldDisconnectStarted = CompletableDeferred<Unit>()
+        val releaseOldDisconnect = CompletableDeferred<Unit>()
+        every { oldPeripheral.state } returns oldState
+        every { newPeripheral.state } returns newState
+        everySuspend { oldPeripheral.disconnect() } calls
+            {
+                oldDisconnectStarted.complete(Unit)
+                releaseOldDisconnect.await()
+            }
+        everySuspend { newPeripheral.disconnect() } returns Unit
+        every { oldPeripheral.close() } returns Unit
+        every { newPeripheral.close() } returns Unit
+        val peripherals = ArrayDeque(listOf(oldPeripheral, newPeripheral))
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripherals.removeFirst() },
+            )
+        val oldDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val newDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(oldDevice, 1.seconds))
+
+        val disconnect = backgroundScope.launch { connection.disconnect() }
+        oldDisconnectStarted.await()
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(newDevice, 1.seconds))
+        releaseOldDisconnect.complete(Unit)
+        disconnect.join()
+        runCurrent()
+
+        assertSame(newPeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(newDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verifySuspend(exactly(0)) { newPeripheral.disconnect() }
+        verify(exactly(0)) { newPeripheral.close() }
+    }
+
+    @Test
+    fun `disconnect invalidates an attempt before peripheral ownership is installed`() = runTest {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        val factoryStarted = CompletableDeferred<Unit>()
+        val releaseFactory = CompletableDeferred<Unit>()
+        every { peripheral.state } returns state
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory =
+                KablePeripheralFactory { _, _ ->
+                    factoryStarted.complete(Unit)
+                    releaseFactory.await()
+                    peripheral
+                },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+
+        val attempt = backgroundScope.launch { connection.connect(device) }
+        factoryStarted.await()
+        connection.disconnect()
+        releaseFactory.complete(Unit)
+        attempt.join()
+
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
+            connection.connectionState.value,
+        )
+        assertNull(connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
+    }
+
+    @Test
+    fun `replacement continues after superseded peripheral teardown times out`() = runTest {
+        val oldState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val newState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val oldPeripheral: Peripheral = mock(MockMode.autofill)
+        val newPeripheral: Peripheral = mock(MockMode.autofill)
+        every { oldPeripheral.state } returns oldState
+        every { newPeripheral.state } returns newState
+        everySuspend { oldPeripheral.disconnect() } calls { awaitCancellation() }
+        everySuspend { newPeripheral.disconnect() } returns Unit
+        every { oldPeripheral.close() } returns Unit
+        every { newPeripheral.close() } returns Unit
+        val peripherals = ArrayDeque(listOf(oldPeripheral, newPeripheral))
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripherals.removeFirst() },
+            )
+        val oldDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val newDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(oldDevice, 1.seconds))
+
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(newDevice, 5.seconds))
+
+        assertSame(newPeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(newDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verify(exactly(1)) { oldPeripheral.close() }
+        verifySuspend(exactly(0)) { newPeripheral.disconnect() }
+        verify(exactly(0)) { newPeripheral.close() }
+    }
+
+    @Test
+    fun `connect failure releases peripheral ownership before rethrowing`() = runTest {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        every { peripheral.state } returns state
+        everySuspend { peripheral.connect() } throws NotConnectedException("connect failed")
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripheral },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01", advertisement = mock(MockMode.autofill))
+
+        val failure = assertFailsWith<NotConnectedException> { connection.connect(device) }
+
+        assertEquals("connect failed", failure.message)
+        assertNull(connection.device)
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            connection.connectionState.value,
+        )
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
+    }
+
+    @Test
+    fun `factory failure before ownership leaves the active connection intact`() = runTest {
+        val activeState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val activePeripheral: Peripheral = mock(MockMode.autofill)
+        every { activePeripheral.state } returns activeState
+        everySuspend { activePeripheral.disconnect() } returns Unit
+        every { activePeripheral.close() } returns Unit
+        val factoryFailure = IllegalStateException("factory failed")
+        var factoryCalls = 0
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory =
+                KablePeripheralFactory { _, _ ->
+                    factoryCalls += 1
+                    if (factoryCalls == 1) activePeripheral else throw factoryFailure
+                },
+            )
+        val activeDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val replacementDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(activeDevice, 1.seconds))
+
+        val failure = assertFailsWith<IllegalStateException> { connection.connect(replacementDevice) }
+
+        assertSame(factoryFailure, failure)
+        assertSame(activePeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(activeDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verifySuspend(exactly(0)) { activePeripheral.disconnect() }
+        verify(exactly(0)) { activePeripheral.close() }
+    }
 
     @Test
     fun `scan emits ble device for discovered advertisement`() = runTest {

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -32,7 +32,9 @@ import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
@@ -152,40 +154,48 @@ class KableBleConnectionTest {
 
     @Test
     fun `disconnect invalidates an attempt before peripheral ownership is installed`() = runTest {
-        val state = MutableStateFlow<State>(State.Disconnected(status = null))
-        val peripheral: Peripheral = mock(MockMode.autofill)
-        val factoryStarted = CompletableDeferred<Unit>()
-        val releaseFactory = CompletableDeferred<Unit>()
-        every { peripheral.state } returns state
-        everySuspend { peripheral.disconnect() } returns Unit
-        every { peripheral.close() } returns Unit
-        val connection =
-            KableBleConnection(
-                scope = backgroundScope,
-                loggingConfig = BleLoggingConfig.Release,
-                peripheralFactory =
-                KablePeripheralFactory { _, _ ->
-                    factoryStarted.complete(Unit)
-                    releaseFactory.await()
-                    peripheral
-                },
-            )
+        val fixture = deferredPeripheralFixture(backgroundScope)
         val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
 
-        val attempt = backgroundScope.launch { connection.connect(device) }
-        factoryStarted.await()
-        connection.disconnect()
-        releaseFactory.complete(Unit)
-        attempt.join()
+        val attempt = backgroundScope.async { runCatching { fixture.connection.connect(device) } }
+        fixture.factoryStarted.await()
+        fixture.connection.disconnect()
+        fixture.releaseFactory.complete(Unit)
+        val failure = attempt.await().exceptionOrNull()
 
+        assertTrue(failure != null && failure !is CancellationException)
         assertEquals(
             BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
-            connection.connectionState.value,
+            fixture.connection.connectionState.value,
         )
-        assertNull(connection.device)
+        assertNull(fixture.connection.device)
         assertNull(ActiveBleConnection.active)
-        verifySuspend(exactly(1)) { peripheral.disconnect() }
-        verify(exactly(1)) { peripheral.close() }
+        verifySuspend(exactly(1)) { fixture.peripheral.disconnect() }
+        verify(exactly(1)) { fixture.peripheral.close() }
+    }
+
+    @Test
+    fun `connectAndAwait maps a superseded attempt to a retryable failure`() = runTest {
+        val fixture = deferredPeripheralFixture(backgroundScope)
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+
+        val attempt = backgroundScope.async { fixture.connection.connectAndAwait(device, 5.seconds) }
+        fixture.factoryStarted.await()
+        fixture.connection.disconnect()
+        fixture.releaseFactory.complete(Unit)
+
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            attempt.await(),
+        )
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
+            fixture.connection.connectionState.value,
+        )
+        assertNull(fixture.connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { fixture.peripheral.disconnect() }
+        verify(exactly(1)) { fixture.peripheral.close() }
     }
 
     @Test
@@ -511,6 +521,35 @@ class KableBleConnectionTest {
 
         assertEquals("Unexpected scanner state", failure.message)
     }
+
+    private fun deferredPeripheralFixture(scope: CoroutineScope): DeferredPeripheralFixture {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        val factoryStarted = CompletableDeferred<Unit>()
+        val releaseFactory = CompletableDeferred<Unit>()
+        every { peripheral.state } returns state
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = scope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory =
+                KablePeripheralFactory { _, _ ->
+                    factoryStarted.complete(Unit)
+                    releaseFactory.await()
+                    peripheral
+                },
+            )
+        return DeferredPeripheralFixture(connection, peripheral, factoryStarted, releaseFactory)
+    }
+
+    private data class DeferredPeripheralFixture(
+        val connection: KableBleConnection,
+        val peripheral: Peripheral,
+        val factoryStarted: CompletableDeferred<Unit>,
+        val releaseFactory: CompletableDeferred<Unit>,
+    )
 
     private class TestKableBleScanner(
         private val scanResults: Flow<KableScanResult>,

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -24,6 +24,7 @@ import com.juul.kable.State
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -34,6 +35,7 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
@@ -45,6 +47,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -153,6 +156,33 @@ class KableBleConnectionTest {
     }
 
     @Test
+    fun `disconnect publishes local terminal state to the connection and tracked device`() = runTest {
+        val state = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        every { peripheral.state } returns state
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripheral },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val localDisconnect = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(device, 1.seconds))
+
+        connection.disconnect()
+
+        assertEquals(localDisconnect, connection.connectionState.value)
+        assertEquals(localDisconnect, device.state.value)
+        assertNull(connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
+    }
+
+    @Test
     fun `disconnect invalidates an attempt before peripheral ownership is installed`() = runTest {
         val fixture = deferredPeripheralFixture(backgroundScope)
         val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
@@ -163,7 +193,7 @@ class KableBleConnectionTest {
         fixture.releaseFactory.complete(Unit)
         val failure = attempt.await().exceptionOrNull()
 
-        assertTrue(failure != null && failure !is CancellationException)
+        assertIs<KableBleConnection.SupersededConnectionAttemptException>(failure)
         assertEquals(
             BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
             fixture.connection.connectionState.value,
@@ -184,10 +214,7 @@ class KableBleConnectionTest {
         fixture.connection.disconnect()
         fixture.releaseFactory.complete(Unit)
 
-        assertEquals(
-            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
-            attempt.await(),
-        )
+        assertEquals(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed), attempt.await())
         assertEquals(
             BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
             fixture.connection.connectionState.value,
@@ -255,19 +282,24 @@ class KableBleConnectionTest {
             BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
             connection.connectionState.value,
         )
+        assertEquals(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed), device.state.value)
         assertNull(ActiveBleConnection.active)
         verifySuspend(exactly(1)) { peripheral.disconnect() }
         verify(exactly(1)) { peripheral.close() }
     }
 
     @Test
-    fun `factory failure before ownership leaves the active connection intact`() = runTest {
+    fun `factory failure before ownership leaves the active connection intact`() = runTest(UnconfinedTestDispatcher()) {
         val activeState = MutableStateFlow<State>(State.Connected(backgroundScope))
         val activePeripheral: Peripheral = mock(MockMode.autofill)
         every { activePeripheral.state } returns activeState
         everySuspend { activePeripheral.disconnect() } returns Unit
         every { activePeripheral.close() } returns Unit
-        val factoryFailure = IllegalStateException("factory failed")
+        // A non-copyable subtype keeps referential identity stable across coroutine stack-trace recovery.
+        val factoryFailure =
+            object : IllegalStateException("factory failed") {
+                override val cause: Throwable? = null
+            }
         var factoryCalls = 0
         val connection =
             KableBleConnection(
@@ -289,8 +321,44 @@ class KableBleConnectionTest {
         assertSame(activePeripheral, ActiveBleConnection.active?.peripheral)
         assertSame(activeDevice, connection.device)
         assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+
+        activeState.value = State.Disconnected(status = null)
+        runCurrent()
+
+        assertIs<BleConnectionState.Disconnected>(connection.connectionState.value)
         verifySuspend(exactly(0)) { activePeripheral.disconnect() }
         verify(exactly(0)) { activePeripheral.close() }
+    }
+
+    @Test
+    fun `bounded connect publishes failure when Kable returns without connecting`() = runTest {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val firstScope = CoroutineScope(backgroundScope.coroutineContext + Job())
+        val secondScope = CoroutineScope(backgroundScope.coroutineContext + Job())
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        every { peripheral.state } returns state
+        everySuspend { peripheral.connect() } sequentiallyReturns listOf(firstScope, secondScope)
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripheral },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01", advertisement = mock(MockMode.autofill))
+
+        val failure = assertFailsWith<NotConnectedException> { connection.connect(device) }
+
+        assertTrue(failure.message.orEmpty().contains("bounded attempts"))
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            connection.connectionState.value,
+        )
+        assertNull(connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
     }
 
     @Test

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/KablePlatformLoggingTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/KablePlatformLoggingTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class KablePlatformLoggingTest {
+    @Test
+    fun `Kable platform diagnostics never forward arbitrary throwable text`() {
+        val matches =
+            Konsist.scopeFromProject().files.filter {
+                "/androidMain/" in it.path && it.path.endsWith("KablePlatformSetup.kt")
+            }
+        assertTrue(
+            matches.size == 1,
+            "expected exactly one androidMain KablePlatformSetup.kt in scope; found ${matches.map { it.path }}",
+        )
+        val source = matches.single().text
+        val throwableLoggerCall = Regex("""(?:Logger|logger)\.[vdiwe]\s*\(""")
+        val offenders =
+            source.lines().withIndex().mapNotNull { (index, line) ->
+                line.takeIf(throwableLoggerCall::containsMatchIn)?.let {
+                    "KablePlatformSetup.kt:${index + 1}: ${line.trim()}"
+                }
+            }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "Kable platform diagnostics must log curated failure types, not throwable messages. Offending lines:\n" +
+                offenders.joinToString("\n"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Strengthen BLE connection lifecycle handling to prevent stale sessions from interfering with newer connections and to bound MTU negotiation on Android.

New Features:
- Introduce a KablePeripheralFactory to abstract peripheral creation and enable controlled peripheral injection in tests.

Bug Fixes:
- Ensure cancelled or timed-out BLE connection attempts cannot close or clear a newer active peripheral or device.
- Guarantee that disconnect cleanup from an old connection cannot tear down a replacement connection or its device state.
- Treat connection timeouts and failures as terminal states and clean up the underlying peripheral before outer reconnect attempts.

Enhancements:
- Centralize BLE connection lifecycle management behind a mutex to serialize ownership changes, state updates, and cleanup.
- Refine connection state publication so consumers always see terminal disconnected states without racing against teardown.
- Improve cancellation handling during connect and connectAndAwait by safely closing owned peripherals and preserving cancellation context.

Tests:
- Add tests covering stale connection attempts being unable to close newer peripherals or overwrite active connection state.
- Add tests ensuring disconnect cleanup from an old peripheral does not clear a newly established device or ActiveBleConnection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves Android BLE connection lifecycle handling by adding MTU negotiation timeouts, ensuring failures and cancellations transition to disconnected states, and consistently cleaning up active GATT resources.

### Features
- Adds a timeout for Android MTU negotiation.
- Falls back to the current ATT MTU when negotiation does not complete.
- Preserves coroutine cancellation during MTU setup.

### Fixes
- Treats connection failures and timeouts as disconnected states.
- Closes in-flight GATT state before propagating cancellation.
- Cleans up the peripheral, active connection, connection scope, and device flow after disconnects or failures.
- Prevents stale connections from closing newer active connections.

### Refactors
- Extracts shared `closeConnection` logic for consistent teardown and state emission.
- Preserves the ordering of disconnected-state emission before cancelling connection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->