### PR TITLE
Anonymize BLE transport logs and MeshLog entries

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,149 +1,16 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: en-US
-
+early_access: true
 reviews:
-  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
-  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
-  profile: chill
+  profile: assertive
+  request_changes_workflow: false
   high_level_summary: true
-  poem: false
-  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
-  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
-    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
-    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
-    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
-    auto_incremental_review: false
-    ignore_usernames:
-      - renovate
-      - renovate[bot]
-      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
-      # translation bumps) — machine-generated content, nothing to review.
-      - github-actions
-      - github-actions[bot]
-    ignore_title_keywords:
-      - "chore: Scheduled updates"
-  # Stop reviewing once a PR is closed.
-  abort_on_close: true
-
-  path_filters:
-    # Generated / huge / non-source — don't review, just noise + token burn.
-    - "!**/build/**"
-    - "!**/*.png"
-    - "!**/*.webp"
-    - "!**/firmware_releases.json"
-    - "!**/emoji-data.json"
-    - "!**/flatpak-sources.json"
-    # Crowdin-managed translations — owned upstream, not hand-edited here.
-    - "!**/values-*/strings.xml"
-    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
-    - "!.specify/**"
-
-  path_instructions:
-    - path: "**/commonMain/**"
-      instructions: >
-        KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
-    - path: "**/*.kt"
-      instructions: >
-        Flag leftover // ... existing code ... placeholders, and any logging of PII, location, or cryptographic keys.
-    - path: "**/src/**/strings.xml"
-      instructions: >
-        New string resources must be alphabetically sorted (scripts/sort-strings.py). Flag out-of-order additions.
-    - path: baselineprofile/
-      instructions: Keep baseline profile generation tied to the `google` flavor and connected devices/emulators, and commit the generated profile output to `androidApp/src/google/generated/baselineProfiles/baseline-prof.txt`.
-    - path: docs/
-      instructions: Treat non-English locale folders as Crowdin-managed output; edit the English sources under `docs/en/` and register new pages through `feature/docs/` instead of hand-editing translated locale directories.
-    - path: screenshot-tests/
-      instructions: When updating docs screenshots, keep `docs-screenshots-manifest.txt` and `docs-screenshot-aliases.properties` in sync with the generated files, and rerun `copyDocsScreenshots` after regenerating screenshots.
-    - path: docs-screenshots/
-      instructions: Keep this module generate-only for documentation screenshots; do not add it to the CI validation gate that is reserved for `screenshot-tests`.
-    - path: desktopApp/
-      instructions: Keep desktop release ProGuard rules aligned with `androidApp/proguard-rules.pro`, and preserve the desktop-specific runtime wiring needed for `Dispatchers.Main` on JVM.
-    - path: androidApp/
-      instructions: Keep the Android app’s `MeshService` declaration and manifest wiring in sync with the implementation that lives in `core:service`.
-    - path: core/service/
-      instructions: Keep `RadioControllerImpl` composed from its sub-controllers via interface delegation; admin sends are fire-and-forget, and any config mutation must go through `editSettings { }` transactions.
-    - path: feature/docs/
-      instructions: Treat the Compose resources under `src/commonMain/composeResources/files/` as generated output from `/docs/en/**` and translated docs sync tasks; do not hand-edit those copied files.
-    - path: feature/map/
-      instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
-    - path: feature/car/
-      instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
-
-  # Every CodeRabbit tool is enabled by default, so this block only ever needs to
-  # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
-  # Tolerance gate) and duplicate comments were the noise we removed. The scanners
-  # CI doesn't run — gitleaks, shellcheck, actionlint, zizmor, semgrep, trivy,
-  # presidio (PII), buf (protobuf) — are already on by default; don't re-list them.
-  tools:
-    detekt:
-      enabled: false
-    # Custom AST rules mechanically enforce the recurring defect classes that prose
-    # can't. See .coderabbit/ast-grep-rules/ and .skills/code-review/SKILL.md.
-    # essential_rules stays on (default) — these are additive.
-    ast-grep:
-      rule_dirs:
-        - ".coderabbit/ast-grep-rules"
-
-  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
-  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
-  finishing_touches:
-    docstrings:
-      enabled: false
-    unit_tests:
-      enabled: false
-
-  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR. PR titles are already linted by CI
-  # (.github/workflows/pull-request-target.yml), so no title check here either.
-  pre_merge_checks:
-    docstrings:
-      mode: "off"
-    # The two defect classes that survive review-by-prose because they are about
-    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
-    # would still pass with the fix reverted. Warning, not error: these are
-    # judgment calls and a false positive must not block a merge.
-    custom_checks:
-      - name: "Sibling call sites and presence semantics"
-        mode: "warning"
-        instructions: >-
-          When a diff changes how an absent value is represented — making a field nullable,
-          removing a zero-guard, or adding a presence check — verify EVERY call site of that
-          field was updated, not just the one the bug was reported against. Ambient temperature
-          was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
-          Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
-          a physically reachable value on that scale (RSSI, temperature, current, voltage,
-          particulate concentration). Two exceptions, do NOT flag either: humidity, where 0 %RH
-          is unreachable and the guard is intentional and tested; and the proto `rx_snr`, which
-          has no presence upstream, so its 0f ambiguity cannot be fixed app-side. An app-level
-          SNR field that IS nullable is still in scope.
-      - name: "Tests prove the path, not the end state"
-        mode: "warning"
-        instructions: >-
-          For each added or changed test, decide whether it would still pass if the production
-          code it covers were reverted. Flag tests that seed a fake's backing store and then
-          assert the value comes back, tests that assert only a collection's size rather than
-          which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
-          (not a stable contract). A test must assert the side effect only the intended path
-          produces — a call counter, a request issued, a cache written.
-
-knowledge_base:
-  # Learnings are how a confirmed finding stops recurring on the next PR. Pin the
-  # scope to this repo: the default `auto` already resolves to `local` for public
-  # repos, but being explicit keeps it from shifting if visibility ever changes.
-  learnings:
-    scope: local
-  # Feed CodeRabbit the same guidance human/AI contributors follow, including
-  # the repo-specific .skills/ modules and Copilot path instructions it
-  # wouldn't pick up by default.
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - ".skills/**/SKILL.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/*.instructions.md"
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,7 +18,6 @@ jobs:
   # (folded into this job rather than run standalone: runner-pool slots, not
   # compute, are the scarce resource during queue bursts).
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -73,6 +73,13 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'test.gradle.kts'
+
+  # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
+  verify-check-changes-filter:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
       - name: Verify module roots are represented in check-changes filter
         run: |
           python3 - <<'PY'

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ build-scan-*.scan
 # Python bytecode from scripts/
 __pycache__/
 *.pyc
