### PR TITLE
fix(map): detach F-Droid map views on disposal

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,149 +1,16 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: en-US
-
+early_access: true
 reviews:
-  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
-  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
-  profile: chill
+  profile: assertive
+  request_changes_workflow: false
   high_level_summary: true
-  poem: false
-  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
-  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
-    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
-    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
-    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
-    auto_incremental_review: false
-    ignore_usernames:
-      - renovate
-      - renovate[bot]
-      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
-      # translation bumps) — machine-generated content, nothing to review.
-      - github-actions
-      - github-actions[bot]
-    ignore_title_keywords:
-      - "chore: Scheduled updates"
-  # Stop reviewing once a PR is closed.
-  abort_on_close: true
-
-  path_filters:
-    # Generated / huge / non-source — don't review, just noise + token burn.
-    - "!**/build/**"
-    - "!**/*.png"
-    - "!**/*.webp"
-    - "!**/firmware_releases.json"
-    - "!**/emoji-data.json"
-    - "!**/flatpak-sources.json"
-    # Crowdin-managed translations — owned upstream, not hand-edited here.
-    - "!**/values-*/strings.xml"
-    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
-    - "!.specify/**"
-
-  path_instructions:
-    - path: "**/commonMain/**"
-      instructions: >
-        KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
-    - path: "**/*.kt"
-      instructions: >
-        Flag leftover // ... existing code ... placeholders, and any logging of PII, location, or cryptographic keys.
-    - path: "**/src/**/strings.xml"
-      instructions: >
-        New string resources must be alphabetically sorted (scripts/sort-strings.py). Flag out-of-order additions.
-    - path: baselineprofile/
-      instructions: Keep baseline profile generation tied to the `google` flavor and connected devices/emulators, and commit the generated profile output to `androidApp/src/google/generated/baselineProfiles/baseline-prof.txt`.
-    - path: docs/
-      instructions: Treat non-English locale folders as Crowdin-managed output; edit the English sources under `docs/en/` and register new pages through `feature/docs/` instead of hand-editing translated locale directories.
-    - path: screenshot-tests/
-      instructions: When updating docs screenshots, keep `docs-screenshots-manifest.txt` and `docs-screenshot-aliases.properties` in sync with the generated files, and rerun `copyDocsScreenshots` after regenerating screenshots.
-    - path: docs-screenshots/
-      instructions: Keep this module generate-only for documentation screenshots; do not add it to the CI validation gate that is reserved for `screenshot-tests`.
-    - path: desktopApp/
-      instructions: Keep desktop release ProGuard rules aligned with `androidApp/proguard-rules.pro`, and preserve the desktop-specific runtime wiring needed for `Dispatchers.Main` on JVM.
-    - path: androidApp/
-      instructions: Keep the Android app’s `MeshService` declaration and manifest wiring in sync with the implementation that lives in `core:service`.
-    - path: core/service/
-      instructions: Keep `RadioControllerImpl` composed from its sub-controllers via interface delegation; admin sends are fire-and-forget, and any config mutation must go through `editSettings { }` transactions.
-    - path: feature/docs/
-      instructions: Treat the Compose resources under `src/commonMain/composeResources/files/` as generated output from `/docs/en/**` and translated docs sync tasks; do not hand-edit those copied files.
-    - path: feature/map/
-      instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
-    - path: feature/car/
-      instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
-
-  # Every CodeRabbit tool is enabled by default, so this block only ever needs to
-  # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
-  # Tolerance gate) and duplicate comments were the noise we removed. The scanners
-  # CI doesn't run — gitleaks, shellcheck, actionlint, zizmor, semgrep, trivy,
-  # presidio (PII), buf (protobuf) — are already on by default; don't re-list them.
-  tools:
-    detekt:
-      enabled: false
-    # Custom AST rules mechanically enforce the recurring defect classes that prose
-    # can't. See .coderabbit/ast-grep-rules/ and .skills/code-review/SKILL.md.
-    # essential_rules stays on (default) — these are additive.
-    ast-grep:
-      rule_dirs:
-        - ".coderabbit/ast-grep-rules"
-
-  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
-  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
-  finishing_touches:
-    docstrings:
-      enabled: false
-    unit_tests:
-      enabled: false
-
-  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR. PR titles are already linted by CI
-  # (.github/workflows/pull-request-target.yml), so no title check here either.
-  pre_merge_checks:
-    docstrings:
-      mode: "off"
-    # The two defect classes that survive review-by-prose because they are about
-    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
-    # would still pass with the fix reverted. Warning, not error: these are
-    # judgment calls and a false positive must not block a merge.
-    custom_checks:
-      - name: "Sibling call sites and presence semantics"
-        mode: "warning"
-        instructions: >-
-          When a diff changes how an absent value is represented — making a field nullable,
-          removing a zero-guard, or adding a presence check — verify EVERY call site of that
-          field was updated, not just the one the bug was reported against. Ambient temperature
-          was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
-          Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
-          a physically reachable value on that scale (RSSI, temperature, current, voltage,
-          particulate concentration). Two exceptions, do NOT flag either: humidity, where 0 %RH
-          is unreachable and the guard is intentional and tested; and the proto `rx_snr`, which
-          has no presence upstream, so its 0f ambiguity cannot be fixed app-side. An app-level
-          SNR field that IS nullable is still in scope.
-      - name: "Tests prove the path, not the end state"
-        mode: "warning"
-        instructions: >-
-          For each added or changed test, decide whether it would still pass if the production
-          code it covers were reverted. Flag tests that seed a fake's backing store and then
-          assert the value comes back, tests that assert only a collection's size rather than
-          which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
-          (not a stable contract). A test must assert the side effect only the intended path
-          produces — a call counter, a request issued, a cache written.
-
-knowledge_base:
-  # Learnings are how a confirmed finding stops recurring on the next PR. Pin the
-  # scope to this repo: the default `auto` already resolves to `local` for public
-  # repos, but being explicit keeps it from shifting if visibility ever changes.
-  learnings:
-    scope: local
-  # Feed CodeRabbit the same guidance human/AI contributors follow, including
-  # the repo-specific .skills/ modules and Copilot path instructions it
-  # wouldn't pick up by default.
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - ".skills/**/SKILL.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/*.instructions.md"
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,7 +18,6 @@ jobs:
   # (folded into this job rather than run standalone: runner-pool slots, not
   # compute, are the scarce resource during queue bursts).
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -73,6 +73,13 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'test.gradle.kts'
+
+  # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
+  verify-check-changes-filter:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
       - name: Verify module roots are represented in check-changes filter
         run: |
           python3 - <<'PY'

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ build-scan-*.scan
 # Python bytecode from scripts/
 __pycache__/
 *.pyc
+.omo/*
+.commandcode

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
@@ -18,6 +18,7 @@ package org.meshtastic.app.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +40,8 @@ import org.osmdroid.views.MapView
 private const val MIN_ZOOM_LEVEL = 1.5
 private const val MAX_ZOOM_LEVEL = 20.0
 private const val DEFAULT_ZOOM_LEVEL = 15.0
+
+private class MapViewReference(var current: MapView? = null)
 
 @Suppress("MagicNumber")
 @Composable
@@ -76,54 +79,81 @@ internal fun rememberMapViewWithLifecycle(
         }
 
     val context = LocalContext.current
-    val mapView = remember {
-        MapView(context).apply {
-            clipToOutline = true
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycle = lifecycleOwner.lifecycle
+    val mapViewReference = remember { MapViewReference() }
+    val mapView =
+        remember(context, lifecycle) {
+            // Keyed remember creates the replacement before the old DisposableEffect is disposed. Read the live
+            // viewport directly so an unsaved pan or zoom survives a context or lifecycle-owner replacement.
+            val previousMapView = mapViewReference.current?.takeIf { it.width > 0 && it.height > 0 }
+            val initialCenter = previousMapView?.projection?.currentCenter ?: savedCenter
+            val initialZoom = previousMapView?.zoomLevelDouble ?: savedZoom
+            MapView(context)
+                .apply {
+                    clipToOutline = true
 
-            setTileSource(tileSource)
-            isVerticalMapRepetitionEnabled = false // disables map repetition
-            setMultiTouchControls(true)
-            val bounds = overlayManager.tilesOverlay.bounds // bounds scrollable map
-            setScrollableAreaLimitLatitude(bounds.actualNorth, bounds.actualSouth, 0)
-            // scales the map tiles to the display density of the screen
-            isTilesScaledToDpi = true
-            // sets the minimum zoom level (the furthest out you can zoom)
-            minZoomLevel = MIN_ZOOM_LEVEL
-            maxZoomLevel = MAX_ZOOM_LEVEL
-            // Disables default +/- button for zooming
-            zoomController.setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT)
+                    setTileSource(tileSource)
+                    isVerticalMapRepetitionEnabled = false // disables map repetition
+                    setMultiTouchControls(true)
+                    val bounds = overlayManager.tilesOverlay.bounds // bounds scrollable map
+                    setScrollableAreaLimitLatitude(bounds.actualNorth, bounds.actualSouth, 0)
+                    // scales the map tiles to the display density of the screen
+                    isTilesScaledToDpi = true
+                    // sets the minimum zoom level (the furthest out you can zoom)
+                    minZoomLevel = MIN_ZOOM_LEVEL
+                    maxZoomLevel = MAX_ZOOM_LEVEL
+                    // Disables default +/- button for zooming
+                    zoomController.setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT)
 
-            controller.setZoom(savedZoom)
-            controller.setCenter(savedCenter)
+                    controller.setZoom(initialZoom)
+                    controller.setCenter(initialCenter)
+                }
+                .also { mapViewReference.current = it }
         }
-    }
-    val lifecycle = LocalLifecycleOwner.current.lifecycle
-    DisposableEffect(lifecycle) {
+    LaunchedEffect(mapView, tileSource) { mapView.setTileSource(tileSource) }
+    DisposableEffect(mapView, lifecycle) {
+        var isResumed = false
+
+        fun saveViewport() {
+            if (mapView.width > 0 && mapView.height > 0) {
+                savedCenter = mapView.projection.currentCenter
+                savedZoom = mapView.zoomLevelDouble
+            }
+        }
+
+        fun resumeMap() {
+            if (!isResumed) {
+                mapView.onResume()
+                isResumed = true
+            }
+        }
+
+        fun pauseMap() {
+            if (isResumed) {
+                mapView.onPause()
+                isResumed = false
+            }
+        }
+
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_PAUSE -> {
-                    mapView.onPause()
-                }
-
-                Lifecycle.Event.ON_RESUME -> {
-                    mapView.onResume()
-                }
-
-                Lifecycle.Event.ON_STOP -> {
-                    savedCenter = mapView.projection.currentCenter
-                    savedZoom = mapView.zoomLevelDouble
-                }
-
+                Lifecycle.Event.ON_PAUSE -> pauseMap()
+                Lifecycle.Event.ON_RESUME -> resumeMap()
+                Lifecycle.Event.ON_STOP -> saveViewport()
                 else -> {}
             }
         }
 
         lifecycle.addObserver(observer)
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) resumeMap()
 
         onDispose {
-            savedCenter = mapView.projection.currentCenter
-            savedZoom = mapView.zoomLevelDouble
+            saveViewport()
             lifecycle.removeObserver(observer)
+            pauseMap()
+            mapView.onDetach()
+            if (mapViewReference.current === mapView) mapViewReference.current = null
         }
     }
     return mapView


### PR DESCRIPTION
Pause and detach osmdroid MapView instances when their composition is disposed so tile-provider, overlay, and lifecycle resources are released.

Key the remembered view directly to its context and lifecycle owner, preventing a stale map from surviving owner replacement after navigation or recreation.

## Summary by Sourcery

Ensure F-Droid map views are correctly paused and detached on lifecycle disposal and avoid reusing stale MapView instances across lifecycle owner changes.

Bug Fixes:
- Pause and fully detach F-Droid MapView instances when their composition is disposed to release tile, overlay, and lifecycle resources.
- Key remembered MapView instances to their context and lifecycle owner to avoid stale views persisting across navigation or recreation.