+.omo/*
+.commandcode

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -22,6 +22,7 @@ import com.juul.kable.GattRequestRejectedException
 import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
 import com.juul.kable.UnmetRequirementException
+import com.juul.kable.UnmetRequirementReason
 
 /**
  * Classification of a BLE-layer exception for the transport layer to act on.
@@ -30,7 +31,8 @@ import com.juul.kable.UnmetRequirementException
  *   Currently always `false` — all known BLE exceptions can resolve without user intervention (BT toggling, permission
  *   grants, transient GATT errors). Reserved for future use.
  * @property gattStatus the platform GATT status code when available (Android-specific).
- * @property message a human-readable description of the failure.
+ * @property message a human-readable, diagnostic-safe description of the failure. Source exception messages are not
+ *   forwarded because platform BLE errors can contain stable device identifiers.
  */
 data class BleExceptionInfo(val isPermanent: Boolean, val gattStatus: Int? = null, val message: String)
 
@@ -43,11 +45,7 @@ data class BleExceptionInfo(val isPermanent: Boolean, val gattStatus: Int? = nul
  */
 fun Throwable.classifyBleException(): BleExceptionInfo? = when (this) {
     is GattStatusException ->
-        BleExceptionInfo(
-            isPermanent = false,
-            gattStatus = status,
-            message = "GATT error (status $status): $message",
-        )
+        BleExceptionInfo(isPermanent = false, gattStatus = status, message = "GATT error (status $status)")
 
     is NotConnectedException -> BleExceptionInfo(isPermanent = false, message = "Not connected")
 
@@ -55,12 +53,17 @@ fun Throwable.classifyBleException(): BleExceptionInfo? = when (this) {
         BleExceptionInfo(isPermanent = false, message = "GATT request rejected (busy)")
 
     is UnmetRequirementException ->
-        // Bluetooth disabled or runtime permission missing. Both can resolve without re-selecting the
-        // device (user re-enables BT, or grants permission). Surface as transient so the transport keeps
-        // retrying; UI can show a hint based on the message.
-        BleExceptionInfo(isPermanent = false, message = message ?: "Bluetooth LE unavailable")
+        // Keep the reason actionable without forwarding platform exception text or device identifiers.
+        BleExceptionInfo(isPermanent = false, message = reason.toBleAvailabilityMessage())
 
     else -> null
+}
+
+/** Maps Kable's typed availability requirement to fixed, user-actionable text. */
+internal fun UnmetRequirementReason.toBleAvailabilityMessage(): String = when (this) {
+    UnmetRequirementReason.BluetoothDisabled -> "Bluetooth is turned off"
+    UnmetRequirementReason.LocationServicesDisabled -> "Location services are turned off"
+    else -> "Bluetooth LE is unavailable"
 }
 
 /**

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
+import com.juul.kable.UnmetRequirementReason
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,12 +37,13 @@ class BleExceptionClassifierTest {
 
     @Test
     fun `GattStatusException maps to non-permanent with status code`() {
-        val ex = GattStatusException(message = "GATT failure", status = 133)
+        val ex = GattStatusException(message = "GATT failure for AA:BB:CC:DD:EE:FF", status = 133)
         val info = ex.classifyBleException()
         assertNotNull(info)
         assertFalse(info.isPermanent)
         assertEquals(133, info.gattStatus)
-        assertTrue(info.message.contains("133"))
+        assertEquals("GATT error (status 133)", info.message)
+        assertFalse(info.message.contains("AA:BB:CC:DD:EE:FF"))
     }
 
     @Test
@@ -52,6 +54,15 @@ class BleExceptionClassifierTest {
         assertFalse(info.isPermanent)
         assertNull(info.gattStatus)
         assertEquals("Not connected", info.message)
+    }
+
+    @Test
+    fun `unmet requirement reasons map to fixed actionable messages`() {
+        assertEquals("Bluetooth is turned off", UnmetRequirementReason.BluetoothDisabled.toBleAvailabilityMessage())
+        assertEquals(
+            "Location services are turned off",
+            UnmetRequirementReason.LocationServicesDisabled.toBleAvailabilityMessage(),
+        )
     }
 
     @Test

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/HistoryManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/HistoryManagerImpl.kt
@@ -20,6 +20,7 @@ import co.touchlab.kermit.Logger
 import okio.ByteString.Companion.toByteString
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.safeCatching
+import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.repository.HistoryManager
 import org.meshtastic.core.repository.MeshPrefs
 import org.meshtastic.core.repository.PacketHandler
@@ -61,9 +62,7 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
 
     private val logger = Logger.withTag(HISTORY_TAG)
 
-    private fun historyLog(message: String, throwable: Throwable? = null) {
-        logger.i(throwable) { message }
-    }
+    private fun historyLog(message: String) = logger.i { message }
 
     private fun activeDeviceAddress(): String? =
         meshPrefs.deviceAddress.value?.takeIf { !it.equals(NO_DEVICE_SELECTED, ignoreCase = true) && it.isNotBlank() }
@@ -91,7 +90,7 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
         val request = buildStoreForwardHistoryRequest(lastRequest, window, max)
 
         historyLog(
-            "requestHistory trigger=$trigger transport=$transport addr=$address " +
+            "requestHistory trigger=$trigger transport=$transport addr=${address.anonymize()} " +
                 "lastRequest=$lastRequest window=$window max=$max",
         )
 
@@ -106,7 +105,9 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
                 ),
             )
         }
-            .onFailure { ex -> logger.w(ex) { "requestHistory failed" } }
+            .onFailure { failure ->
+                logger.w { "requestHistory failed cause=${failure::class.simpleName ?: "Exception"}" }
+            }
     }
 
     override fun updateStoreForwardLastRequest(source: String, lastRequest: Int, transport: String) {
@@ -117,7 +118,7 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
             meshPrefs.setStoreForwardLastRequest(address, lastRequest)
             historyLog(
                 "historyMarker updated source=$source transport=$transport " +
-                    "addr=$address from=$current to=$lastRequest",
+                    "addr=${address.anonymize()} from=$current to=$lastRequest",
             )
         }
     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -38,6 +38,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
+import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.model.util.toOneLineString
 import org.meshtastic.core.model.util.toPIIString
 import org.meshtastic.core.repository.ConnectionStateProvider
@@ -282,8 +283,8 @@ class PacketHandlerImpl(
     private fun insertMeshLog(packetToSave: MeshLog) {
         scope.handledLaunch {
             Logger.d {
-                "insert: ${packetToSave.message_type} = " +
-                    "${packetToSave.raw_message.toOneLineString()} from=${packetToSave.fromNum}"
+                "insert: ${packetToSave.message_type} " +
+                    "port=${packetToSave.portNum} from=${packetToSave.fromNum.anonymize()}"
             }
             meshLogRepository.value.insert(packetToSave)
         }

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
@@ -29,12 +29,20 @@ import kotlin.test.assertTrue
  * attempt anonymised the hand-written log statements in `core/ble` and missed the Kable `identifier`, which stamps the
  * address onto *every* line the BLE library emits, plus further sites in the DFU transports and WiFi provisioning.
  *
- * Scoped to the BLE-adjacent modules so matching on the `address` suffix stays low-noise.
+ * Scoped to BLE-adjacent modules and the two address-bearing transport/history sources so matching on the `address`
+ * suffix stays low-noise.
  */
 class BleAddressLoggingTest {
 
     private val scannedPathFragments =
-        listOf("/core/ble/", "/feature/firmware/", "/feature/wifi-provision/", "/feature/connections/")
+        listOf(
+            "/core/ble/",
+            "/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/HistoryManagerImpl.kt",
+            "/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt",
+            "/feature/firmware/",
+            "/feature/wifi-provision/",
+            "/feature/connections/",
+        )
 
     /**
      * Files where an address is used as an identity rather than as diagnostic text — building the connection string or
@@ -42,8 +50,11 @@ class BleAddressLoggingTest {
      */
     private val identityUseAllowlist = listOf("DeviceListEntry.kt")
 
-    /** Interpolation of anything ending in `address`, e.g. `${device.address}` or `$address`. */
-    private val interpolatedAddress = Regex("""\$\{?[A-Za-z0-9_.]*[aA]ddress}?""")
+    /** Kotlin identifiers inside a braced interpolation. */
+    private val interpolationIdentifier = Regex("""\b[A-Za-z_][A-Za-z0-9_]*\b""")
+
+    /** Identifiers whose values are already anonymized before interpolation. */
+    private val safeAddressIdentifiers = setOf("logAddress", "anonymizedAddress")
 
     /**
      * Files this rule covers.
@@ -68,27 +79,205 @@ class BleAddressLoggingTest {
             paths.any { it.endsWith("KableBleConnection.kt") },
             "expected core/ble sources in scope; got ${paths.size} files, e.g. ${paths.take(3)}",
         )
+        assertTrue(paths.any { it.endsWith("BleRadioTransport.kt") }, "BLE transport logging escaped the scan")
+        assertTrue(paths.any { it.endsWith("HistoryManagerImpl.kt") }, "history logging escaped the scan")
     }
 
     @Test
     fun `a BLE address is never interpolated into log or exception text without anonymize`() {
         val offenders =
             scannedFiles().flatMap { file ->
-                file.text.lines().withIndex().mapNotNull { (index, line) ->
-                    val isDiagnostic = "Logger." in line || "throw " in line || "check(" in line || "require(" in line
-                    val interpolates = interpolatedAddress.containsMatchIn(line)
-                    val anonymised = "anonymize" in line
-                    if (isDiagnostic && interpolates && !anonymised) {
-                        "${file.path.substringAfterLast("/kotlin/")}:${index + 1}: ${line.trim()}"
-                    } else {
-                        null
-                    }
-                }
+                rawAddressDiagnosticOffenders(file.path.substringAfterLast("/kotlin/"), file.text)
             }
 
         assertTrue(
             offenders.isEmpty(),
             "BLE addresses must be anonymised in diagnostic text. Offending lines:\n" + offenders.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun `an anonymized prefix cannot hide a raw address on the same diagnostic line`() {
+        val sources =
+            listOf(
+                """Logger.w { "${'$'}logAddress failed for ${'$'}address" }""",
+                """Logger.w { "${'$'}{address.anonymize()} failed for ${'$'}address" }""",
+            )
+
+        sources.forEach { source ->
+            val offenders = rawAddressDiagnosticOffenders("MixedAddressFixture.kt", source)
+
+            assertTrue(
+                offenders.isNotEmpty(),
+                "the privacy guard must reject mixed anonymized and raw address tokens: $source",
+            )
+        }
+    }
+
+    @Test
+    fun `a raw address on a diagnostic continuation line is rejected`() {
+        val source =
+            """
+            Logger.w {
+                "connection failed for " +
+                    "${'$'}address"
+            }
+            """
+                .trimIndent()
+
+        val offenders = rawAddressDiagnosticOffenders("ContinuationFixture.kt", source)
+
+        assertTrue(offenders.isNotEmpty(), "the privacy guard must scan the complete multi-line diagnostic")
+    }
+
+    @Test
+    fun `explicitly anonymized address expressions remain valid diagnostics`() {
+        val sources =
+            listOf(
+                """Logger.i { "Targets: ${'$'}{targetAddresses.map { it.anonymize() }}" }""",
+                """Logger.i { "Bonding ${'$'}{entry.device.address.anonymize}" }""",
+                """Logger.i { "${'$'}logAddress connected" }""",
+            )
+
+        sources.forEach { source ->
+            assertTrue(
+                rawAddressDiagnosticOffenders("AnonymizedAddressFixture.kt", source).isEmpty(),
+                "the privacy guard rejected an explicitly anonymized expression: $source",
+            )
+        }
+    }
+
+    private val diagnosticMarkers = listOf("Logger.", "logger.", "historyLog(", "addr=", "throw ", "check(", "require(")
+
+    private fun rawAddressDiagnosticOffenders(path: String, source: String): List<String> {
+        val lines = source.lines()
+        val offenders = mutableListOf<String>()
+        var index = 0
+        while (index < lines.size) {
+            val line = lines[index]
+            if (diagnosticMarkers.any { it in line }) {
+                val block = collectDiagnosticBlock(lines, index)
+                if (containsRawAddressInterpolation(block.joinToString("\n"))) {
+                    offenders += "$path:${index + 1}: ${line.trim()}"
+                }
+                index += block.size
+            } else {
+                index += 1
+            }
+        }
+        return offenders
+    }
+
+    /** Collects one multi-line diagnostic expression, including Logger lambdas and parenthesized calls. */
+    private fun collectDiagnosticBlock(lines: List<String>, start: Int): List<String> {
+        val block = mutableListOf<String>()
+        var delimiterDepth = 0
+        var cursor = start
+        do {
+            val line = lines[cursor]
+            block += line
+            delimiterDepth += delimiterDelta(line)
+            cursor += 1
+        } while (cursor < lines.size && (delimiterDepth > 0 || block.last().trimEnd().endsWith("+")))
+        return block
+    }
+
+    private fun delimiterDelta(line: String): Int =
+        line.count { it == '(' || it == '[' || it == '{' } - line.count { it == ')' || it == ']' || it == '}' }
+
+    /**
+     * Returns true when a string-template interpolation contains more address references than explicit anonymization
+     * operations. Braced expressions are scanned with balanced braces so collection expressions with lambdas remain
+     * intact, while a mixed expression such as `${address.anonymize()} / $address` still exposes the second reference.
+     */
+    private fun containsRawAddressInterpolation(line: String): Boolean {
+        var cursor = 0
+        var rawAddressFound = false
+        while (cursor < line.length && !rawAddressFound) {
+            val dollar = line.indexOf('$', startIndex = cursor)
+            if (dollar < 0 || dollar + 1 >= line.length) {
+                cursor = line.length
+            } else if (line[dollar + 1] == '{') {
+                val end = findInterpolationEnd(line, expressionStart = dollar + 2)
+                if (end < 0) {
+                    rawAddressFound = true
+                } else {
+                    val expression = line.substring(dollar + 2, end)
+                    val residual =
+                        safeAddressIdentifiers.fold(expression) { current, identifier ->
+                            current.replace(Regex("""\b$identifier\b"""), "")
+                        }
+                    val addressReferences =
+                        interpolationIdentifier.findAll(residual).count { match ->
+                            match.value.endsWith("address", ignoreCase = true) ||
+                                match.value.endsWith("addresses", ignoreCase = true)
+                        }
+                    val anonymizations = Regex("""\banonymize\b""").findAll(residual).count()
+                    rawAddressFound = addressReferences > anonymizations
+                    cursor = end + 1
+                }
+            } else {
+                val identifier = line.substring(dollar + 1).takeWhile { it == '_' || it.isLetterOrDigit() }
+                val safe = identifier in safeAddressIdentifiers
+                val addressLike =
+                    identifier.endsWith("address", ignoreCase = true) ||
+                        identifier.endsWith("addresses", ignoreCase = true)
+                rawAddressFound = identifier.isNotEmpty() && addressLike && !safe
+                cursor = dollar + 1 + identifier.length
+            }
+        }
+        return rawAddressFound
+    }
+
+    private fun findInterpolationEnd(line: String, expressionStart: Int): Int {
+        var depth = 1
+        for (index in expressionStart until line.length) {
+            when (line[index]) {
+                '{' -> depth += 1
+
+                '}' -> {
+                    depth -= 1
+                    if (depth == 0) return index
+                }
+            }
+        }
+        return -1
+    }
+
+    @Test
+    fun `privacy-sensitive BLE diagnostics never forward arbitrary throwable text`() {
+        val throwableLoggerCall = Regex("""(?:Logger|logger)\.[vdiwe]\s*\(""")
+        val protectedFiles = setOf("BleRadioTransport.kt", "HistoryManagerImpl.kt")
+        val offenders =
+            scannedFiles()
+                .filter { file -> protectedFiles.any { file.path.endsWith(it) } }
+                .flatMap { file ->
+                    file.text.lines().withIndex().mapNotNull { (index, line) ->
+                        line.takeIf(throwableLoggerCall::containsMatchIn)?.let {
+                            "${file.path.substringAfterLast("/kotlin/")}:${index + 1}: ${line.trim()}"
+                        }
+                    }
+                }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "BLE diagnostics must log curated failure types, not throwable messages. Offending lines:\n" +
+                offenders.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun `BLE transport diagnostic identifiers are derived from the anonymized address`() {
+        val source =
+            scannedFiles().single { it.path.endsWith("BleRadioTransport.kt") }.text.replace(Regex("""\s+"""), " ")
+
+        assertTrue(
+            Regex("""val\s+anonymizedAddress\s*=\s*address\.anonymize\(\)""").containsMatchIn(source),
+            "BLE transport must derive its diagnostic identifier through anonymize()",
+        )
+        assertTrue(
+            Regex("""val\s+logAddress\s*=\s*"\[\$\{?anonymizedAddress}?]"""").containsMatchIn(source),
+            "BLE transport log prefix must use only the anonymized identifier",
         )
     }
 

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -65,6 +65,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private const val SCAN_RETRY_COUNT = 3
+private const val MAX_LOG_CAUSE_DEPTH = 6
 private val SCAN_RETRY_DELAY = 1.seconds
 private val CONNECTION_TIMEOUT = 15.seconds
 
@@ -148,8 +149,11 @@ class BleRadioTransport(
     private val bluetoothRepository: BluetoothRepository,
     private val connectionFactory: BleConnectionFactory,
     private val callback: RadioTransportCallback,
-    internal val address: String,
+    private val address: String,
 ) : RadioTransport {
+
+    private val anonymizedAddress = address.anonymize()
+    private val logAddress = "[$anonymizedAddress]"
 
     // Detached cleanup scope for last-ditch GATT teardown from the exception handler.
     // Must NOT be a child of `scope`: when an uncaught exception fires in connectionScope,
@@ -160,7 +164,7 @@ class BleRadioTransport(
     private val cleanupScope: CoroutineScope = CoroutineScope(SupervisorJob() + scope.coroutineContext.minusKey(Job))
 
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        Logger.w(throwable) { "[$address] Uncaught exception in connectionScope" }
+        Logger.w { "$logAddress Uncaught exception in connectionScope cause=${throwable.safeLogType()}" }
         if (throwable !is CancellationException) {
             // Record the cause BEFORE the CAS so there is no window where another coroutine
             // sees sessionFailed == true but sessionFailureCause == null. first-cause is
@@ -177,7 +181,7 @@ class BleRadioTransport(
             try {
                 bleConnection.disconnect()
             } catch (e: Exception) {
-                Logger.w(e) { "[$address] Failed to disconnect in exception handler" }
+                Logger.w { "$logAddress Failed to disconnect in exception handler cause=${e.safeLogType()}" }
             }
         }
     }
@@ -225,7 +229,7 @@ class BleRadioTransport(
                 delay(HEARTBEAT_DRAIN_DELAY)
                 radioService?.requestDrain()
             },
-            logTag = address,
+            logTag = anonymizedAddress,
         )
 
     override fun start() {
@@ -244,9 +248,9 @@ class BleRadioTransport(
             // Use one bounded, address-filtered scan. Splitting this into a short scan plus an escalated scan consumed
             // two Android scanner registrations per reconnect and could hit SCAN_FAILED_SCANNING_TOO_FREQUENTLY when a
             // user switched devices while the reconnect policy and the Connections screen were also scanning.
-            Logger.i { "[${address.anonymize()}] Bonded device found; scanning once for a fresh advertisement" }
+            Logger.i { "$logAddress Bonded device found; scanning once for a fresh advertisement" }
             scanForFreshDevice(SCAN_TIMEOUT)?.let {
-                Logger.i { "[${address.anonymize()}] Fresh advertisement found; using scanned device" }
+                Logger.i { "$logAddress Fresh advertisement found; using scanned device" }
                 return it
             }
 
@@ -255,14 +259,14 @@ class BleRadioTransport(
             // This remains bounded by CONNECTION_TIMEOUT in connectAndAwait(), after which BleReconnectPolicy owns
             // retry/backoff.
             Logger.w {
-                "[${address.anonymize()}] No fresh advertisement within $SCAN_TIMEOUT; " +
+                "$logAddress No fresh advertisement within $SCAN_TIMEOUT; " +
                     "falling back to bonded handle for bounded autoConnect"
             }
             return bondedDevice
         }
 
         // Non-bonded path: preserve existing retry behavior (SCAN_RETRY_COUNT attempts at SCAN_TIMEOUT).
-        Logger.i { "[${address.anonymize()}] Device not found in bonded list, scanning" }
+        Logger.i { "$logAddress Device not found in bonded list, scanning" }
         repeat(SCAN_RETRY_COUNT) { attempt ->
             scanForFreshDevice(SCAN_TIMEOUT)?.let {
                 return it
@@ -271,7 +275,8 @@ class BleRadioTransport(
                 delay(SCAN_RETRY_DELAY)
             }
         }
-        throw RadioNotConnectedException("Device not found at address $address")
+        Logger.w { "$logAddress Selected radio was not found after BLE scan retries" }
+        throw RadioNotConnectedException("Selected radio was not found")
     }
 
     /**
@@ -299,7 +304,7 @@ class BleRadioTransport(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        Logger.v(e) { "[${address.anonymize()}] Scan failed (timeout=$timeout)" }
+        Logger.v { "$logAddress Scan failed (timeout=$timeout) cause=${e.safeLogType()}" }
         null
     }
 
@@ -314,7 +319,7 @@ class BleRadioTransport(
                             throw e
                         } catch (e: Exception) {
                             val failureTime = (nowMillis - connectionStartTime).milliseconds
-                            Logger.w(e) { "[$address] Failed to connect after $failureTime" }
+                            Logger.w { "$logAddress Failed to connect after $failureTime cause=${e.safeLogType()}" }
                             BleReconnectPolicy.Outcome.Failed(e)
                         }
                     },
@@ -325,8 +330,11 @@ class BleRadioTransport(
                         // a modal dialog would just confuse the user. The warning log is the
                         // observability surface for this transient event.
                         if (!sessionFailed.value) {
-                            error?.let {
-                                Logger.w(it) { "[$address] BLE reconnect attempt failed; continuing automatic retry" }
+                            error?.let { failure ->
+                                Logger.w {
+                                    "$logAddress BLE reconnect attempt failed; continuing automatic retry " +
+                                        "cause=${failure.safeLogType()}"
+                                }
                             }
                             callback.onDisconnect(isPermanent = false)
                         }
@@ -352,7 +360,7 @@ class BleRadioTransport(
         connectionStartTime = nowMillis
         sessionFailed.value = false
         sessionFailureCause = null
-        Logger.i { "[$address] BLE connection attempt started" }
+        Logger.i { "$logAddress BLE connection attempt started" }
 
         val device = findDevice()
 
@@ -361,7 +369,8 @@ class BleRadioTransport(
         val state = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
 
         if (state !is BleConnectionState.Connected) {
-            throw RadioNotConnectedException("Failed to connect to device at address $address")
+            Logger.w { "$logAddress BLE connection completed without a connected state: $state" }
+            throw RadioNotConnectedException("Failed to connect to the selected radio")
         }
 
         // Post-OTA GATT cache invalidation: the device rebooted with potentially different
@@ -370,11 +379,9 @@ class BleRadioTransport(
         val radioServiceForCache = callback as? RadioInterfaceService
         if (radioServiceForCache?.consumeGattCacheInvalidationRequest() == true) {
             val invalidated = bleConnection.invalidateServiceCache()
-            Logger.d { "[${address.anonymize()}] Post-OTA GATT cache invalidation requested: $invalidated" }
+            Logger.d { "$logAddress Post-OTA GATT cache invalidation requested: $invalidated" }
             if (invalidated) {
-                Logger.i {
-                    "[${address.anonymize()}] Reconnecting after GATT cache refresh to force service rediscovery"
-                }
+                Logger.i { "$logAddress Reconnecting after GATT cache refresh to force service rediscovery" }
                 bleConnection.disconnect()
                 delay(POST_INVALIDATION_RECONNECT_DELAY)
                 val reconnectState = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
@@ -383,7 +390,7 @@ class BleRadioTransport(
                         "Failed to reconnect after post-OTA GATT cache refresh (state=$reconnectState)",
                     )
                 }
-                Logger.i { "[${address.anonymize()}] Reconnected after GATT cache refresh" }
+                Logger.i { "$logAddress Reconnected after GATT cache refresh" }
             }
         }
 
@@ -395,11 +402,13 @@ class BleRadioTransport(
 
         // If a fatal session failure (fromRadio/logRadio error) forced disconnect during setup,
         // skip the Connected gate — return a retryable failure so BleReconnectPolicy handles it.
-        if (sessionFailureCause != null) {
-            Logger.w(sessionFailureCause) {
-                "[$address] Session failed during profile setup — returning failed outcome"
+        val setupFailure = sessionFailureCause
+        if (setupFailure != null) {
+            Logger.w {
+                "$logAddress Session failed during profile setup — returning failed outcome " +
+                    "cause=${setupFailure.safeLogType()}"
             }
-            return BleReconnectPolicy.Outcome.Failed(sessionFailureCause ?: RuntimeException("Session setup failed"))
+            return BleReconnectPolicy.Outcome.Failed(setupFailure)
         }
 
         // Wait for the StateFlow to actually reflect Connected before watching for the next
@@ -421,7 +430,10 @@ class BleRadioTransport(
             }
         if (connectedReached == null) {
             val failure = sessionFailureCause ?: RuntimeException("Timed out waiting for Connected state gate")
-            Logger.w(failure) { "[$address] Session failed before Connected gate — returning failed outcome" }
+            Logger.w {
+                "$logAddress Session failed before Connected gate — returning failed outcome " +
+                    "cause=${failure.safeLogType()}"
+            }
             // CRITICAL: force GATT cleanup before returning Failed so we don't start a new
             // attempt over an uncleared session. Without this, a timeout caused by flow lag or
             // a stale-Disconnected state mismatch would leave a live/half-live GATT handle behind.
@@ -431,7 +443,10 @@ class BleRadioTransport(
                 try {
                     bleConnection.disconnect()
                 } catch (ignored: Exception) {
-                    Logger.w(ignored) { "[$address] disconnect() failed during Connected-gate timeout cleanup" }
+                    Logger.w {
+                        "$logAddress disconnect() failed during Connected-gate timeout cleanup " +
+                            "cause=${ignored.safeLogType()}"
+                    }
                 }
             }
             return BleReconnectPolicy.Outcome.Failed(failure)
@@ -449,14 +464,16 @@ class BleRadioTransport(
             onDisconnected()
         }
 
-        Logger.i { "[$address] BLE connection dropped (reason: $disconnectReason), preparing to reconnect" }
+        Logger.i { "$logAddress BLE connection dropped (reason: $disconnectReason), preparing to reconnect" }
 
         // Internal session failures (write/read exceptions that triggered handleFailure →
         // disconnect) must NOT be treated as intentional/user disconnects — the reconnect policy
         // needs to escalate backoff for these.
         val internalFailure = sessionFailureCause
         if (internalFailure != null) {
-            Logger.w(internalFailure) { "[$address] Session forced disconnect due to internal failure" }
+            Logger.w {
+                "$logAddress Session forced disconnect due to internal failure cause=${internalFailure.safeLogType()}"
+            }
         }
         val wasIntentional =
             if (internalFailure != null) {
@@ -469,7 +486,7 @@ class BleRadioTransport(
 
         if (!wasStable && !wasIntentional) {
             Logger.w {
-                "[$address] Connection lasted only $connectionUptime " +
+                "$logAddress Connection lasted only $connectionUptime " +
                     "(< ${reconnectPolicy.minStableConnection}) — treating as unstable"
             }
         }
@@ -482,10 +499,10 @@ class BleRadioTransport(
 
         // Bond before connecting: firmware may require an encrypted link, and without a bond Android fails with
         // status 5 or 133. Non-Android targets use repository-specific no-op behavior.
-        Logger.i { "[$address] Device not bonded, initiating bonding" }
+        Logger.i { "$logAddress Device not bonded, initiating bonding" }
         try {
             bluetoothRepository.bond(device)
-            Logger.i { "[$address] Bonding successful" }
+            Logger.i { "$logAddress Bonding successful" }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -493,9 +510,14 @@ class BleRadioTransport(
             // setup. If the device is still not bonded, continuing would fail later with a cryptic status (5/133), so
             // stop now and let BleReconnectPolicy own the retry/backoff.
             if (bluetoothRepository.isBonded(address)) {
-                Logger.w(e) { "[$address] Bonding reported failure but device is bonded; continuing" }
+                Logger.w {
+                    "$logAddress Bonding reported failure but device is bonded; continuing cause=${e.safeLogType()}"
+                }
             } else {
-                Logger.w(e) { "[$address] Bonding failed and device is still not bonded; stopping connection attempt" }
+                Logger.w {
+                    "$logAddress Bonding failed and device is still not bonded; stopping connection attempt " +
+                        "cause=${e.safeLogType()}"
+                }
                 throw RadioNotConnectedException("Bonding failed and device is still not bonded", e)
             }
         }
@@ -504,16 +526,13 @@ class BleRadioTransport(
     private suspend fun onConnected() {
         try {
             bleConnection.deviceFlow.first()?.let { device ->
-                val rssi = retryBleOperation(tag = address) { device.readRssi() }
-                Logger.d {
-                    "[${address.anonymize()}] Connection confirmed. " +
-                        "Initial RSSI: ${rssi?.let { "$it dBm" } ?: "unknown"}"
-                }
+                val rssi = retryBleOperation(tag = anonymizedAddress) { device.readRssi() }
+                Logger.d { "$logAddress Connection confirmed. Initial RSSI: ${rssi?.let { "$it dBm" } ?: "unknown"}" }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Logger.w(e) { "[$address] Failed to read initial connection RSSI" }
+            Logger.w { "$logAddress Failed to read initial connection RSSI cause=${e.safeLogType()}" }
         }
     }
 
@@ -526,7 +545,7 @@ class BleRadioTransport(
         // onDisconnect calls (one with the real error message from handleFailure, one
         // generic from here).
         val firstWriter = sessionFailed.compareAndSet(expect = false, update = true)
-        Logger.i { "[$address] BLE disconnected - ${formatSessionStats()}" }
+        Logger.i { "$logAddress BLE disconnected - ${formatSessionStats()}" }
         if (firstWriter) {
             // Signal immediately so the UI reflects the disconnect while reconnect continues.
             callback.onDisconnect(isPermanent = false)
@@ -541,29 +560,29 @@ class BleRadioTransport(
 
                 radioService.fromRadio
                     .onEach { packet ->
-                        Logger.v { "[$address] Received packet fromRadio (${packet.size} bytes)" }
+                        Logger.v { "$logAddress Received packet fromRadio (${packet.size} bytes)" }
                         dispatchPacket(packet)
                     }
                     .catch { e ->
-                        Logger.w(e) { "[$address] Error in fromRadio flow" }
+                        Logger.w { "$logAddress Error in fromRadio flow cause=${e.safeLogType()}" }
                         handleFailure(e)
                     }
                     .launchIn(this)
 
                 radioService.logRadio
                     .onEach { packet ->
-                        Logger.v { "[$address] Received packet logRadio (${packet.size} bytes)" }
+                        Logger.v { "$logAddress Received packet logRadio (${packet.size} bytes)" }
                         dispatchPacket(packet)
                     }
                     .catch { e ->
-                        Logger.w(e) { "[$address] Error in logRadio flow" }
+                        Logger.w { "$logAddress Error in logRadio flow cause=${e.safeLogType()}" }
                         handleFailure(e)
                     }
                     .launchIn(this)
 
                 this@BleRadioTransport.radioService = radioService
 
-                Logger.i { "[$address] Profile service active and characteristics subscribed" }
+                Logger.i { "$logAddress Profile service active and characteristics subscribed" }
 
                 // Wait for FROMNUM CCCD write before triggering the Meshtastic handshake.
                 // Bounded: if fromRadio fails before subscriptionReady completes, handleFailure
@@ -579,16 +598,16 @@ class BleRadioTransport(
                 if (!subscriptionReady || sessionFailed.value) {
                     val cause =
                         sessionFailureCause ?: RuntimeException("Timed out waiting for FROMNUM subscription readiness")
-                    Logger.w(cause) {
+                    Logger.w {
                         val reason = if (!subscriptionReady) "timed out" else "failed"
-                        "[$address] Subscription wait $reason — aborting setup"
+                        "$logAddress Subscription wait $reason — aborting setup cause=${cause.safeLogType()}"
                     }
                     throw cause
                 }
 
                 // Log negotiated MTU for diagnostics
                 val maxLen = bleConnection.maximumWriteValueLength(BleWriteType.WITHOUT_RESPONSE)
-                Logger.i { "[$address] BLE Radio Session Ready. Max write length (WITHOUT_RESPONSE): $maxLen bytes" }
+                Logger.i { "$logAddress BLE Radio Session Ready. Max write length (WITHOUT_RESPONSE): $maxLen bytes" }
 
                 requestHighPriorityAndScheduleDowngrade()
 
@@ -616,7 +635,7 @@ class BleRadioTransport(
                 if (!sessionFailed.value) {
                     this@BleRadioTransport.callback.onConnect()
                 } else {
-                    Logger.w { "[$address] Session failed during setup — skipping onConnect" }
+                    Logger.w { "$logAddress Session failed during setup — skipping onConnect" }
                 }
             }
         } catch (e: CancellationException) {
@@ -628,12 +647,14 @@ class BleRadioTransport(
                 try {
                     bleConnection.disconnect()
                 } catch (ignored: Exception) {
-                    Logger.w(ignored) { "[$address] disconnect() failed during cancellation cleanup" }
+                    Logger.w {
+                        "$logAddress disconnect() failed during cancellation cleanup cause=${ignored.safeLogType()}"
+                    }
                 }
             }
             throw e
         } catch (e: Exception) {
-            Logger.w(e) { "[$address] Profile service discovery or operation failed" }
+            Logger.w { "$logAddress Profile service discovery or operation failed cause=${e.safeLogType()}" }
             // Clear stale state so the next attempt starts clean — if failure happened after
             // radioService assignment but before callback.onConnect(), stale state would survive.
             radioService = null
@@ -642,7 +663,7 @@ class BleRadioTransport(
                 try {
                     bleConnection.disconnect()
                 } catch (ignored: Exception) {
-                    Logger.w(ignored) { "[$address] disconnect() failed after profile error" }
+                    Logger.w { "$logAddress disconnect() failed after profile error cause=${ignored.safeLogType()}" }
                 }
             }
             throw e // Re-throw so attemptConnection() returns Outcome.Failed(e) for policy backoff.
@@ -655,14 +676,14 @@ class BleRadioTransport(
      */
     private suspend fun CoroutineScope.requestHighPriorityAndScheduleDowngrade() {
         if (bleConnection.requestHighConnectionPriority()) {
-            Logger.d { "[$address] Requested high BLE connection priority" }
+            Logger.d { "$logAddress Requested high BLE connection priority" }
             // Wait for the connection parameter update before starting heavy traffic.
             delay(1.seconds)
         }
         launch {
             delay(PRIORITY_DOWNGRADE_DELAY)
             if (bleConnection.requestBalancedConnectionPriority()) {
-                Logger.d { "[$address] Downgraded to balanced BLE connection priority" }
+                Logger.d { "$logAddress Downgraded to balanced BLE connection priority" }
             }
         }
     }
@@ -686,7 +707,7 @@ class BleRadioTransport(
     override fun handleSendToRadio(p: ByteArray) {
         // Fast-path check: skip coroutine launch entirely if no transport is active.
         if (radioService == null) {
-            Logger.w { "[$address] toRadio characteristic unavailable, can't send data" }
+            Logger.w { "$logAddress toRadio characteristic unavailable, can't send data" }
             return
         }
         connectionScope.launch {
@@ -697,17 +718,17 @@ class BleRadioTransport(
                 val currentService =
                     radioService
                         ?: run {
-                            Logger.w { "[$address] toRadio characteristic cleared during write queue" }
+                            Logger.w { "$logAddress toRadio characteristic cleared during write queue" }
                             return@withLock
                         }
                 try {
-                    retryBleOperation(tag = address, retryWhile = { currentService === radioService }) {
+                    retryBleOperation(tag = anonymizedAddress, retryWhile = { currentService === radioService }) {
                         currentService.sendToRadio(p)
                     }
                     val sent = packetsSent.incrementAndGet()
                     val txBytes = bytesSent.addAndGet(p.size.toLong())
                     Logger.v {
-                        "[$address] Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $txBytes bytes)"
+                        "$logAddress Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $txBytes bytes)"
                     }
                 } catch (e: CancellationException) {
                     throw e
@@ -716,13 +737,16 @@ class BleRadioTransport(
                     // If radioService was replaced (new reconnect cycle) or cleared (handleFailure
                     // already ran), this is a stale write from the old session — silently discard.
                     if (currentService === radioService) {
-                        Logger.w(e) {
-                            "[$address] Failed to write packet to toRadioCharacteristic after " +
-                                "${packetsSent.value} successful writes"
+                        Logger.w {
+                            "$logAddress Failed to write packet to toRadioCharacteristic after " +
+                                "${packetsSent.value} successful writes cause=${e.safeLogType()}"
                         }
                         handleFailure(e)
                     } else {
-                        Logger.d(e) { "[$address] Stale write failure ignored because the session was replaced" }
+                        Logger.d {
+                            "$logAddress Stale write failure ignored because the session was replaced " +
+                                "cause=${e.safeLogType()}"
+                        }
                     }
                 }
             }
@@ -738,7 +762,7 @@ class BleRadioTransport(
 
     /** Closes the connection to the device. */
     override suspend fun close() {
-        Logger.i { "[$address] Disconnecting. ${formatSessionStats()}" }
+        Logger.i { "$logAddress Disconnecting. ${formatSessionStats()}" }
         connectionScope.cancel()
         // GATT cleanup must run under NonCancellable so a cancelled caller cannot skip it,
         // which would leak BluetoothGatt and trigger status 133 on the next reconnect.
@@ -748,7 +772,7 @@ class BleRadioTransport(
             try {
                 withTimeoutOrNull(GATT_CLEANUP_TIMEOUT) { bleConnection.disconnect() }
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                Logger.w(e) { "[$address] Failed to disconnect in close()" }
+                Logger.w { "$logAddress Failed to disconnect in close() cause=${e.safeLogType()}" }
             }
         }
         // Our own disconnect succeeded — the exception-handler safety net is no longer
@@ -760,7 +784,7 @@ class BleRadioTransport(
     private fun dispatchPacket(packet: ByteArray) {
         val received = packetsReceived.incrementAndGet()
         val rxBytes = bytesReceived.addAndGet(packet.size.toLong())
-        Logger.v { "[$address] Dispatching packet #$received " + "(${packet.size} bytes, total RX: $rxBytes bytes)" }
+        Logger.v { "$logAddress Dispatching packet #$received " + "(${packet.size} bytes, total RX: $rxBytes bytes)" }
         callback.handleFromRadio(packet)
     }
 
@@ -800,7 +824,7 @@ class BleRadioTransport(
         // user-facing.
         callback.onDisconnect(isPermanent, errorMessage = if (isPermanent) msg else null)
 
-        Logger.w(throwable) { "[$address] Session failure — forcing cleanup for reconnect" }
+        Logger.w { "$logAddress Session failure — forcing cleanup for reconnect cause=${throwable.safeLogType()}" }
 
         // Force GATT disconnect on the detached cleanupScope (matching the pattern used by
         // the exceptionHandler defined above). This causes Kable's connectionState
@@ -809,7 +833,7 @@ class BleRadioTransport(
             try {
                 bleConnection.disconnect()
             } catch (e: Exception) {
-                Logger.w(e) { "[$address] Failed to disconnect after session failure" }
+                Logger.w { "$logAddress Failed to disconnect after session failure cause=${e.safeLogType()}" }
             }
         }
     }
@@ -838,5 +862,26 @@ class BleRadioTransport(
                 else -> this.message ?: this::class.simpleName ?: "Unknown"
             }
         return false to msg
+    }
+
+    /** Retains actionable BLE status and exception type without forwarding platform text or device identifiers. */
+    private fun Throwable.safeLogType(): String {
+        val outerType = this::class.simpleName ?: "Exception"
+        var current: Throwable? = this
+        var classifiedType: String? = null
+        var remainingDepth = MAX_LOG_CAUSE_DEPTH
+        while (current != null && classifiedType == null && remainingDepth > 0) {
+            val failure = current
+            val info = failure.classifyBleException()
+            if (info != null) {
+                val bleType = failure::class.simpleName ?: "BleException"
+                val classified = info.gattStatus?.let { "$bleType(status=$it)" } ?: bleType
+                classifiedType = if (failure === this) classified else "$outerType(cause=$classified)"
+            } else {
+                current = failure.cause
+            }
+            remainingDepth--
+        }
+        return classifiedType ?: outerType
     }
 }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.ble.MeshtasticBleConstants.FROMNUM_CHARACTERISTIC
 import org.meshtastic.core.ble.MeshtasticBleConstants.FROMRADIO_CHARACTERISTIC
@@ -72,7 +73,7 @@ class BleRadioTransportTest {
 
         val bleTransport =
             BleRadioTransport(
-                scope = testScope,
+                scope = backgroundScope,
                 scanner = scanner,
                 bluetoothRepository = bluetoothRepository,
                 connectionFactory = connectionFactory,
@@ -81,27 +82,12 @@ class BleRadioTransportTest {
             )
         bleTransport.start()
         try {
-            // start() begins connect() which is async
-            // In a real test we'd verify the connection state,
-            // but for now this confirms it works with the fakes.
-            assertEquals(address, bleTransport.address)
+            advanceTimeBy(BleReconnectPolicy.DEFAULT_SETTLE_DELAY.inWholeMilliseconds)
+            runCurrent()
+            assertEquals(address, scanner.lastScanAddress)
         } finally {
             bleTransport.close()
         }
-    }
-
-    @Test
-    fun `address returns correct value`() {
-        val bleTransport =
-            BleRadioTransport(
-                scope = testScope,
-                scanner = scanner,
-                bluetoothRepository = bluetoothRepository,
-                connectionFactory = connectionFactory,
-                callback = service,
-                address = address,
-            )
-        assertEquals(address, bleTransport.address)
     }
 
     /**


### PR DESCRIPTION
## Summary by Sourcery

Improve BLE transport and packet handling logging to consistently use anonymized identifiers and redact sensitive data.

Enhancements:
- Introduce reusable anonymized BLE address/log tag in BleRadioTransport and apply it across connection, scanning, bonding, and session lifecycle logs.
- Adjust BLE retry operations to use anonymized tags instead of raw device addresses for observability.
- Simplify MeshLog insertion debug output to avoid raw message contents and include port plus anonymized sender ID.