### PR TITLE
ble profile restore 2.8 - Integration branch review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,149 +1,16 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: en-US
-
+early_access: true
 reviews:
-  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
-  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
-  profile: chill
+  profile: assertive
+  request_changes_workflow: false
   high_level_summary: true
-  poem: false
-  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
-  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
-    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
-    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
-    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
-    auto_incremental_review: false
-    ignore_usernames:
-      - renovate
-      - renovate[bot]
-      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
-      # translation bumps) — machine-generated content, nothing to review.
-      - github-actions
-      - github-actions[bot]
-    ignore_title_keywords:
-      - "chore: Scheduled updates"
-  # Stop reviewing once a PR is closed.
-  abort_on_close: true
-
-  path_filters:
-    # Generated / huge / non-source — don't review, just noise + token burn.
-    - "!**/build/**"
-    - "!**/*.png"
-    - "!**/*.webp"
-    - "!**/firmware_releases.json"
-    - "!**/emoji-data.json"
-    - "!**/flatpak-sources.json"
-    # Crowdin-managed translations — owned upstream, not hand-edited here.
-    - "!**/values-*/strings.xml"
-    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
-    - "!.specify/**"
-
-  path_instructions:
-    - path: "**/commonMain/**"
-      instructions: >
-        KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
-    - path: "**/*.kt"
-      instructions: >
-        Flag leftover // ... existing code ... placeholders, and any logging of PII, location, or cryptographic keys.
-    - path: "**/src/**/strings.xml"
-      instructions: >
-        New string resources must be alphabetically sorted (scripts/sort-strings.py). Flag out-of-order additions.
-    - path: baselineprofile/
-      instructions: Keep baseline profile generation tied to the `google` flavor and connected devices/emulators, and commit the generated profile output to `androidApp/src/google/generated/baselineProfiles/baseline-prof.txt`.
-    - path: docs/
-      instructions: Treat non-English locale folders as Crowdin-managed output; edit the English sources under `docs/en/` and register new pages through `feature/docs/` instead of hand-editing translated locale directories.
-    - path: screenshot-tests/
-      instructions: When updating docs screenshots, keep `docs-screenshots-manifest.txt` and `docs-screenshot-aliases.properties` in sync with the generated files, and rerun `copyDocsScreenshots` after regenerating screenshots.
-    - path: docs-screenshots/
-      instructions: Keep this module generate-only for documentation screenshots; do not add it to the CI validation gate that is reserved for `screenshot-tests`.
-    - path: desktopApp/
-      instructions: Keep desktop release ProGuard rules aligned with `androidApp/proguard-rules.pro`, and preserve the desktop-specific runtime wiring needed for `Dispatchers.Main` on JVM.
-    - path: androidApp/
-      instructions: Keep the Android app’s `MeshService` declaration and manifest wiring in sync with the implementation that lives in `core:service`.
-    - path: core/service/
-      instructions: Keep `RadioControllerImpl` composed from its sub-controllers via interface delegation; admin sends are fire-and-forget, and any config mutation must go through `editSettings { }` transactions.
-    - path: feature/docs/
-      instructions: Treat the Compose resources under `src/commonMain/composeResources/files/` as generated output from `/docs/en/**` and translated docs sync tasks; do not hand-edit those copied files.
-    - path: feature/map/
-      instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
-    - path: feature/car/
-      instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
-
-  # Every CodeRabbit tool is enabled by default, so this block only ever needs to
-  # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
-  # Tolerance gate) and duplicate comments were the noise we removed. The scanners
-  # CI doesn't run — gitleaks, shellcheck, actionlint, zizmor, semgrep, trivy,
-  # presidio (PII), buf (protobuf) — are already on by default; don't re-list them.
-  tools:
-    detekt:
-      enabled: false
-    # Custom AST rules mechanically enforce the recurring defect classes that prose
-    # can't. See .coderabbit/ast-grep-rules/ and .skills/code-review/SKILL.md.
-    # essential_rules stays on (default) — these are additive.
-    ast-grep:
-      rule_dirs:
-        - ".coderabbit/ast-grep-rules"
-
-  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
-  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
-  finishing_touches:
-    docstrings:
-      enabled: false
-    unit_tests:
-      enabled: false
-
-  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR. PR titles are already linted by CI
-  # (.github/workflows/pull-request-target.yml), so no title check here either.
-  pre_merge_checks:
-    docstrings:
-      mode: "off"
-    # The two defect classes that survive review-by-prose because they are about
-    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
-    # would still pass with the fix reverted. Warning, not error: these are
-    # judgment calls and a false positive must not block a merge.
-    custom_checks:
-      - name: "Sibling call sites and presence semantics"
-        mode: "warning"
-        instructions: >-
-          When a diff changes how an absent value is represented — making a field nullable,
-          removing a zero-guard, or adding a presence check — verify EVERY call site of that
-          field was updated, not just the one the bug was reported against. Ambient temperature
-          was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
-          Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
-          a physically reachable value on that scale (RSSI, temperature, current, voltage,
-          particulate concentration). Two exceptions, do NOT flag either: humidity, where 0 %RH
-          is unreachable and the guard is intentional and tested; and the proto `rx_snr`, which
-          has no presence upstream, so its 0f ambiguity cannot be fixed app-side. An app-level
-          SNR field that IS nullable is still in scope.
-      - name: "Tests prove the path, not the end state"
-        mode: "warning"
-        instructions: >-
-          For each added or changed test, decide whether it would still pass if the production
-          code it covers were reverted. Flag tests that seed a fake's backing store and then
-          assert the value comes back, tests that assert only a collection's size rather than
-          which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
-          (not a stable contract). A test must assert the side effect only the intended path
-          produces — a call counter, a request issued, a cache written.
-
-knowledge_base:
-  # Learnings are how a confirmed finding stops recurring on the next PR. Pin the
-  # scope to this repo: the default `auto` already resolves to `local` for public
-  # repos, but being explicit keeps it from shifting if visibility ever changes.
-  learnings:
-    scope: local
-  # Feed CodeRabbit the same guidance human/AI contributors follow, including
-  # the repo-specific .skills/ modules and Copilot path instructions it
-  # wouldn't pick up by default.
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - ".skills/**/SKILL.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/*.instructions.md"
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,7 +18,6 @@ jobs:
   # (folded into this job rather than run standalone: runner-pool slots, not
   # compute, are the scarce resource during queue bursts).
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -73,6 +73,13 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'test.gradle.kts'
+
+  # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
+  verify-check-changes-filter:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
       - name: Verify module roots are represented in check-changes filter
         run: |
           python3 - <<'PY'

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ build-scan-*.scan
 # Python bytecode from scripts/
 __pycache__/
 *.pyc
+.omo/*
+.commandcode

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1088,7 +1088,6 @@ mqtt_status_inactive
 mqtt_status_reconnecting
 mqtt_status_reconnecting_with_attempt
 mqtt_test_connection
-must_set_region
 must_update
 ### MUTE ###
 mute_1_week

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -792,6 +792,7 @@ ignore_mqtt
 ignore_remove
 ### IMPORT ###
 import_configuration
+import_configuration_failed
 import_export_label
 import_known_shared_contact_text
 import_label
@@ -805,6 +806,13 @@ insert
 insert_link_message
 insert_link_title
 insert_link_url_hint
+### INSTALL ###
+install_configuration_bluetooth_repair_hint
+install_configuration_failed
+install_configuration_in_progress_title
+install_configuration_in_progress_warning
+install_configuration_preparing
+install_configuration_stage
 installed_firmware_version
 internal
 interval_always_on

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
@@ -18,6 +18,7 @@ package org.meshtastic.app.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +40,8 @@ import org.osmdroid.views.MapView
 private const val MIN_ZOOM_LEVEL = 1.5
 private const val MAX_ZOOM_LEVEL = 20.0
 private const val DEFAULT_ZOOM_LEVEL = 15.0
+
+private class MapViewReference(var current: MapView? = null)
 
 @Suppress("MagicNumber")
 @Composable
@@ -76,54 +79,81 @@ internal fun rememberMapViewWithLifecycle(
         }
 
     val context = LocalContext.current
-    val mapView = remember {
-        MapView(context).apply {
-            clipToOutline = true
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycle = lifecycleOwner.lifecycle
+    val mapViewReference = remember { MapViewReference() }
+    val mapView =
+        remember(context, lifecycle) {
+            // Keyed remember creates the replacement before the old DisposableEffect is disposed. Read the live
+            // viewport directly so an unsaved pan or zoom survives a context or lifecycle-owner replacement.
+            val previousMapView = mapViewReference.current?.takeIf { it.width > 0 && it.height > 0 }
+            val initialCenter = previousMapView?.projection?.currentCenter ?: savedCenter
+            val initialZoom = previousMapView?.zoomLevelDouble ?: savedZoom
+            MapView(context)
+                .apply {
+                    clipToOutline = true
 
-            setTileSource(tileSource)
-            isVerticalMapRepetitionEnabled = false // disables map repetition
-            setMultiTouchControls(true)
-            val bounds = overlayManager.tilesOverlay.bounds // bounds scrollable map
-            setScrollableAreaLimitLatitude(bounds.actualNorth, bounds.actualSouth, 0)
-            // scales the map tiles to the display density of the screen
-            isTilesScaledToDpi = true
-            // sets the minimum zoom level (the furthest out you can zoom)
-            minZoomLevel = MIN_ZOOM_LEVEL
-            maxZoomLevel = MAX_ZOOM_LEVEL
-            // Disables default +/- button for zooming
-            zoomController.setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT)
+                    setTileSource(tileSource)
+                    isVerticalMapRepetitionEnabled = false // disables map repetition
+                    setMultiTouchControls(true)
+                    val bounds = overlayManager.tilesOverlay.bounds // bounds scrollable map
+                    setScrollableAreaLimitLatitude(bounds.actualNorth, bounds.actualSouth, 0)
+                    // scales the map tiles to the display density of the screen
+                    isTilesScaledToDpi = true
+                    // sets the minimum zoom level (the furthest out you can zoom)
+                    minZoomLevel = MIN_ZOOM_LEVEL
+                    maxZoomLevel = MAX_ZOOM_LEVEL
+                    // Disables default +/- button for zooming
+                    zoomController.setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT)
 
-            controller.setZoom(savedZoom)
-            controller.setCenter(savedCenter)
+                    controller.setZoom(initialZoom)
+                    controller.setCenter(initialCenter)
+                }
+                .also { mapViewReference.current = it }
         }
-    }
-    val lifecycle = LocalLifecycleOwner.current.lifecycle
-    DisposableEffect(lifecycle) {
+    LaunchedEffect(mapView, tileSource) { mapView.setTileSource(tileSource) }
+    DisposableEffect(mapView, lifecycle) {
+        var isResumed = false
+
+        fun saveViewport() {
+            if (mapView.width > 0 && mapView.height > 0) {
+                savedCenter = mapView.projection.currentCenter
+                savedZoom = mapView.zoomLevelDouble
+            }
+        }
+
+        fun resumeMap() {
+            if (!isResumed) {
+                mapView.onResume()
+                isResumed = true
+            }
+        }
+
+        fun pauseMap() {
+            if (isResumed) {
+                mapView.onPause()
+                isResumed = false
+            }
+        }
+
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_PAUSE -> {
-                    mapView.onPause()
-                }
-
-                Lifecycle.Event.ON_RESUME -> {
-                    mapView.onResume()
-                }
-
-                Lifecycle.Event.ON_STOP -> {
-                    savedCenter = mapView.projection.currentCenter
-                    savedZoom = mapView.zoomLevelDouble
-                }
-
+                Lifecycle.Event.ON_PAUSE -> pauseMap()
+                Lifecycle.Event.ON_RESUME -> resumeMap()
+                Lifecycle.Event.ON_STOP -> saveViewport()
                 else -> {}
             }
         }
 
         lifecycle.addObserver(observer)
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) resumeMap()
 
         onDispose {
-            savedCenter = mapView.projection.currentCenter
-            savedZoom = mapView.zoomLevelDouble
+            saveViewport()
             lifecycle.removeObserver(observer)
+            pauseMap()
+            mapView.onDetach()
+            if (mapViewReference.current === mapView) mapViewReference.current = null
         }
     }
     return mapView

--- a/core/ble/build.gradle.kts
+++ b/core/ble/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             implementation(projects.core.model)
 
             implementation(libs.kermit)
+            implementation(libs.kotlinx.atomicfu)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kable.core)
         }

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -73,7 +73,7 @@ internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConn
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.w(e) { "[${device.address.anonymize()}] Failed to request MTU" }
+            Logger.w { "[${device.address.anonymize()}] Failed to request MTU (${e::class.simpleName ?: "Exception"})" }
         }
     }
 }
@@ -92,13 +92,17 @@ internal actual fun Peripheral.negotiatedMaxWriteLength(): Int? {
 internal actual fun Peripheral.requestHighConnectionPriority(): Boolean {
     val androidPeripheral = this as? AndroidPeripheral ?: return false
     return runCatching { androidPeripheral.requestConnectionPriority(AndroidPeripheral.Priority.High) }
-        .onFailure { Logger.w(it) { "requestConnectionPriority(High) threw" } }
+        .onFailure { failure ->
+            Logger.w { "requestConnectionPriority(High) threw (${failure::class.simpleName ?: "Exception"})" }
+        }
         .getOrDefault(false)
 }
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean {
     val androidPeripheral = this as? AndroidPeripheral ?: return false
     return runCatching { androidPeripheral.requestConnectionPriority(AndroidPeripheral.Priority.Balanced) }
-        .onFailure { Logger.w(it) { "requestConnectionPriority(Balanced) threw" } }
+        .onFailure { failure ->
+            Logger.w { "requestConnectionPriority(Balanced) threw (${failure::class.simpleName ?: "Exception"})" }
+        }
         .getOrDefault(false)
 }

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -22,7 +22,10 @@ import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
 import com.juul.kable.PooledThreadingStrategy
 import com.juul.kable.toIdentifier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.core.model.util.anonymize
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Shared thread pool for Kable BLE connections.
@@ -34,6 +37,9 @@ import org.meshtastic.core.model.util.anonymize
  * A single app-wide instance is used because Kable recommends exactly one pool per application.
  */
 private val sharedThreadingStrategy = PooledThreadingStrategy()
+
+/** Keeps a lost Android MTU callback from blocking the complete GATT connection lifecycle. */
+private val MTU_NEGOTIATION_TIMEOUT = 5.seconds
 
 internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConnect: () -> Boolean) {
     // Bonded devices without a fresh advertisement must use autoConnect = true. Otherwise,
@@ -55,8 +61,17 @@ internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConn
             // Android defaults to 23 bytes MTU. Meshtastic packets can be 512 bytes.
             // Requesting the max MTU is critical for preventing dropped packets and stalls.
             @Suppress("MagicNumber")
-            val negotiatedMtu = requestMtu(512)
-            Logger.i { "[${device.address.anonymize()}] Negotiated MTU: $negotiatedMtu" }
+            val negotiatedMtu = withTimeoutOrNull(MTU_NEGOTIATION_TIMEOUT) { requestMtu(512) }
+            if (negotiatedMtu == null) {
+                Logger.w {
+                    "[${device.address.anonymize()}] MTU callback timed out after $MTU_NEGOTIATION_TIMEOUT; " +
+                        "continuing with the current ATT MTU"
+                }
+            } else {
+                Logger.i { "[${device.address.anonymize()}] Negotiated MTU: $negotiatedMtu" }
+            }
+        } catch (e: CancellationException) {
+            throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             Logger.w(e) { "[${device.address.anonymize()}] Failed to request MTU" }
         }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleExceptionClassifier.kt
@@ -22,6 +22,7 @@ import com.juul.kable.GattRequestRejectedException
 import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
 import com.juul.kable.UnmetRequirementException
+import com.juul.kable.UnmetRequirementReason
 
 /**
  * Classification of a BLE-layer exception for the transport layer to act on.
@@ -30,7 +31,8 @@ import com.juul.kable.UnmetRequirementException
  *   Currently always `false` — all known BLE exceptions can resolve without user intervention (BT toggling, permission
  *   grants, transient GATT errors). Reserved for future use.
  * @property gattStatus the platform GATT status code when available (Android-specific).
- * @property message a human-readable description of the failure.
+ * @property message a human-readable, diagnostic-safe description of the failure. Source exception messages are not
+ *   forwarded because platform BLE errors can contain stable device identifiers.
  */
 data class BleExceptionInfo(val isPermanent: Boolean, val gattStatus: Int? = null, val message: String)
 
@@ -43,11 +45,7 @@ data class BleExceptionInfo(val isPermanent: Boolean, val gattStatus: Int? = nul
  */
 fun Throwable.classifyBleException(): BleExceptionInfo? = when (this) {
     is GattStatusException ->
-        BleExceptionInfo(
-            isPermanent = false,
-            gattStatus = status,
-            message = "GATT error (status $status): $message",
-        )
+        BleExceptionInfo(isPermanent = false, gattStatus = status, message = "GATT error (status $status)")
 
     is NotConnectedException -> BleExceptionInfo(isPermanent = false, message = "Not connected")
 
@@ -55,12 +53,17 @@ fun Throwable.classifyBleException(): BleExceptionInfo? = when (this) {
         BleExceptionInfo(isPermanent = false, message = "GATT request rejected (busy)")
 
     is UnmetRequirementException ->
-        // Bluetooth disabled or runtime permission missing. Both can resolve without re-selecting the
-        // device (user re-enables BT, or grants permission). Surface as transient so the transport keeps
-        // retrying; UI can show a hint based on the message.
-        BleExceptionInfo(isPermanent = false, message = message ?: "Bluetooth LE unavailable")
+        // Keep the reason actionable without forwarding platform exception text or device identifiers.
+        BleExceptionInfo(isPermanent = false, message = reason.toBleAvailabilityMessage())
 
     else -> null
+}
+
+/** Maps Kable's typed availability requirement to fixed, user-actionable text. */
+internal fun UnmetRequirementReason.toBleAvailabilityMessage(): String = when (this) {
+    UnmetRequirementReason.BluetoothDisabled -> "Bluetooth is turned off"
+    UnmetRequirementReason.LocationServicesDisabled -> "Location services are turned off"
+    else -> "Bluetooth LE is unavailable"
 }
 
 /**

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -40,14 +40,27 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.job
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.model.util.anonymize
 import kotlin.concurrent.Volatile
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
+
+internal fun interface KablePeripheralFactory {
+    suspend fun create(device: MeshtasticBleDevice, builderAction: PeripheralBuilder.() -> Unit): Peripheral
+}
+
+private object DefaultKablePeripheralFactory : KablePeripheralFactory {
+    override suspend fun create(device: MeshtasticBleDevice, builderAction: PeripheralBuilder.() -> Unit): Peripheral =
+        device.advertisement?.let { advertisement -> Peripheral(advertisement, builderAction) }
+            ?: createPeripheral(device.address, builderAction)
+}
 
 /** [BleService] implementation backed by a Kable [Peripheral] for a specific GATT service. */
 class KableBleService(private val peripheral: Peripheral, private val serviceUuid: Uuid) : BleService {
@@ -101,8 +114,18 @@ class KableBleService(private val peripheral: Peripheral, private val serviceUui
  * the `autoConnect` path. At most two attempts are made per [connect] call — the caller ([BleRadioTransport]) owns the
  * macro-level retry/backoff loop.
  */
-class KableBleConnection(private val scope: CoroutineScope, private val loggingConfig: BleLoggingConfig) :
-    BleConnection {
+@Suppress("TooManyFunctions")
+class KableBleConnection
+internal constructor(
+    private val scope: CoroutineScope,
+    private val loggingConfig: BleLoggingConfig,
+    private val peripheralFactory: KablePeripheralFactory,
+) : BleConnection {
+
+    constructor(
+        scope: CoroutineScope,
+        loggingConfig: BleLoggingConfig,
+    ) : this(scope, loggingConfig, DefaultKablePeripheralFactory)
 
     @Volatile private var peripheral: Peripheral? = null
 
@@ -110,9 +133,17 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
 
     @Volatile private var connectionScope: CoroutineScope? = null
 
+    private val lifecycleMutex = Mutex()
+
+    /** Invalidates connect attempts that have not installed ownership yet. Guarded by [lifecycleMutex]. */
+    private var lifecycleGeneration = 0L
+
     companion object {
         /** Settle delay between a direct connect failure and the autoConnect fallback attempt. */
         private val AUTOCONNECT_FALLBACK_DELAY = 1.seconds
+
+        /** Bounds best-effort GATT teardown so a wedged old peripheral cannot stall reconnect indefinitely. */
+        private val PERIPHERAL_TEARDOWN_TIMEOUT = 2.seconds
     }
 
     private val _deviceFlow = MutableStateFlow<BleDevice?>(null)
@@ -125,41 +156,68 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
         MutableStateFlow<BleConnectionState>(BleConnectionState.Disconnected(DisconnectReason.Unknown))
     override val connectionState: StateFlow<BleConnectionState> = _connectionState.asStateFlow()
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
     override suspend fun connect(device: BleDevice) {
+        var owned: Peripheral? = null
+        try {
+            connectInternal(device) { owned = it }
+        } catch (e: CancellationException) {
+            closeAfterCancellation(owned, e)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            closeAfterConnectFailure(owned, e)
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
+    private suspend fun connectInternal(device: BleDevice, onPeripheralCreated: (Peripheral) -> Unit) {
         val meshtasticDevice = device as? MeshtasticBleDevice ?: error("Unsupported BleDevice type: ${device::class}")
+        val attemptGeneration = lifecycleMutex.withLock { ++lifecycleGeneration }
         var autoConnect = meshtasticDevice.advertisement == null
 
         /** Applies logging, observation exception handling, and platform config shared by both peripheral types. */
         fun PeripheralBuilder.commonConfig() {
             logging { applyConfig(loggingConfig, identifier = device.address.anonymize()) }
             observationExceptionHandler { cause ->
-                Logger.w(cause) { "[${device.address.anonymize()}] Observation failure suppressed" }
+                Logger.w {
+                    "[${device.address.anonymize()}] Observation failure suppressed " +
+                        "(${cause::class.simpleName ?: "Exception"})"
+                }
             }
             platformConfig(device) { autoConnect }
         }
 
-        val p =
-            meshtasticDevice.advertisement?.let { adv -> Peripheral(adv) { commonConfig() } }
-                ?: createPeripheral(device.address) { commonConfig() }
+        val p = peripheralFactory.create(meshtasticDevice) { commonConfig() }
+        onPeripheralCreated(p)
+        currentCoroutineContext().ensureActive()
 
-        // Install ownership of the new peripheral atomically. Cancellation between
-        // peripheral construction and field assignment would strand `p` (Kable allocates
-        // a per-peripheral scope + Bluetooth-state observer eagerly), so the cleanup,
-        // assignment, and ActiveBleConnection update must complete as a single unit.
-        // _deviceFlow.emit() is intentionally outside this block — making it
-        // non-cancellable could hang teardown on a slow collector.
-        withContext(NonCancellable) {
-            cleanUpPeripheral(device.address)
-            peripheral = p
-            ActiveBleConnection.active = ActiveConnection(p, device.address)
+        // Install ownership atomically with attempt validation. A disconnect or newer connect that wins first
+        // invalidates the generation, so outer failure cleanup closes this peripheral without replacing the live one.
+        val ownership =
+            withContext(NonCancellable) {
+                lifecycleMutex.withLock {
+                    if (attemptGeneration != lifecycleGeneration) {
+                        OwnershipInstallResult(installed = false, previous = null)
+                    } else {
+                        val old = peripheral
+                        stateJob?.cancel()
+                        connectionScope?.coroutineContext?.job?.cancel()
+                        stateJob = null
+                        connectionScope = null
+                        peripheral = p
+                        _deviceFlow.value = device
+                        ActiveBleConnection.active = ActiveConnection(p, device.address)
+                        OwnershipInstallResult(installed = true, previous = old.takeUnless { it === p })
+                    }
+                }
+            }
+        if (!ownership.installed) throw CancellationException("BLE connection attempt was superseded")
+        closePeripheralBounded(ownership.previous, "replace")
+
+        if (lifecycleMutex.withLock { peripheral !== p || attemptGeneration != lifecycleGeneration }) {
+            throw CancellationException("BLE connection attempt was superseded")
         }
 
-        _deviceFlow.emit(device)
-
-        stateJob?.cancel()
         var hasStartedConnecting = false
-        stateJob =
+        val newStateJob =
             p.state
                 .onEach { kableState ->
                     val mappedState = kableState.toBleConnectionState(hasStartedConnecting) ?: return@onEach
@@ -167,37 +225,78 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
                         hasStartedConnecting = true
                     }
 
-                    meshtasticDevice.updateState(mappedState)
-
-                    _connectionState.emit(mappedState)
+                    publishStateIfOwned(p, attemptGeneration, meshtasticDevice, mappedState)
                 }
                 .launchIn(scope)
+        lifecycleMutex.withLock {
+            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+                stateJob = newStateJob
+            } else {
+                newStateJob.cancel()
+            }
+        }
 
         // Bounded to at most two attempts: direct connect, then autoConnect fallback when a fresh
         // advertisement was available. Advertisement-less devices start on the autoConnect path.
         // The outer reconnect loop (BleRadioTransport) owns the macro retry budget — see class kdoc.
         repeat(2) {
-            if (p.state.value is State.Connected) return
+            if (!isOwned(p, attemptGeneration)) {
+                throw CancellationException("BLE connection attempt was superseded")
+            }
+            if (p.state.value is State.Connected) {
+                if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+                    throw CancellationException("BLE connection attempt was superseded")
+                }
+                return
+            }
             autoConnect =
                 try {
-                    connectionScope?.let { oldScope ->
+                    val oldScope =
+                        lifecycleMutex.withLock {
+                            if (peripheral !== p || attemptGeneration != lifecycleGeneration) {
+                                throw CancellationException("BLE connection attempt was superseded")
+                            }
+                            connectionScope.also { connectionScope = null }
+                        }
+                    oldScope?.let { scopeToCancel ->
                         Logger.d {
                             "[${device.address.anonymize()}] Cancelling previous connectionScope before reconnect"
                         }
-                        oldScope.coroutineContext.job.cancel()
+                        scopeToCancel.coroutineContext.job.cancel()
                     }
-                    connectionScope = p.connect()
+                    val connectedScope = p.connect()
+                    val installed =
+                        lifecycleMutex.withLock {
+                            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+                                connectionScope = connectedScope
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                    if (!installed) {
+                        connectedScope.coroutineContext.job.cancel()
+                        throw CancellationException("BLE connection attempt was superseded")
+                    }
                     false
                 } catch (e: CancellationException) {
                     throw e
                 } catch (@Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception) {
+                    if (!isOwned(p, attemptGeneration)) {
+                        throw CancellationException("BLE connection attempt was superseded")
+                    }
                     if (autoConnect) {
                         // Already on the autoConnect path and still failing: surface a clear Disconnected
                         // and let the outer reconnect loop (BleRadioTransport) own the macro retry budget.
                         Logger.w {
                             "[${device.address.anonymize()}] autoConnect also failed; deferring to outer reconnect loop"
                         }
-                        _connectionState.emit(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed))
+                        publishStateIfOwned(
+                            p,
+                            attemptGeneration,
+                            meshtasticDevice,
+                            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+                        )
                         throw e
                     }
                     Logger.d { "[${device.address.anonymize()}] Direct connect failed, falling back to autoConnect" }
@@ -210,53 +309,120 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
         // would have kept iterating; the bounded loop defers to the outer reconnect policy.
         // Guard against false-positive Connected by verifying state here.
         if (p.state.value !is State.Connected) {
-            _connectionState.emit(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed))
+            if (!isOwned(p, attemptGeneration)) {
+                throw CancellationException("BLE connection attempt was superseded")
+            }
+            publishStateIfOwned(
+                p,
+                attemptGeneration,
+                meshtasticDevice,
+                BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            )
             throw NotConnectedException(
                 "Failed to establish connection after bounded attempts (state=${p.state.value})",
             )
         }
+        if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+            throw CancellationException("BLE connection attempt was superseded")
+        }
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    override suspend fun connectAndAwait(device: BleDevice, timeout: Duration): BleConnectionState = try {
-        withTimeout(timeout) {
-            connect(device)
-            BleConnectionState.Connected
+    override suspend fun connectAndAwait(device: BleDevice, timeout: Duration): BleConnectionState {
+        var owned: Peripheral? = null
+        val result =
+            try {
+                withTimeout(timeout) {
+                    connectInternal(device) { owned = it }
+                    BleConnectionState.Connected
+                }
+            } catch (_: TimeoutCancellationException) {
+                BleConnectionState.Disconnected(DisconnectReason.Timeout)
+            } catch (e: CancellationException) {
+                closeAfterCancellation(owned, e)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.w {
+                    "[${device.address.anonymize()}] connectAndAwait failed (${e::class.simpleName ?: "Exception"})"
+                }
+                BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)
+            }
+
+        if (result is BleConnectionState.Disconnected) {
+            // A failed Kable connect can leave the physical GATT connected. Release this attempt before the outer
+            // reconnect policy starts another scan or connection.
+            closeConnection(owned, result)
         }
-    } catch (_: TimeoutCancellationException) {
-        // Our own timeout expired — treat as a failed attempt so callers can retry.
-        BleConnectionState.Disconnected(DisconnectReason.Timeout)
-    } catch (e: CancellationException) {
-        // External cancellation (scope closed) — must propagate.
-        throw e
-    } catch (_: Exception) {
-        BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)
+        return result
     }
 
-    override suspend fun disconnect() = withContext(NonCancellable) {
-        // Emit Disconnected before cancelling stateJob so downstream collectors see the
-        // state transition. If we cancel stateJob first, the peripheral's state flow
-        // emission of Disconnected is never forwarded to _connectionState.
-        _connectionState.emit(BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect))
+    override suspend fun disconnect() {
+        val owned =
+            lifecycleMutex.withLock {
+                lifecycleGeneration += 1
+                peripheral
+            }
+        if (owned == null) {
+            lifecycleMutex.withLock {
+                _connectionState.value = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
+                _deviceFlow.value = null
+            }
+        } else {
+            closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect))
+        }
+    }
 
-        stateJob?.cancel()
-        stateJob = null
+    private suspend fun publishStateIfOwned(
+        owned: Peripheral,
+        generation: Long,
+        device: MeshtasticBleDevice,
+        state: BleConnectionState,
+    ): Boolean = lifecycleMutex.withLock {
+        if (peripheral !== owned || generation != lifecycleGeneration) return@withLock false
+        device.updateState(state)
+        _connectionState.value = state
+        true
+    }
 
-        // Capture the peripheral we own before clearing it so we can identity-check
-        // ActiveBleConnection below. A stale disconnect from an earlier connection
-        // attempt's exception handler must not clobber a newer connection that has
-        // already installed itself as active.
-        val owned = peripheral
-        safeClosePeripheral("disconnect")
-        peripheral = null
-        connectionScope = null
+    private suspend fun isOwned(owned: Peripheral, generation: Long): Boolean =
+        lifecycleMutex.withLock { peripheral === owned && generation == lifecycleGeneration }
 
-        if (owned != null && ActiveBleConnection.active?.peripheral === owned) {
-            ActiveBleConnection.active = null
+    private suspend fun closeAfterCancellation(owned: Peripheral?, cancellation: CancellationException): Nothing {
+        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.Cancelled)) }
+            .exceptionOrNull()
+            ?.let(cancellation::addSuppressed)
+        throw cancellation
+    }
+
+    private suspend fun closeAfterConnectFailure(owned: Peripheral?, failure: Exception): Nothing {
+        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)) }
+            .exceptionOrNull()
+            ?.let(failure::addSuppressed)
+        throw failure
+    }
+
+    private suspend fun closeConnection(owned: Peripheral?, disconnectedState: BleConnectionState.Disconnected) =
+        withContext(NonCancellable) {
+            lifecycleMutex.withLock {
+                if (owned != null && peripheral === owned) {
+                    // Publish before cancelling the collector so downstream consumers cannot miss the terminal
+                    // state when the peripheral's own Disconnected emission races teardown.
+                    _connectionState.value = disconnectedState
+                    stateJob?.cancel()
+                    connectionScope?.coroutineContext?.job?.cancel()
+                    stateJob = null
+                    connectionScope = null
+                    peripheral = null
+                    if (ActiveBleConnection.active?.peripheral === owned) {
+                        ActiveBleConnection.active = null
+                    }
+                    _deviceFlow.value = null
+                }
+            }
+
+            closePeripheralBounded(owned, "disconnect")
         }
 
-        _deviceFlow.emit(null)
-    }
+    private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?)
 
     @Suppress("ThrowsCount")
     override suspend fun <T> profile(
@@ -305,31 +471,45 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
 
     override fun invalidateServiceCache(): Boolean = peripheral?.refreshGattCache() == true
 
-    /** Ensures the previous peripheral's GATT resources are fully released. */
-    private suspend fun cleanUpPeripheral(tag: String) {
-        withContext(NonCancellable) { safeClosePeripheral(tag) }
-    }
-
     /**
-     * Safely disconnects and closes the current [peripheral], logging any failures.
+     * Safely disconnects and closes [target], logging any failures.
      *
      * Kable requires `close()` to release broadcast receivers on Android (Kable issue #359). Separate try/catch blocks
      * ensure `close()` always runs even if `disconnect()` throws.
      */
+    private suspend fun closePeripheralBounded(target: Peripheral?, tag: String) {
+        if (target == null) return
+        val completed =
+            withContext(NonCancellable) {
+                withTimeoutOrNull(PERIPHERAL_TEARDOWN_TIMEOUT) {
+                    safeClosePeripheral(target, tag)
+                    true
+                } ?: false
+            }
+        if (!completed) Logger.w { "[$tag] Timed out closing peripheral" }
+    }
+
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun safeClosePeripheral(tag: String) {
+    private suspend fun safeClosePeripheral(target: Peripheral, tag: String) {
+        // Deferred rethrow instead of a throw inside finally: detekt forbids exceptions from finally blocks,
+        // and a close() CancellationException must not discard a disconnect() cancellation.
+        var cancellation: CancellationException? = null
         try {
-            peripheral?.disconnect()
+            target.disconnect()
         } catch (_: NotConnectedException) {
             // Silence "Disconnect requested" which Kable throws if already disconnected.
-            // This is a common non-fatal reported in Crashlytics that is safe to ignore here.
+        } catch (e: CancellationException) {
+            cancellation = e
         } catch (e: Exception) {
-            Logger.w(e) { "[$tag] Failed to disconnect peripheral" }
+            Logger.w { "[$tag] Failed to disconnect peripheral (${e::class.simpleName ?: "Exception"})" }
         }
         try {
-            peripheral?.close()
+            target.close()
+        } catch (e: CancellationException) {
+            cancellation = cancellation ?: e
         } catch (e: Exception) {
-            Logger.w(e) { "[$tag] Failed to close peripheral" }
+            Logger.w { "[$tag] Failed to close peripheral (${e::class.simpleName ?: "Exception"})" }
         }
+        cancellation?.let { throw it }
     }
 }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -160,6 +160,8 @@ internal constructor(
         var owned: Peripheral? = null
         try {
             connectInternal(device) { owned = it }
+        } catch (e: SupersededConnectionAttemptException) {
+            closeAfterConnectFailure(owned, e)
         } catch (e: CancellationException) {
             closeAfterCancellation(owned, e)
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -209,11 +211,11 @@ internal constructor(
                     }
                 }
             }
-        if (!ownership.installed) throw CancellationException("BLE connection attempt was superseded")
+        if (!ownership.installed) throw SupersededConnectionAttemptException()
         closePeripheralBounded(ownership.previous, "replace")
 
         if (lifecycleMutex.withLock { peripheral !== p || attemptGeneration != lifecycleGeneration }) {
-            throw CancellationException("BLE connection attempt was superseded")
+            throw SupersededConnectionAttemptException()
         }
 
         var hasStartedConnecting = false
@@ -241,11 +243,11 @@ internal constructor(
         // The outer reconnect loop (BleRadioTransport) owns the macro retry budget — see class kdoc.
         repeat(2) {
             if (!isOwned(p, attemptGeneration)) {
-                throw CancellationException("BLE connection attempt was superseded")
+                throw SupersededConnectionAttemptException()
             }
             if (p.state.value is State.Connected) {
                 if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
-                    throw CancellationException("BLE connection attempt was superseded")
+                    throw SupersededConnectionAttemptException()
                 }
                 return
             }
@@ -254,7 +256,7 @@ internal constructor(
                     val oldScope =
                         lifecycleMutex.withLock {
                             if (peripheral !== p || attemptGeneration != lifecycleGeneration) {
-                                throw CancellationException("BLE connection attempt was superseded")
+                                throw SupersededConnectionAttemptException()
                             }
                             connectionScope.also { connectionScope = null }
                         }
@@ -276,14 +278,16 @@ internal constructor(
                         }
                     if (!installed) {
                         connectedScope.coroutineContext.job.cancel()
-                        throw CancellationException("BLE connection attempt was superseded")
+                        throw SupersededConnectionAttemptException()
                     }
                     false
+                } catch (e: SupersededConnectionAttemptException) {
+                    throw e
                 } catch (e: CancellationException) {
                     throw e
                 } catch (@Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception) {
                     if (!isOwned(p, attemptGeneration)) {
-                        throw CancellationException("BLE connection attempt was superseded")
+                        throw SupersededConnectionAttemptException()
                     }
                     if (autoConnect) {
                         // Already on the autoConnect path and still failing: surface a clear Disconnected
@@ -310,7 +314,7 @@ internal constructor(
         // Guard against false-positive Connected by verifying state here.
         if (p.state.value !is State.Connected) {
             if (!isOwned(p, attemptGeneration)) {
-                throw CancellationException("BLE connection attempt was superseded")
+                throw SupersededConnectionAttemptException()
             }
             publishStateIfOwned(
                 p,
@@ -323,7 +327,7 @@ internal constructor(
             )
         }
         if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
-            throw CancellationException("BLE connection attempt was superseded")
+            throw SupersededConnectionAttemptException()
         }
     }
 
@@ -338,6 +342,8 @@ internal constructor(
                 }
             } catch (_: TimeoutCancellationException) {
                 BleConnectionState.Disconnected(DisconnectReason.Timeout)
+            } catch (_: SupersededConnectionAttemptException) {
+                BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)
             } catch (e: CancellationException) {
                 closeAfterCancellation(owned, e)
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -421,6 +427,8 @@ internal constructor(
 
             closePeripheralBounded(owned, "disconnect")
         }
+
+    private class SupersededConnectionAttemptException : Exception()
 
     private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?)
 

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -24,6 +24,7 @@ import com.juul.kable.State
 import com.juul.kable.WriteType
 import com.juul.kable.characteristicOf
 import com.juul.kable.writeWithoutResponse
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -135,8 +136,11 @@ internal constructor(
 
     private val lifecycleMutex = Mutex()
 
-    /** Invalidates connect attempts that have not installed ownership yet. Guarded by [lifecycleMutex]. */
-    private var lifecycleGeneration = 0L
+    /** Invalidates connect attempts before or after ownership installation. Guarded by [lifecycleMutex]. */
+    private var connectAttemptGeneration = 0L
+
+    /** Identifies the currently installed peripheral without invalidating it for a pending replacement. */
+    private var ownershipGeneration = 0L
 
     companion object {
         /** Settle delay between a direct connect failure and the autoConnect fallback attempt. */
@@ -172,8 +176,8 @@ internal constructor(
     @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
     private suspend fun connectInternal(device: BleDevice, onPeripheralCreated: (Peripheral) -> Unit) {
         val meshtasticDevice = device as? MeshtasticBleDevice ?: error("Unsupported BleDevice type: ${device::class}")
-        val attemptGeneration = lifecycleMutex.withLock { ++lifecycleGeneration }
-        var autoConnect = meshtasticDevice.advertisement == null
+        val attemptGeneration = lifecycleMutex.withLock { ++connectAttemptGeneration }
+        val autoConnect = atomic(meshtasticDevice.advertisement == null)
 
         /** Applies logging, observation exception handling, and platform config shared by both peripheral types. */
         fun PeripheralBuilder.commonConfig() {
@@ -184,7 +188,7 @@ internal constructor(
                         "(${cause::class.simpleName ?: "Exception"})"
                 }
             }
-            platformConfig(device) { autoConnect }
+            platformConfig(device) { autoConnect.value }
         }
 
         val p = peripheralFactory.create(meshtasticDevice) { commonConfig() }
@@ -196,8 +200,8 @@ internal constructor(
         val ownership =
             withContext(NonCancellable) {
                 lifecycleMutex.withLock {
-                    if (attemptGeneration != lifecycleGeneration) {
-                        OwnershipInstallResult(installed = false, previous = null)
+                    if (attemptGeneration != connectAttemptGeneration) {
+                        OwnershipInstallResult(installed = false, previous = null, generation = null)
                     } else {
                         val old = peripheral
                         stateJob?.cancel()
@@ -207,14 +211,20 @@ internal constructor(
                         peripheral = p
                         _deviceFlow.value = device
                         ActiveBleConnection.active = ActiveConnection(p, device.address)
-                        OwnershipInstallResult(installed = true, previous = old.takeUnless { it === p })
+                        ownershipGeneration += 1
+                        OwnershipInstallResult(
+                            installed = true,
+                            previous = old.takeUnless { it === p },
+                            generation = ownershipGeneration,
+                        )
                     }
                 }
             }
         if (!ownership.installed) throw SupersededConnectionAttemptException()
+        val installedGeneration = checkNotNull(ownership.generation)
         closePeripheralBounded(ownership.previous, "replace")
 
-        if (lifecycleMutex.withLock { peripheral !== p || attemptGeneration != lifecycleGeneration }) {
+        if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
             throw SupersededConnectionAttemptException()
         }
 
@@ -227,11 +237,11 @@ internal constructor(
                         hasStartedConnecting = true
                     }
 
-                    publishStateIfOwned(p, attemptGeneration, meshtasticDevice, mappedState)
+                    publishStateIfOwned(p, installedGeneration, meshtasticDevice, mappedState)
                 }
                 .launchIn(scope)
         lifecycleMutex.withLock {
-            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+            if (peripheral === p && installedGeneration == ownershipGeneration) {
                 stateJob = newStateJob
             } else {
                 newStateJob.cancel()
@@ -242,20 +252,24 @@ internal constructor(
         // advertisement was available. Advertisement-less devices start on the autoConnect path.
         // The outer reconnect loop (BleRadioTransport) owns the macro retry budget — see class kdoc.
         repeat(2) {
-            if (!isOwned(p, attemptGeneration)) {
+            if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
                 throw SupersededConnectionAttemptException()
             }
             if (p.state.value is State.Connected) {
-                if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+                if (!publishStateIfOwned(p, installedGeneration, meshtasticDevice, BleConnectionState.Connected)) {
                     throw SupersededConnectionAttemptException()
                 }
                 return
             }
-            autoConnect =
+            autoConnect.value =
                 try {
                     val oldScope =
                         lifecycleMutex.withLock {
-                            if (peripheral !== p || attemptGeneration != lifecycleGeneration) {
+                            if (
+                                peripheral !== p ||
+                                attemptGeneration != connectAttemptGeneration ||
+                                installedGeneration != ownershipGeneration
+                            ) {
                                 throw SupersededConnectionAttemptException()
                             }
                             connectionScope.also { connectionScope = null }
@@ -269,7 +283,11 @@ internal constructor(
                     val connectedScope = p.connect()
                     val installed =
                         lifecycleMutex.withLock {
-                            if (peripheral === p && attemptGeneration == lifecycleGeneration) {
+                            if (
+                                peripheral === p &&
+                                attemptGeneration == connectAttemptGeneration &&
+                                installedGeneration == ownershipGeneration
+                            ) {
                                 connectionScope = connectedScope
                                 true
                             } else {
@@ -286,18 +304,18 @@ internal constructor(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (@Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception) {
-                    if (!isOwned(p, attemptGeneration)) {
+                    if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
                         throw SupersededConnectionAttemptException()
                     }
-                    if (autoConnect) {
-                        // Already on the autoConnect path and still failing: surface a clear Disconnected
-                        // and let the outer reconnect loop (BleRadioTransport) own the macro retry budget.
+                    if (autoConnect.value) {
+                        // The autoConnect fallback also failed. Publish Disconnected and let the outer reconnect loop
+                        // own the macro retry budget.
                         Logger.w {
                             "[${device.address.anonymize()}] autoConnect also failed; deferring to outer reconnect loop"
                         }
                         publishStateIfOwned(
                             p,
-                            attemptGeneration,
+                            installedGeneration,
                             meshtasticDevice,
                             BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
                         )
@@ -313,12 +331,12 @@ internal constructor(
         // would have kept iterating; the bounded loop defers to the outer reconnect policy.
         // Guard against false-positive Connected by verifying state here.
         if (p.state.value !is State.Connected) {
-            if (!isOwned(p, attemptGeneration)) {
+            if (!isCurrentOwnedAttempt(p, attemptGeneration, installedGeneration)) {
                 throw SupersededConnectionAttemptException()
             }
             publishStateIfOwned(
                 p,
-                attemptGeneration,
+                installedGeneration,
                 meshtasticDevice,
                 BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
             )
@@ -326,7 +344,7 @@ internal constructor(
                 "Failed to establish connection after bounded attempts (state=${p.state.value})",
             )
         }
-        if (!publishStateIfOwned(p, attemptGeneration, meshtasticDevice, BleConnectionState.Connected)) {
+        if (!publishStateIfOwned(p, installedGeneration, meshtasticDevice, BleConnectionState.Connected)) {
             throw SupersededConnectionAttemptException()
         }
     }
@@ -362,18 +380,20 @@ internal constructor(
     }
 
     override suspend fun disconnect() {
+        val localDisconnect = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
         val owned =
             lifecycleMutex.withLock {
-                lifecycleGeneration += 1
-                peripheral
+                connectAttemptGeneration += 1
+                val current = peripheral
+                if (current == null) {
+                    (_deviceFlow.value as? MeshtasticBleDevice)?.updateState(localDisconnect)
+                    _connectionState.value = localDisconnect
+                    _deviceFlow.value = null
+                }
+                current
             }
-        if (owned == null) {
-            lifecycleMutex.withLock {
-                _connectionState.value = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
-                _deviceFlow.value = null
-            }
-        } else {
-            closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect))
+        if (owned != null) {
+            closeConnection(owned, localDisconnect)
         }
     }
 
@@ -383,26 +403,37 @@ internal constructor(
         device: MeshtasticBleDevice,
         state: BleConnectionState,
     ): Boolean = lifecycleMutex.withLock {
-        if (peripheral !== owned || generation != lifecycleGeneration) return@withLock false
+        if (peripheral !== owned || generation != ownershipGeneration) return@withLock false
         device.updateState(state)
         _connectionState.value = state
         true
     }
 
-    private suspend fun isOwned(owned: Peripheral, generation: Long): Boolean =
-        lifecycleMutex.withLock { peripheral === owned && generation == lifecycleGeneration }
+    private suspend fun isCurrentOwnedAttempt(
+        owned: Peripheral,
+        attemptGeneration: Long,
+        installedGeneration: Long,
+    ): Boolean = lifecycleMutex.withLock {
+        peripheral === owned &&
+            attemptGeneration == connectAttemptGeneration &&
+            installedGeneration == ownershipGeneration
+    }
 
     private suspend fun closeAfterCancellation(owned: Peripheral?, cancellation: CancellationException): Nothing {
-        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.Cancelled)) }
-            .exceptionOrNull()
-            ?.let(cancellation::addSuppressed)
+        if (owned != null) {
+            runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.Cancelled)) }
+                .exceptionOrNull()
+                ?.let(cancellation::addSuppressed)
+        }
         throw cancellation
     }
 
     private suspend fun closeAfterConnectFailure(owned: Peripheral?, failure: Exception): Nothing {
-        runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)) }
-            .exceptionOrNull()
-            ?.let(failure::addSuppressed)
+        if (owned != null) {
+            runCatching { closeConnection(owned, BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed)) }
+                .exceptionOrNull()
+                ?.let(failure::addSuppressed)
+        }
         throw failure
     }
 
@@ -410,8 +441,10 @@ internal constructor(
         withContext(NonCancellable) {
             lifecycleMutex.withLock {
                 if (owned != null && peripheral === owned) {
+                    ownershipGeneration += 1
                     // Publish before cancelling the collector so downstream consumers cannot miss the terminal
                     // state when the peripheral's own Disconnected emission races teardown.
+                    (_deviceFlow.value as? MeshtasticBleDevice)?.updateState(disconnectedState)
                     _connectionState.value = disconnectedState
                     stateJob?.cancel()
                     connectionScope?.coroutineContext?.job?.cancel()
@@ -428,9 +461,9 @@ internal constructor(
             closePeripheralBounded(owned, "disconnect")
         }
 
-    private class SupersededConnectionAttemptException : Exception()
+    internal class SupersededConnectionAttemptException : Exception("BLE connection attempt was superseded")
 
-    private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?)
+    private data class OwnershipInstallResult(val installed: Boolean, val previous: Peripheral?, val generation: Long?)
 
     @Suppress("ThrowsCount")
     override suspend fun <T> profile(

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/BleExceptionClassifierTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.GattStatusException
 import com.juul.kable.NotConnectedException
+import com.juul.kable.UnmetRequirementReason
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,12 +37,13 @@ class BleExceptionClassifierTest {
 
     @Test
     fun `GattStatusException maps to non-permanent with status code`() {
-        val ex = GattStatusException(message = "GATT failure", status = 133)
+        val ex = GattStatusException(message = "GATT failure for AA:BB:CC:DD:EE:FF", status = 133)
         val info = ex.classifyBleException()
         assertNotNull(info)
         assertFalse(info.isPermanent)
         assertEquals(133, info.gattStatus)
-        assertTrue(info.message.contains("133"))
+        assertEquals("GATT error (status 133)", info.message)
+        assertFalse(info.message.contains("AA:BB:CC:DD:EE:FF"))
     }
 
     @Test
@@ -52,6 +54,15 @@ class BleExceptionClassifierTest {
         assertFalse(info.isPermanent)
         assertNull(info.gattStatus)
         assertEquals("Not connected", info.message)
+    }
+
+    @Test
+    fun `unmet requirement reasons map to fixed actionable messages`() {
+        assertEquals("Bluetooth is turned off", UnmetRequirementReason.BluetoothDisabled.toBleAvailabilityMessage())
+        assertEquals(
+            "Location services are turned off",
+            UnmetRequirementReason.LocationServicesDisabled.toBleAvailabilityMessage(),
+        )
     }
 
     @Test

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -23,6 +23,7 @@ import com.juul.kable.State
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -33,6 +34,7 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
@@ -44,6 +46,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -152,6 +155,33 @@ class KableBleConnectionTest {
     }
 
     @Test
+    fun `disconnect publishes local terminal state to the connection and tracked device`() = runTest {
+        val state = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        every { peripheral.state } returns state
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripheral },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val localDisconnect = BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect)
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(device, 1.seconds))
+
+        connection.disconnect()
+
+        assertEquals(localDisconnect, connection.connectionState.value)
+        assertEquals(localDisconnect, device.state.value)
+        assertNull(connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
+    }
+
+    @Test
     fun `disconnect invalidates an attempt before peripheral ownership is installed`() = runTest {
         val fixture = deferredPeripheralFixture(backgroundScope)
         val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
@@ -162,7 +192,7 @@ class KableBleConnectionTest {
         fixture.releaseFactory.complete(Unit)
         val failure = attempt.await().exceptionOrNull()
 
-        assertTrue(failure != null && failure !is CancellationException)
+        assertIs<KableBleConnection.SupersededConnectionAttemptException>(failure)
         assertEquals(
             BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
             fixture.connection.connectionState.value,
@@ -183,10 +213,7 @@ class KableBleConnectionTest {
         fixture.connection.disconnect()
         fixture.releaseFactory.complete(Unit)
 
-        assertEquals(
-            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
-            attempt.await(),
-        )
+        assertEquals(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed), attempt.await())
         assertEquals(
             BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
             fixture.connection.connectionState.value,
@@ -254,19 +281,24 @@ class KableBleConnectionTest {
             BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
             connection.connectionState.value,
         )
+        assertEquals(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed), device.state.value)
         assertNull(ActiveBleConnection.active)
         verifySuspend(exactly(1)) { peripheral.disconnect() }
         verify(exactly(1)) { peripheral.close() }
     }
 
     @Test
-    fun `factory failure before ownership leaves the active connection intact`() = runTest {
+    fun `factory failure before ownership leaves the active connection intact`() = runTest(UnconfinedTestDispatcher()) {
         val activeState = MutableStateFlow<State>(State.Connected(backgroundScope))
         val activePeripheral: Peripheral = mock(MockMode.autofill)
         every { activePeripheral.state } returns activeState
         everySuspend { activePeripheral.disconnect() } returns Unit
         every { activePeripheral.close() } returns Unit
-        val factoryFailure = IllegalStateException("factory failed")
+        // A non-copyable subtype keeps referential identity stable across coroutine stack-trace recovery.
+        val factoryFailure =
+            object : IllegalStateException("factory failed") {
+                override val cause: Throwable? = null
+            }
         var factoryCalls = 0
         val connection =
             KableBleConnection(
@@ -288,8 +320,44 @@ class KableBleConnectionTest {
         assertSame(activePeripheral, ActiveBleConnection.active?.peripheral)
         assertSame(activeDevice, connection.device)
         assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+
+        activeState.value = State.Disconnected(status = null)
+        runCurrent()
+
+        assertIs<BleConnectionState.Disconnected>(connection.connectionState.value)
         verifySuspend(exactly(0)) { activePeripheral.disconnect() }
         verify(exactly(0)) { activePeripheral.close() }
+    }
+
+    @Test
+    fun `bounded connect publishes failure when Kable returns without connecting`() = runTest {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val firstScope = CoroutineScope(backgroundScope.coroutineContext + Job())
+        val secondScope = CoroutineScope(backgroundScope.coroutineContext + Job())
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        every { peripheral.state } returns state
+        everySuspend { peripheral.connect() } sequentiallyReturns listOf(firstScope, secondScope)
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripheral },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01", advertisement = mock(MockMode.autofill))
+
+        val failure = assertFailsWith<NotConnectedException> { connection.connect(device) }
+
+        assertTrue(failure.message.orEmpty().contains("bounded attempts"))
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            connection.connectionState.value,
+        )
+        assertNull(connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
     }
 
     @Test

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -31,7 +31,9 @@ import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
@@ -151,40 +153,48 @@ class KableBleConnectionTest {
 
     @Test
     fun `disconnect invalidates an attempt before peripheral ownership is installed`() = runTest {
-        val state = MutableStateFlow<State>(State.Disconnected(status = null))
-        val peripheral: Peripheral = mock(MockMode.autofill)
-        val factoryStarted = CompletableDeferred<Unit>()
-        val releaseFactory = CompletableDeferred<Unit>()
-        every { peripheral.state } returns state
-        everySuspend { peripheral.disconnect() } returns Unit
-        every { peripheral.close() } returns Unit
-        val connection =
-            KableBleConnection(
-                scope = backgroundScope,
-                loggingConfig = BleLoggingConfig.Release,
-                peripheralFactory =
-                KablePeripheralFactory { _, _ ->
-                    factoryStarted.complete(Unit)
-                    releaseFactory.await()
-                    peripheral
-                },
-            )
+        val fixture = deferredPeripheralFixture(backgroundScope)
         val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
 
-        val attempt = backgroundScope.launch { connection.connect(device) }
-        factoryStarted.await()
-        connection.disconnect()
-        releaseFactory.complete(Unit)
-        attempt.join()
+        val attempt = backgroundScope.async { runCatching { fixture.connection.connect(device) } }
+        fixture.factoryStarted.await()
+        fixture.connection.disconnect()
+        fixture.releaseFactory.complete(Unit)
+        val failure = attempt.await().exceptionOrNull()
 
+        assertTrue(failure != null && failure !is CancellationException)
         assertEquals(
             BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
-            connection.connectionState.value,
+            fixture.connection.connectionState.value,
         )
-        assertNull(connection.device)
+        assertNull(fixture.connection.device)
         assertNull(ActiveBleConnection.active)
-        verifySuspend(exactly(1)) { peripheral.disconnect() }
-        verify(exactly(1)) { peripheral.close() }
+        verifySuspend(exactly(1)) { fixture.peripheral.disconnect() }
+        verify(exactly(1)) { fixture.peripheral.close() }
+    }
+
+    @Test
+    fun `connectAndAwait maps a superseded attempt to a retryable failure`() = runTest {
+        val fixture = deferredPeripheralFixture(backgroundScope)
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+
+        val attempt = backgroundScope.async { fixture.connection.connectAndAwait(device, 5.seconds) }
+        fixture.factoryStarted.await()
+        fixture.connection.disconnect()
+        fixture.releaseFactory.complete(Unit)
+
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            attempt.await(),
+        )
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
+            fixture.connection.connectionState.value,
+        )
+        assertNull(fixture.connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { fixture.peripheral.disconnect() }
+        verify(exactly(1)) { fixture.peripheral.close() }
     }
 
     @Test
@@ -441,6 +451,35 @@ class KableBleConnectionTest {
 
         assertEquals("Unexpected scanner state", failure.message)
     }
+
+    private fun deferredPeripheralFixture(scope: CoroutineScope): DeferredPeripheralFixture {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        val factoryStarted = CompletableDeferred<Unit>()
+        val releaseFactory = CompletableDeferred<Unit>()
+        every { peripheral.state } returns state
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = scope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory =
+                KablePeripheralFactory { _, _ ->
+                    factoryStarted.complete(Unit)
+                    releaseFactory.await()
+                    peripheral
+                },
+            )
+        return DeferredPeripheralFixture(connection, peripheral, factoryStarted, releaseFactory)
+    }
+
+    private data class DeferredPeripheralFixture(
+        val connection: KableBleConnection,
+        val peripheral: Peripheral,
+        val factoryStarted: CompletableDeferred<Unit>,
+        val releaseFactory: CompletableDeferred<Unit>,
+    )
 
     private class TestKableBleScanner(
         private val scanResults: Flow<KableScanResult>,

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -17,11 +17,25 @@
 package org.meshtastic.core.ble
 
 import com.juul.kable.Advertisement
+import com.juul.kable.NotConnectedException
+import com.juul.kable.Peripheral
+import com.juul.kable.State
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -30,11 +44,14 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -42,6 +59,228 @@ import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class KableBleConnectionTest {
+
+    @AfterTest
+    fun tearDown() {
+        ActiveBleConnection.active = null
+    }
+
+    @Test
+    fun `cancelled stale attempt cannot close a newer peripheral`() = runTest {
+        val oldState = MutableStateFlow<State>(State.Connecting.Bluetooth)
+        val newState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val oldPeripheral: Peripheral = mock(MockMode.autofill)
+        val newPeripheral: Peripheral = mock(MockMode.autofill)
+        val oldConnectStarted = CompletableDeferred<Unit>()
+        every { oldPeripheral.state } returns oldState
+        every { newPeripheral.state } returns newState
+        everySuspend { oldPeripheral.connect() } calls
+            {
+                oldConnectStarted.complete(Unit)
+                awaitCancellation()
+            }
+        everySuspend { oldPeripheral.disconnect() } returns Unit
+        everySuspend { newPeripheral.disconnect() } returns Unit
+        every { oldPeripheral.close() } returns Unit
+        every { newPeripheral.close() } returns Unit
+        val peripherals = ArrayDeque(listOf(oldPeripheral, newPeripheral))
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripherals.removeFirst() },
+            )
+        val oldDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val newDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+
+        val oldAttempt = backgroundScope.launch { connection.connectAndAwait(oldDevice, 30.seconds) }
+        oldConnectStarted.await()
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(newDevice, 1.seconds))
+        oldAttempt.cancelAndJoin()
+        runCurrent()
+
+        assertSame(newPeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(newDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verifySuspend(exactly(0)) { newPeripheral.disconnect() }
+        verify(exactly(0)) { newPeripheral.close() }
+    }
+
+    @Test
+    fun `disconnect cleanup cannot clear a replacement device`() = runTest {
+        val oldState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val newState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val oldPeripheral: Peripheral = mock(MockMode.autofill)
+        val newPeripheral: Peripheral = mock(MockMode.autofill)
+        val oldDisconnectStarted = CompletableDeferred<Unit>()
+        val releaseOldDisconnect = CompletableDeferred<Unit>()
+        every { oldPeripheral.state } returns oldState
+        every { newPeripheral.state } returns newState
+        everySuspend { oldPeripheral.disconnect() } calls
+            {
+                oldDisconnectStarted.complete(Unit)
+                releaseOldDisconnect.await()
+            }
+        everySuspend { newPeripheral.disconnect() } returns Unit
+        every { oldPeripheral.close() } returns Unit
+        every { newPeripheral.close() } returns Unit
+        val peripherals = ArrayDeque(listOf(oldPeripheral, newPeripheral))
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripherals.removeFirst() },
+            )
+        val oldDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val newDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(oldDevice, 1.seconds))
+
+        val disconnect = backgroundScope.launch { connection.disconnect() }
+        oldDisconnectStarted.await()
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(newDevice, 1.seconds))
+        releaseOldDisconnect.complete(Unit)
+        disconnect.join()
+        runCurrent()
+
+        assertSame(newPeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(newDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verifySuspend(exactly(0)) { newPeripheral.disconnect() }
+        verify(exactly(0)) { newPeripheral.close() }
+    }
+
+    @Test
+    fun `disconnect invalidates an attempt before peripheral ownership is installed`() = runTest {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        val factoryStarted = CompletableDeferred<Unit>()
+        val releaseFactory = CompletableDeferred<Unit>()
+        every { peripheral.state } returns state
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory =
+                KablePeripheralFactory { _, _ ->
+                    factoryStarted.complete(Unit)
+                    releaseFactory.await()
+                    peripheral
+                },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+
+        val attempt = backgroundScope.launch { connection.connect(device) }
+        factoryStarted.await()
+        connection.disconnect()
+        releaseFactory.complete(Unit)
+        attempt.join()
+
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.LocalDisconnect),
+            connection.connectionState.value,
+        )
+        assertNull(connection.device)
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
+    }
+
+    @Test
+    fun `replacement continues after superseded peripheral teardown times out`() = runTest {
+        val oldState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val newState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val oldPeripheral: Peripheral = mock(MockMode.autofill)
+        val newPeripheral: Peripheral = mock(MockMode.autofill)
+        every { oldPeripheral.state } returns oldState
+        every { newPeripheral.state } returns newState
+        everySuspend { oldPeripheral.disconnect() } calls { awaitCancellation() }
+        everySuspend { newPeripheral.disconnect() } returns Unit
+        every { oldPeripheral.close() } returns Unit
+        every { newPeripheral.close() } returns Unit
+        val peripherals = ArrayDeque(listOf(oldPeripheral, newPeripheral))
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripherals.removeFirst() },
+            )
+        val oldDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val newDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(oldDevice, 1.seconds))
+
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(newDevice, 5.seconds))
+
+        assertSame(newPeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(newDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verify(exactly(1)) { oldPeripheral.close() }
+        verifySuspend(exactly(0)) { newPeripheral.disconnect() }
+        verify(exactly(0)) { newPeripheral.close() }
+    }
+
+    @Test
+    fun `connect failure releases peripheral ownership before rethrowing`() = runTest {
+        val state = MutableStateFlow<State>(State.Disconnected(status = null))
+        val peripheral: Peripheral = mock(MockMode.autofill)
+        every { peripheral.state } returns state
+        everySuspend { peripheral.connect() } throws NotConnectedException("connect failed")
+        everySuspend { peripheral.disconnect() } returns Unit
+        every { peripheral.close() } returns Unit
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory = KablePeripheralFactory { _, _ -> peripheral },
+            )
+        val device = MeshtasticBleDevice("AA:BB:CC:DD:EE:01", advertisement = mock(MockMode.autofill))
+
+        val failure = assertFailsWith<NotConnectedException> { connection.connect(device) }
+
+        assertEquals("connect failed", failure.message)
+        assertNull(connection.device)
+        assertEquals(
+            BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed),
+            connection.connectionState.value,
+        )
+        assertNull(ActiveBleConnection.active)
+        verifySuspend(exactly(1)) { peripheral.disconnect() }
+        verify(exactly(1)) { peripheral.close() }
+    }
+
+    @Test
+    fun `factory failure before ownership leaves the active connection intact`() = runTest {
+        val activeState = MutableStateFlow<State>(State.Connected(backgroundScope))
+        val activePeripheral: Peripheral = mock(MockMode.autofill)
+        every { activePeripheral.state } returns activeState
+        everySuspend { activePeripheral.disconnect() } returns Unit
+        every { activePeripheral.close() } returns Unit
+        val factoryFailure = IllegalStateException("factory failed")
+        var factoryCalls = 0
+        val connection =
+            KableBleConnection(
+                scope = backgroundScope,
+                loggingConfig = BleLoggingConfig.Release,
+                peripheralFactory =
+                KablePeripheralFactory { _, _ ->
+                    factoryCalls += 1
+                    if (factoryCalls == 1) activePeripheral else throw factoryFailure
+                },
+            )
+        val activeDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:01")
+        val replacementDevice = MeshtasticBleDevice("AA:BB:CC:DD:EE:02")
+        assertEquals(BleConnectionState.Connected, connection.connectAndAwait(activeDevice, 1.seconds))
+
+        val failure = assertFailsWith<IllegalStateException> { connection.connect(replacementDevice) }
+
+        assertSame(factoryFailure, failure)
+        assertSame(activePeripheral, ActiveBleConnection.active?.peripheral)
+        assertSame(activeDevice, connection.device)
+        assertEquals(BleConnectionState.Connected, connection.connectionState.value)
+        verifySuspend(exactly(0)) { activePeripheral.disconnect() }
+        verify(exactly(0)) { activePeripheral.close() }
+    }
 
     @Test
     fun `scan emits ble device for discovered advertisement`() = runTest {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
@@ -32,6 +32,7 @@ import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.TelemetryType
 import org.meshtastic.core.model.util.isWithinSizeLimit
+import org.meshtastic.core.repository.AwaitedSendResult
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
@@ -89,6 +90,8 @@ class CommandSenderImpl(
     override fun getCachedChannelSet(): ChannelSet = channelSet.value
 
     override fun getCurrentPacketId(): Long = currentPacketId.value
+
+    private fun Int.nonZeroRequestId(): Int = takeUnless { it == 0 } ?: generatePacketId()
 
     override fun generatePacketId(): Int {
         val numPacketIds = ((1L shl PACKET_ID_SHIFT_BITS) - 1)
@@ -174,11 +177,20 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(meshPacket)
     }
 
+    private fun buildAdminMessagePacket(
+        destNum: Int,
+        requestId: Int,
+        wantResponse: Boolean,
+        initFn: () -> AdminMessage,
+    ): MeshPacket = buildAdminPacket(
+        to = destNum,
+        id = requestId.nonZeroRequestId(),
+        wantResponse = wantResponse,
+        adminMessage = initFn().copy(session_passkey = sessionManager.getPasskey(destNum)),
+    )
+
     override suspend fun sendAdmin(destNum: Int, requestId: Int, wantResponse: Boolean, initFn: () -> AdminMessage) {
-        val adminMsg = initFn().copy(session_passkey = sessionManager.getPasskey(destNum))
-        val packet =
-            buildAdminPacket(to = destNum, id = requestId, wantResponse = wantResponse, adminMessage = adminMsg)
-        packetHandler.sendToRadio(packet)
+        packetHandler.sendToRadio(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn))
     }
 
     override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {
@@ -187,17 +199,13 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(ToRadio(packet = packet))
     }
 
-    override suspend fun sendAdminAwait(
+    override suspend fun sendAdminAwaitResult(
         destNum: Int,
         requestId: Int,
         wantResponse: Boolean,
         initFn: () -> AdminMessage,
-    ): Boolean {
-        val adminMsg = initFn().copy(session_passkey = sessionManager.getPasskey(destNum))
-        val packet =
-            buildAdminPacket(to = destNum, id = requestId, wantResponse = wantResponse, adminMessage = adminMsg)
-        return packetHandler.sendToRadioAndAwait(packet)
-    }
+    ): AwaitedSendResult =
+        packetHandler.sendToRadioAndAwaitResult(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn))
 
     override suspend fun sendPosition(pos: ProtoPosition, destNum: Int?, wantResponse: Boolean) {
         val myNum = nodeManager.myNodeNum.value ?: return
@@ -281,19 +289,22 @@ class CommandSenderImpl(
     }
 
     override suspend fun requestTraceroute(requestId: Int, destNum: Int) {
-        tracerouteHandler.recordStartTime(requestId)
-        packetHandler.sendToRadio(
-            buildMeshPacket(
-                to = destNum,
-                wantAck = true,
-                id = requestId,
-                channel = getChannelIndex(destNum),
-                decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
-            ),
-        )
+        val effectiveRequestId = requestId.nonZeroRequestId()
+        val queued =
+            packetHandler.sendToRadio(
+                buildMeshPacket(
+                    to = destNum,
+                    wantAck = true,
+                    id = effectiveRequestId,
+                    channel = getChannelIndex(destNum),
+                    decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
+                ),
+            )
+        if (queued) tracerouteHandler.recordStartTime(effectiveRequestId)
     }
 
     override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) {
+        val effectiveRequestId = requestId.nonZeroRequestId()
         val type = TelemetryType.entries.getOrNull(typeValue) ?: TelemetryType.DEVICE
 
         val portNum: PortNum
@@ -320,7 +331,7 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(
             buildMeshPacket(
                 to = destNum,
-                id = requestId,
+                id = effectiveRequestId,
                 channel = getChannelIndex(destNum),
                 decoded = Data(portnum = portNum, payload = payloadBytes, want_response = true, dest = destNum),
             ),
@@ -328,57 +339,59 @@ class CommandSenderImpl(
     }
 
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {
-        neighborInfoHandler.recordStartTime(requestId)
+        val effectiveRequestId = requestId.nonZeroRequestId()
         val myNum = nodeManager.myNodeNum.value ?: 0
-        if (destNum == myNum) {
-            val neighborInfoToSend =
-                neighborInfoHandler.lastNeighborInfo
-                    ?: run {
-                        val oneHour = 1.hours.inWholeMinutes.toInt()
-                        Logger.d { "No stored neighbor info from connected radio, sending dummy data" }
-                        NeighborInfo(
-                            node_id = myNum,
-                            last_sent_by_id = myNum,
-                            node_broadcast_interval_secs = oneHour,
-                            neighbors =
-                            listOf(
-                                Neighbor(
-                                    node_id = 0, // Dummy node ID that can be intercepted
-                                    snr = 0f,
-                                    last_rx_time = (nowMillis / 1000L).toInt(),
-                                    node_broadcast_interval_secs = oneHour,
+        val queued =
+            if (destNum == myNum) {
+                val neighborInfoToSend =
+                    neighborInfoHandler.lastNeighborInfo
+                        ?: run {
+                            val oneHour = 1.hours.inWholeMinutes.toInt()
+                            Logger.d { "No stored neighbor info from connected radio, sending dummy data" }
+                            NeighborInfo(
+                                node_id = myNum,
+                                last_sent_by_id = myNum,
+                                node_broadcast_interval_secs = oneHour,
+                                neighbors =
+                                listOf(
+                                    Neighbor(
+                                        node_id = 0, // Dummy node ID that can be intercepted
+                                        snr = 0f,
+                                        last_rx_time = (nowMillis / 1000L).toInt(),
+                                        node_broadcast_interval_secs = oneHour,
+                                    ),
                                 ),
-                            ),
-                        )
-                    }
+                            )
+                        }
 
-            // Send the neighbor info from our connected radio to ourselves (simulated)
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = requestId,
-                    channel = getChannelIndex(destNum),
-                    decoded =
-                    Data(
-                        portnum = PortNum.NEIGHBORINFO_APP,
-                        payload = neighborInfoToSend.encode().toByteString(),
-                        want_response = true,
+                // Send the neighbor info from our connected radio to ourselves (simulated)
+                packetHandler.sendToRadio(
+                    buildMeshPacket(
+                        to = destNum,
+                        wantAck = true,
+                        id = effectiveRequestId,
+                        channel = getChannelIndex(destNum),
+                        decoded =
+                        Data(
+                            portnum = PortNum.NEIGHBORINFO_APP,
+                            payload = neighborInfoToSend.encode().toByteString(),
+                            want_response = true,
+                        ),
                     ),
-                ),
-            )
-        } else {
-            // Send request to remote
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = requestId,
-                    channel = getChannelIndex(destNum),
-                    decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
-                ),
-            )
-        }
+                )
+            } else {
+                // Send request to remote
+                packetHandler.sendToRadio(
+                    buildMeshPacket(
+                        to = destNum,
+                        wantAck = true,
+                        id = effectiveRequestId,
+                        channel = getChannelIndex(destNum),
+                        decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
+                    ),
+                )
+            }
+        if (queued) neighborInfoHandler.recordStartTime(effectiveRequestId)
     }
 
     override fun sendLockdownPassphrase(

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
@@ -64,6 +64,10 @@ import kotlin.random.Random
 import kotlin.time.Duration.Companion.hours
 import org.meshtastic.proto.Position as ProtoPosition
 
+/** Thrown when the outbound packet queue refuses admission for a command. */
+class PacketQueueRejectedException(operation: String) :
+    IllegalStateException("$operation was rejected by the outbound packet queue")
+
 @Suppress("TooManyFunctions", "CyclomaticComplexMethod", "LongParameterList")
 @Single
 class CommandSenderImpl(
@@ -154,10 +158,10 @@ class CommandSenderImpl(
             p.status = MessageStatus.QUEUED
         }
 
-        sendNow(p)
+        if (!sendNow(p)) p.status = MessageStatus.ERROR
     }
 
-    private suspend fun sendNow(p: DataPacket) {
+    private suspend fun sendNow(p: DataPacket): Boolean {
         val meshPacket =
             buildMeshPacket(
                 to = resolveNodeNum(NodeAddress.fromString(p.to)),
@@ -174,7 +178,11 @@ class CommandSenderImpl(
                 ),
             )
         p.time = nowMillis
-        packetHandler.sendToRadio(meshPacket)
+        return packetHandler.sendToRadio(meshPacket)
+    }
+
+    private suspend fun enqueueOrThrow(packet: MeshPacket, operation: String) {
+        if (!packetHandler.sendToRadio(packet)) throw PacketQueueRejectedException(operation)
     }
 
     private fun buildAdminMessagePacket(
@@ -190,7 +198,7 @@ class CommandSenderImpl(
     )
 
     override suspend fun sendAdmin(destNum: Int, requestId: Int, wantResponse: Boolean, initFn: () -> AdminMessage) {
-        packetHandler.sendToRadio(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn))
+        enqueueOrThrow(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn), "Admin command")
     }
 
     override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {
@@ -212,11 +220,7 @@ class CommandSenderImpl(
         val idNum = destNum ?: myNum
         Logger.d { "Sending our position/time to=$idNum $pos" }
 
-        if (localConfig.value.position?.fixed_position != true) {
-            nodeManager.handleReceivedPosition(myNum, myNum, pos, nowMillis)
-        }
-
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = idNum,
                 channel = if (destNum == null) 0 else getChannelIndex(destNum),
@@ -228,7 +232,11 @@ class CommandSenderImpl(
                     want_response = wantResponse,
                 ),
             ),
+            "Position update",
         )
+        if (localConfig.value.position?.fixed_position != true) {
+            nodeManager.handleReceivedPosition(myNum, myNum, pos, nowMillis)
+        }
     }
 
     override suspend fun requestPosition(destNum: Int, currentPosition: Position) {
@@ -239,7 +247,7 @@ class CommandSenderImpl(
                 altitude = currentPosition.altitude,
                 time = (nowMillis / 1000L).toInt(),
             )
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = destNum,
                 channel = getChannelIndex(destNum),
@@ -251,6 +259,7 @@ class CommandSenderImpl(
                     want_response = true,
                 ),
             ),
+            "Position request",
         )
     }
 
@@ -274,7 +283,7 @@ class CommandSenderImpl(
     override suspend fun requestUserInfo(destNum: Int) {
         val myNum = nodeManager.myNodeNum.value ?: return
         val myNode = nodeManager.nodeDBbyNodeNum[myNum] ?: return
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = destNum,
                 channel = getChannelIndex(destNum),
@@ -285,22 +294,23 @@ class CommandSenderImpl(
                     payload = myNode.user.encode().toByteString(),
                 ),
             ),
+            "User-info request",
         )
     }
 
     override suspend fun requestTraceroute(requestId: Int, destNum: Int) {
         val effectiveRequestId = requestId.nonZeroRequestId()
-        val queued =
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = effectiveRequestId,
-                    channel = getChannelIndex(destNum),
-                    decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
-                ),
-            )
-        if (queued) tracerouteHandler.recordStartTime(effectiveRequestId)
+        enqueueOrThrow(
+            buildMeshPacket(
+                to = destNum,
+                wantAck = true,
+                id = effectiveRequestId,
+                channel = getChannelIndex(destNum),
+                decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
+            ),
+            "Traceroute request",
+        )
+        tracerouteHandler.recordStartTime(effectiveRequestId)
     }
 
     override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) {
@@ -328,20 +338,21 @@ class CommandSenderImpl(
                     .toByteString()
         }
 
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = destNum,
                 id = effectiveRequestId,
                 channel = getChannelIndex(destNum),
                 decoded = Data(portnum = portNum, payload = payloadBytes, want_response = true, dest = destNum),
             ),
+            "Telemetry request",
         )
     }
 
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {
         val effectiveRequestId = requestId.nonZeroRequestId()
         val myNum = nodeManager.myNodeNum.value ?: 0
-        val queued =
+        val packet =
             if (destNum == myNum) {
                 val neighborInfoToSend =
                     neighborInfoHandler.lastNeighborInfo
@@ -365,33 +376,30 @@ class CommandSenderImpl(
                         }
 
                 // Send the neighbor info from our connected radio to ourselves (simulated)
-                packetHandler.sendToRadio(
-                    buildMeshPacket(
-                        to = destNum,
-                        wantAck = true,
-                        id = effectiveRequestId,
-                        channel = getChannelIndex(destNum),
-                        decoded =
-                        Data(
-                            portnum = PortNum.NEIGHBORINFO_APP,
-                            payload = neighborInfoToSend.encode().toByteString(),
-                            want_response = true,
-                        ),
+                buildMeshPacket(
+                    to = destNum,
+                    wantAck = true,
+                    id = effectiveRequestId,
+                    channel = getChannelIndex(destNum),
+                    decoded =
+                    Data(
+                        portnum = PortNum.NEIGHBORINFO_APP,
+                        payload = neighborInfoToSend.encode().toByteString(),
+                        want_response = true,
                     ),
                 )
             } else {
                 // Send request to remote
-                packetHandler.sendToRadio(
-                    buildMeshPacket(
-                        to = destNum,
-                        wantAck = true,
-                        id = effectiveRequestId,
-                        channel = getChannelIndex(destNum),
-                        decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
-                    ),
+                buildMeshPacket(
+                    to = destNum,
+                    wantAck = true,
+                    id = effectiveRequestId,
+                    channel = getChannelIndex(destNum),
+                    decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
                 )
             }
-        if (queued) neighborInfoHandler.recordStartTime(effectiveRequestId)
+        enqueueOrThrow(packet, "Neighbor-info request")
+        neighborInfoHandler.recordStartTime(effectiveRequestId)
     }
 
     override fun sendLockdownPassphrase(

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/HistoryManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/HistoryManagerImpl.kt
@@ -20,6 +20,7 @@ import co.touchlab.kermit.Logger
 import okio.ByteString.Companion.toByteString
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.safeCatching
+import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.repository.HistoryManager
 import org.meshtastic.core.repository.MeshPrefs
 import org.meshtastic.core.repository.PacketHandler
@@ -61,9 +62,7 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
 
     private val logger = Logger.withTag(HISTORY_TAG)
 
-    private fun historyLog(message: String, throwable: Throwable? = null) {
-        logger.i(throwable) { message }
-    }
+    private fun historyLog(message: String) = logger.i { message }
 
     private fun activeDeviceAddress(): String? =
         meshPrefs.deviceAddress.value?.takeIf { !it.equals(NO_DEVICE_SELECTED, ignoreCase = true) && it.isNotBlank() }
@@ -91,7 +90,7 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
         val request = buildStoreForwardHistoryRequest(lastRequest, window, max)
 
         historyLog(
-            "requestHistory trigger=$trigger transport=$transport addr=$address " +
+            "requestHistory trigger=$trigger transport=$transport addr=${address.anonymize()} " +
                 "lastRequest=$lastRequest window=$window max=$max",
         )
 
@@ -106,7 +105,9 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
                 ),
             )
         }
-            .onFailure { ex -> logger.w(ex) { "requestHistory failed" } }
+            .onFailure { failure ->
+                logger.w { "requestHistory failed cause=${failure::class.simpleName ?: "Exception"}" }
+            }
     }
 
     override fun updateStoreForwardLastRequest(source: String, lastRequest: Int, transport: String) {
@@ -117,7 +118,7 @@ class HistoryManagerImpl(private val meshPrefs: MeshPrefs, private val packetHan
             meshPrefs.setStoreForwardLastRequest(address, lastRequest)
             historyLog(
                 "historyMarker updated source=$source transport=$transport " +
-                    "addr=$address from=$current to=$lastRequest",
+                    "addr=${address.anonymize()} from=$current to=$lastRequest",
             )
         }
     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -39,7 +39,6 @@ import org.meshtastic.core.common.di.ServiceScope
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.ConnectionState
-import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
@@ -220,7 +219,11 @@ class PacketHandlerImpl(
         }
         if (serviceStopped) {
             withContext(NonCancellable) {
-                queueMutex.withLock { if (!pending.deferred.isCompleted) stopAndDrainPacketQueueLocked() }
+                val failedPacketIds =
+                    queueMutex.withLock {
+                        if (!pending.deferred.isCompleted) stopAndDrainPacketQueueLocked() else emptyList()
+                    }
+                changeStatusesNow(failedPacketIds, MessageStatus.ERROR)
             }
         }
         return pending.deferred.await()
@@ -229,15 +232,19 @@ class PacketHandlerImpl(
     override fun stopPacketQueue() {
         // Run async so callers (non-suspend) don't block, but all mutations are
         // serialized under the same mutexes used by the queue processor and senders.
-        scope.launch {
+        scope.handledLaunch {
             Logger.i { "Stopping packet queueJob" }
-            queueMutex.withLock {
-                queueStopped = true
-                queueJob?.cancel()
-                queueJob = null
-                queueGeneration++
-                queuedPackets.clear()
-                completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+            withContext(NonCancellable) {
+                val failedPacketIds =
+                    queueMutex.withLock {
+                        queueStopped = true
+                        queueJob?.cancel()
+                        queueJob = null
+                        queueGeneration++
+                        queuedPackets.clear()
+                        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                    }
+                changeStatusesNow(failedPacketIds, MessageStatus.ERROR)
             }
         }
     }
@@ -254,10 +261,13 @@ class PacketHandlerImpl(
         scope.launch {
             responseMutex.withLock {
                 if (requestId != 0) {
-                    queueResponse[requestId]?.deferred?.complete(success.toAwaitedSendStatus())
+                    queueResponse[requestId]
+                        ?.takeIf { it.wasDispatched }
+                        ?.deferred
+                        ?.complete(success.toAwaitedSendStatus())
                 } else {
                     queueResponse.values
-                        .firstOrNull { !it.deferred.isCompleted }
+                        .firstOrNull { it.wasDispatched && !it.deferred.isCompleted }
                         ?.deferred
                         ?.complete(success.toAwaitedSendStatus())
                 }
@@ -266,7 +276,12 @@ class PacketHandlerImpl(
     }
 
     override suspend fun removeResponse(dataRequestId: Int, complete: Boolean) {
-        responseMutex.withLock { queueResponse[dataRequestId]?.deferred?.complete(complete.toAwaitedSendStatus()) }
+        responseMutex.withLock {
+            queueResponse[dataRequestId]
+                ?.takeIf { it.wasDispatched }
+                ?.deferred
+                ?.complete(complete.toAwaitedSendStatus())
+        }
     }
 
     /**
@@ -274,10 +289,13 @@ class PacketHandlerImpl(
      * atomic — preventing two concurrent callers from launching duplicate processors.
      */
     private fun startPacketQueueLocked() {
+        check(queueMutex.isLocked) { "Packet queue workers must start while queueMutex is held" }
         if (queueStopped || queueJob?.isActive == true) return
 
         val generation = ++queueGeneration
         // Install cleanup before admission releases queueMutex so cancellation cannot bypass the worker's finally.
+        // UNDISPATCHED enters immediately, then suspends on queueMutex until enqueuePacket releases the admission
+        // lock; this closes the cancellation gap without running queue mutation inside the caller's critical section.
         queueJob =
             scope.handledLaunch(start = CoroutineStart.UNDISPATCHED) {
                 try {
@@ -299,6 +317,7 @@ class PacketHandlerImpl(
             Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
             val status = withTimeout(TIMEOUT) { response.await() }
             Logger.d { "queueJob packet id=${packet.id.toUInt()} status $status" }
+            if (status != AwaitedSendStatus.ACCEPTED) changeStatus(packet.id, MessageStatus.ERROR)
             // External status paths only complete the response; the queue worker owns reservation removal so an ID
             // cannot be reused while its original packet can still be transmitted.
             removePendingResponse(packet.id, pending)
@@ -307,16 +326,25 @@ class PacketHandlerImpl(
             // Complete an awaiting caller before removing the response. Its timeout starts here, after the packet is
             // actually sent, rather than while it waits behind the existing FIFO backlog.
             pending.deferred.complete(AwaitedSendStatus.TIMED_OUT)
+            // A response the transport already accepted must not be reclassified by the timeout.
+            if (pending.deferred.getCompleted() != AwaitedSendStatus.ACCEPTED) {
+                changeStatus(packet.id, MessageStatus.ERROR)
+            }
             removePendingResponse(packet.id, pending)
         } catch (e: CancellationException) {
             // A later queued packet makes finishPacketQueueGeneration restart the worker instead of draining the
-            // interrupted entry. Complete and remove this reservation before propagating cancellation.
+            // interrupted entry. Complete and remove this reservation before propagating cancellation. A response
+            // the transport already accepted keeps its ACCEPTED status: shutdown preemption cannot reclassify it.
             pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
+            if (pending.deferred.getCompleted() != AwaitedSendStatus.ACCEPTED) {
+                changeStatus(packet.id, MessageStatus.ERROR)
+            }
             removePendingResponse(packet.id, pending)
             throw e // Preserve structured concurrency cancellation propagation.
         } catch (e: Exception) {
             Logger.d { "queueJob packet id=${packet.id.toUInt()} failed" }
             pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+            changeStatus(packet.id, MessageStatus.ERROR)
             removePendingResponse(packet.id, pending)
         }
         // Queue shutdown can clear the same entry concurrently; identity-checked removal keeps every path idempotent.
@@ -326,65 +354,75 @@ class PacketHandlerImpl(
         // Keep completion, replacement, and disconnect draining atomic with new admissions. queueGeneration
         // advances only under queueMutex: stopPacketQueue() drains every pending response, while
         // startPacketQueueLocked() advances it only after the previous queueJob is inactive. Therefore a stale
-        // worker
-        // has already lost ownership to a path that drained or replaced it and must not clear that replacement job.
-        queueMutex.withLock {
-            if (generation != queueGeneration) return@withLock
-            queueJob = null
-            when {
-                queueStopped || !scope.isActive -> stopAndDrainPacketQueueLocked()
+        // worker has already lost ownership to a path that drained or replaced it and must not clear that
+        // replacement
+        // job.
+        val failedPacketIds =
+            queueMutex.withLock {
+                if (generation != queueGeneration) return@withLock emptyList()
+                queueJob = null
+                when {
+                    queueStopped || !scope.isActive -> stopAndDrainPacketQueueLocked()
 
-                connectionStateProvider.connectionState.value != ConnectionState.Connected ->
-                    stopAndDrainPacketQueueLocked()
+                    connectionStateProvider.connectionState.value != ConnectionState.Connected ->
+                        stopAndDrainPacketQueueLocked()
 
-                queuedPackets.isNotEmpty() -> startPacketQueueLocked()
+                    queuedPackets.isNotEmpty() -> {
+                        startPacketQueueLocked()
+                        emptyList()
+                    }
 
-                else -> {
-                    // A normally completed worker has no pending response. Anything left here belongs to an
-                    // in-flight
-                    // packet interrupted by cancellation or an unexpected worker exit.
-                    completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                    else -> {
+                        // A normally completed worker has no pending response. Anything left here belongs to an
+                        // in-flight packet interrupted by cancellation or an unexpected worker exit.
+                        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                    }
                 }
             }
-        }
+        changeStatusesNow(failedPacketIds, MessageStatus.ERROR)
     }
 
-    private suspend fun stopAndDrainPacketQueueLocked() {
+    private suspend fun stopAndDrainPacketQueueLocked(): List<Int> {
         queueStopped = true
         queuedPackets.clear()
-        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+        return completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
     }
 
-    private fun changeStatus(packetId: Int, m: MessageStatus) = scope.handledLaunch {
-        if (packetId != 0) {
-            getDataPacketById(packetId)?.let { p ->
-                if (p.status == m) return@handledLaunch
-                packetRepository.value.updateMessageStatus(p, m)
+    private fun changeStatus(packetId: Int, m: MessageStatus) =
+        scope.handledLaunch { changeStatusesNow(listOf(packetId), m) }
+
+    /** Resolves and updates all known packet IDs within one shared bound, including during non-cancellable teardown. */
+    private suspend fun changeStatusesNow(packetIds: Collection<Int>, status: MessageStatus) {
+        val remaining = packetIds.filterTo(mutableSetOf()) { it != 0 }
+        withTimeoutOrNull(1.seconds) {
+            while (remaining.isNotEmpty()) {
+                remaining.toList().forEach { packetId ->
+                    val packet = packetRepository.value.getPacketById(packetId) ?: return@forEach
+                    if (packet.status != status) packetRepository.value.updateMessageStatus(packet, status)
+                    remaining.remove(packetId)
+                }
+                if (remaining.isNotEmpty()) delay(100.milliseconds)
             }
         }
-    }
-
-    private suspend fun getDataPacketById(packetId: Int): DataPacket? = withTimeoutOrNull(1.seconds) {
-        var dataPacket: DataPacket? = null
-        while (dataPacket == null) {
-            dataPacket = packetRepository.value.getPacketById(packetId)
-            if (dataPacket == null) delay(100.milliseconds)
+        if (remaining.isNotEmpty()) {
+            Logger.w { "Could not apply $status to ${remaining.size} unresolved packet IDs within 1 second" }
         }
-        dataPacket
     }
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun sendPacket(packet: MeshPacket, pending: PendingResponse): Deferred<AwaitedSendStatus> {
         try {
             requireConnected()
-            pending.recordDispatch(dispatchToRadio(ToRadio(packet = packet)))
+            // Serialize dispatch publication with response callbacks. Even a transport that schedules a callback
+            // immediately cannot complete this response before wasDispatched reflects the admission result.
+            responseMutex.withLock { pending.recordDispatch(dispatchToRadio(ToRadio(packet = packet))) }
             if (!pending.wasDispatched) {
                 Logger.w { "sendToRadio dropped: no active transport accepted id=${packet.id.toUInt()}" }
                 pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
             }
         } catch (ex: RadioNotConnectedException) {
             Logger.w(ex) { "sendToRadio skipped: Not connected to radio" }
-            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+            pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
         } catch (ex: CancellationException) {
             throw ex
         } catch (ex: Exception) {
@@ -406,13 +444,15 @@ class PacketHandlerImpl(
     }
 
     private fun Boolean.toAwaitedSendStatus(): AwaitedSendStatus =
-        if (this) AwaitedSendStatus.ACCEPTED else AwaitedSendStatus.REJECTED
+        if (this) AwaitedSendStatus.ACCEPTED else AwaitedSendStatus.RADIO_REJECTED
 
-    private suspend fun completePendingResponses(status: AwaitedSendStatus) {
-        responseMutex.withLock {
-            queueResponse.values.forEach { pending -> pending.deferred.complete(status) }
-            queueResponse.clear()
-        }
+    private suspend fun completePendingResponses(status: AwaitedSendStatus): List<Int> = responseMutex.withLock {
+        val completedPacketIds =
+            queueResponse.mapNotNull { (packetId, pending) ->
+                packetId.takeIf { pending.deferred.complete(status) }
+            }
+        queueResponse.clear()
+        completedPacketIds
     }
 
     private fun insertMeshLog(packetToSave: MeshLog) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -42,6 +42,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
+import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.model.util.toOneLineString
 import org.meshtastic.core.model.util.toPIIString
 import org.meshtastic.core.repository.AwaitedSendResult
@@ -458,8 +459,8 @@ class PacketHandlerImpl(
     private fun insertMeshLog(packetToSave: MeshLog) {
         scope.handledLaunch {
             Logger.d {
-                "insert: ${packetToSave.message_type} = " +
-                    "${packetToSave.raw_message.toOneLineString()} from=${packetToSave.fromNum}"
+                "insert: ${packetToSave.message_type} " +
+                    "port=${packetToSave.portNum} from=${packetToSave.fromNum.anonymize()}"
             }
             meshLogRepository.value.insert(packetToSave)
         }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -152,7 +152,7 @@ class PacketHandlerImpl(
             pending == null && !scope.isActive ->
                 Logger.w { "Rejecting packet id=${packet.id.toUInt()}: service scope is no longer active" }
 
-            pending == null -> Logger.w { "Dropping duplicate queued packet id=${packet.id.toUInt()}" }
+            pending == null -> Logger.w { "Rejecting packet with reserved id=${packet.id.toUInt()}" }
         }
         return pending != null
     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -17,16 +17,21 @@
 package org.meshtastic.core.data.manager
 
 import co.touchlab.kermit.Logger
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.asDeferred
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
@@ -40,6 +45,8 @@ import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
 import org.meshtastic.core.model.util.toOneLineString
 import org.meshtastic.core.model.util.toPIIString
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketHandler
@@ -77,24 +84,43 @@ class PacketHandlerImpl(
     }
 
     private var queueJob: Job? = null
+    private var queueGeneration = 0L
 
     private val queueMutex = Mutex()
-    private val queuedPackets = mutableListOf<MeshPacket>()
+    private val queuedPackets = mutableListOf<QueuedPacket>()
 
     // Set to true by stopPacketQueue() under queueMutex. Checked by startPacketQueueLocked()
     // and the queue processor's finally block to prevent restarting a stopped queue.
     private var queueStopped = false
 
     private val responseMutex = Mutex()
-    private val queueResponse = mutableMapOf<Int, CompletableDeferred<Boolean>>()
+
+    private data class QueuedPacket(val packet: MeshPacket, val pending: PendingResponse)
+
+    private class PendingResponse {
+        val deferred: CompletableDeferred<AwaitedSendStatus> = CompletableDeferred()
+        private val dispatched = atomic(false)
+
+        val wasDispatched: Boolean
+            get() = dispatched.value
+
+        fun recordDispatch(accepted: Boolean) {
+            dispatched.value = accepted
+        }
+    }
+
+    private val queueResponse = mutableMapOf<Int, PendingResponse>()
 
     override fun sendToRadio(p: ToRadio) {
+        dispatchToRadio(p)
+    }
+
+    private fun dispatchToRadio(p: ToRadio): Boolean {
         Logger.d { "Sending to radio ${p.toPIIString()}" }
-        val b = p.encode()
+        val dispatched = radioInterfaceService.trySendToRadio(p.encode())
+        if (!dispatched) return false
 
-        radioInterfaceService.sendToRadio(b)
         p.packet?.id?.let { changeStatus(it, MessageStatus.ENROUTE) }
-
         val packet = p.packet
         if (packet?.decoded != null) {
             val packetToSave =
@@ -109,6 +135,7 @@ class PacketHandlerImpl(
                 )
             insertMeshLog(packetToSave)
         }
+        return true
     }
 
     /**
@@ -117,38 +144,86 @@ class PacketHandlerImpl(
      * multiple calls — e.g. an `editSettings { … }` begin → writes → commit sequence — MUST be issued from a single
      * coroutine; concurrent senders share FIFO only at the per-call grain.
      */
-    override suspend fun sendToRadio(packet: MeshPacket) {
-        queueMutex.withLock {
-            queueStopped = false
-            queuedPackets.add(packet)
-            startPacketQueueLocked()
+    override suspend fun sendToRadio(packet: MeshPacket): Boolean {
+        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
+        when {
+            packet.id == 0 -> Logger.w { "Dropping queued packet without an ID" }
+
+            pending == null && !scope.isActive ->
+                Logger.w { "Rejecting packet id=${packet.id.toUInt()}: service scope is no longer active" }
+
+            pending == null -> Logger.w { "Dropping duplicate queued packet id=${packet.id.toUInt()}" }
         }
+        return pending != null
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    override suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean {
-        // Pre-register the deferred so the queue processor and QueueStatus handler
-        // can find it immediately — no polling required.
-        val deferred = CompletableDeferred<Boolean>()
-        responseMutex.withLock { queueResponse[packet.id] = deferred }
-        queueMutex.withLock {
-            queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
-            queuedPackets.add(packet)
-            startPacketQueueLocked()
+    override suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult {
+        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
+        if (pending == null) {
+            val status =
+                when {
+                    packet.id == 0 -> {
+                        Logger.w { "Rejecting awaited packet without an ID" }
+                        AwaitedSendStatus.REJECTED
+                    }
+
+                    !scope.isActive -> {
+                        Logger.w {
+                            "Rejecting awaited packet id=${packet.id.toUInt()}: service scope is no longer active"
+                        }
+                        AwaitedSendStatus.TRANSPORT_STOPPED
+                    }
+
+                    else -> {
+                        Logger.w { "Rejecting duplicate awaited packet id=${packet.id.toUInt()}" }
+                        AwaitedSendStatus.REJECTED
+                    }
+                }
+            return AwaitedSendResult(status = status, dispatched = false)
         }
         return try {
-            withTimeout(TIMEOUT) { deferred.await() }
-        } catch (e: TimeoutCancellationException) {
-            Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} timeout" }
-            false
+            // The queue processor owns both the response timeout and the ID reservation. Permanent
+            // service-scope shutdown is the only caller-observed terminal condition because no worker may exist.
+            AwaitedSendResult(status = awaitPendingResponse(pending), dispatched = pending.wasDispatched)
         } catch (e: CancellationException) {
             throw e // Preserve structured concurrency cancellation propagation.
         } catch (e: Exception) {
             Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} failed: ${e.message}" }
-            false
-        } finally {
-            responseMutex.withLock { queueResponse.remove(packet.id) }
+            AwaitedSendResult(status = AwaitedSendStatus.SEND_FAILED, dispatched = pending.wasDispatched)
         }
+    }
+
+    /**
+     * Reserves [packet]'s non-zero ID and queues it as one atomic admission. The reservation spans both queued and
+     * in-flight work, so a second sender cannot replace the original caller's [PendingResponse].
+     */
+    private suspend fun enqueuePacket(packet: MeshPacket): PendingResponse? = queueMutex.withLock {
+        responseMutex.withLock responseLock@{
+            if (!scope.isActive || queueResponse.containsKey(packet.id)) return@responseLock null
+
+            val pending = PendingResponse()
+            queueResponse[packet.id] = pending
+            queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
+            queuedPackets.add(QueuedPacket(packet = packet, pending = pending))
+            startPacketQueueLocked()
+            pending
+        }
+    }
+
+    /** Waits for the queue-owned result, draining synchronously if service-scope shutdown wins admission. */
+    private suspend fun awaitPendingResponse(pending: PendingResponse): AwaitedSendStatus {
+        val scopeJob = scope.coroutineContext[Job] ?: return pending.deferred.await()
+        val serviceStopped = select {
+            pending.deferred.onAwait { false }
+            scopeJob.onJoin { true }
+        }
+        if (serviceStopped) {
+            withContext(NonCancellable) {
+                queueMutex.withLock { if (!pending.deferred.isCompleted) stopAndDrainPacketQueueLocked() }
+            }
+        }
+        return pending.deferred.await()
     }
 
     override fun stopPacketQueue() {
@@ -160,11 +235,9 @@ class PacketHandlerImpl(
                 queueStopped = true
                 queueJob?.cancel()
                 queueJob = null
+                queueGeneration++
                 queuedPackets.clear()
-            }
-            responseMutex.withLock {
-                queueResponse.values.forEach { if (!it.isCompleted) it.complete(false) }
-                queueResponse.clear()
+                completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
             }
         }
     }
@@ -181,16 +254,19 @@ class PacketHandlerImpl(
         scope.launch {
             responseMutex.withLock {
                 if (requestId != 0) {
-                    queueResponse.remove(requestId)?.complete(success)
+                    queueResponse[requestId]?.deferred?.complete(success.toAwaitedSendStatus())
                 } else {
-                    queueResponse.values.firstOrNull { !it.isCompleted }?.complete(success)
+                    queueResponse.values
+                        .firstOrNull { !it.deferred.isCompleted }
+                        ?.deferred
+                        ?.complete(success.toAwaitedSendStatus())
                 }
             }
         }
     }
 
     override suspend fun removeResponse(dataRequestId: Int, complete: Boolean) {
-        responseMutex.withLock { queueResponse.remove(dataRequestId)?.complete(complete) }
+        responseMutex.withLock { queueResponse[dataRequestId]?.deferred?.complete(complete.toAwaitedSendStatus()) }
     }
 
     /**
@@ -198,45 +274,85 @@ class PacketHandlerImpl(
      * atomic — preventing two concurrent callers from launching duplicate processors.
      */
     private fun startPacketQueueLocked() {
-        if (queueStopped) return
-        if (queueJob?.isActive == true) return
+        if (queueStopped || queueJob?.isActive == true) return
+
+        val generation = ++queueGeneration
+        // Install cleanup before admission releases queueMutex so cancellation cannot bypass the worker's finally.
         queueJob =
-            scope.handledLaunch {
+            scope.handledLaunch(start = CoroutineStart.UNDISPATCHED) {
                 try {
                     while (connectionStateProvider.connectionState.value == ConnectionState.Connected) {
-                        val packet = queueMutex.withLock { queuedPackets.removeFirstOrNull() } ?: break
-                        @Suppress("TooGenericExceptionCaught", "SwallowedException")
-                        try {
-                            val response = sendPacket(packet)
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
-                            val success = withTimeout(TIMEOUT) { response.await() }
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} success $success" }
-                        } catch (e: TimeoutCancellationException) {
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} timeout" }
-                            // Clean up the deferred for this packet. sendToRadioAndAwait callers
-                            // also clean up in their own finally block (idempotent remove).
-                            responseMutex.withLock { queueResponse.remove(packet.id) }
-                        } catch (e: CancellationException) {
-                            throw e // Preserve structured concurrency cancellation propagation.
-                        } catch (e: Exception) {
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} failed" }
-                            responseMutex.withLock { queueResponse.remove(packet.id) }
-                        }
-                        // Deferred cleanup is now handled in the catch blocks above.
-                        // handleQueueStatus (normal success) and stopPacketQueue (bulk cleanup)
-                        // also remove entries, and these removals are idempotent.
+                        val queuedPacket = queueMutex.withLock { queuedPackets.removeFirstOrNull() } ?: break
+                        processQueuedPacket(queuedPacket)
                     }
                 } finally {
-                    // Hold queueMutex so that clearing queueJob and the restart decision are
-                    // atomic with respect to new senders calling startPacketQueueLocked().
-                    queueMutex.withLock {
-                        queueJob = null
-                        if (!queueStopped && queuedPackets.isNotEmpty()) {
-                            startPacketQueueLocked()
-                        }
-                    }
+                    finishPacketQueueGeneration(generation)
                 }
             }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun processQueuedPacket(queuedPacket: QueuedPacket) {
+        val (packet, pending) = queuedPacket
+        try {
+            val response = sendPacket(packet, pending)
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
+            val status = withTimeout(TIMEOUT) { response.await() }
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} status $status" }
+            // External status paths only complete the response; the queue worker owns reservation removal so an ID
+            // cannot be reused while its original packet can still be transmitted.
+            removePendingResponse(packet.id, pending)
+        } catch (e: TimeoutCancellationException) {
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} timeout" }
+            // Complete an awaiting caller before removing the response. Its timeout starts here, after the packet is
+            // actually sent, rather than while it waits behind the existing FIFO backlog.
+            pending.deferred.complete(AwaitedSendStatus.TIMED_OUT)
+            removePendingResponse(packet.id, pending)
+        } catch (e: CancellationException) {
+            // A later queued packet makes finishPacketQueueGeneration restart the worker instead of draining the
+            // interrupted entry. Complete and remove this reservation before propagating cancellation.
+            pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
+            removePendingResponse(packet.id, pending)
+            throw e // Preserve structured concurrency cancellation propagation.
+        } catch (e: Exception) {
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} failed" }
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+            removePendingResponse(packet.id, pending)
+        }
+        // Queue shutdown can clear the same entry concurrently; identity-checked removal keeps every path idempotent.
+    }
+
+    private suspend fun finishPacketQueueGeneration(generation: Long) = withContext(NonCancellable) {
+        // Keep completion, replacement, and disconnect draining atomic with new admissions. queueGeneration
+        // advances only under queueMutex: stopPacketQueue() drains every pending response, while
+        // startPacketQueueLocked() advances it only after the previous queueJob is inactive. Therefore a stale
+        // worker
+        // has already lost ownership to a path that drained or replaced it and must not clear that replacement job.
+        queueMutex.withLock {
+            if (generation != queueGeneration) return@withLock
+            queueJob = null
+            when {
+                queueStopped || !scope.isActive -> stopAndDrainPacketQueueLocked()
+
+                connectionStateProvider.connectionState.value != ConnectionState.Connected ->
+                    stopAndDrainPacketQueueLocked()
+
+                queuedPackets.isNotEmpty() -> startPacketQueueLocked()
+
+                else -> {
+                    // A normally completed worker has no pending response. Anything left here belongs to an
+                    // in-flight
+                    // packet interrupted by cancellation or an unexpected worker exit.
+                    completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                }
+            }
+        }
+    }
+
+    private suspend fun stopAndDrainPacketQueueLocked() {
+        queueStopped = true
+        queuedPackets.clear()
+        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
     }
 
     private fun changeStatus(packetId: Int, m: MessageStatus) = scope.handledLaunch {
@@ -258,25 +374,45 @@ class PacketHandlerImpl(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun sendPacket(packet: MeshPacket): Deferred<Boolean> {
-        // Reuse a deferred pre-registered by sendToRadioAndAwait, or create a new one.
-        val deferred = responseMutex.withLock { queueResponse.getOrPut(packet.id) { CompletableDeferred() } }
+    private suspend fun sendPacket(packet: MeshPacket, pending: PendingResponse): Deferred<AwaitedSendStatus> {
         try {
-            if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
-                throw RadioNotConnectedException()
+            requireConnected()
+            pending.recordDispatch(dispatchToRadio(ToRadio(packet = packet)))
+            if (!pending.wasDispatched) {
+                Logger.w { "sendToRadio dropped: no active transport accepted id=${packet.id.toUInt()}" }
+                pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
             }
-            sendToRadio(ToRadio(packet = packet))
         } catch (ex: RadioNotConnectedException) {
             Logger.w(ex) { "sendToRadio skipped: Not connected to radio" }
-            deferred.complete(false)
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+        } catch (ex: CancellationException) {
+            throw ex
         } catch (ex: Exception) {
             Logger.e(ex) { "sendToRadio error: ${ex.message}" }
-            deferred.complete(false)
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
         }
-        // Return a read-only Deferred view (kotlinx.coroutines 1.11+) so callers can await it
-        // without being able to complete the underlying CompletableDeferred; cancellation is
-        // still exposed via Deferred/Job.
-        return deferred.asDeferred()
+        // The declared Deferred return type exposes only read-only completion to callers.
+        return pending.deferred
+    }
+
+    private suspend fun removePendingResponse(packetId: Int, pending: PendingResponse) = withContext(NonCancellable) {
+        responseMutex.withLock { if (queueResponse[packetId] === pending) queueResponse.remove(packetId) }
+    }
+
+    private fun requireConnected() {
+        if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
+            throw RadioNotConnectedException()
+        }
+    }
+
+    private fun Boolean.toAwaitedSendStatus(): AwaitedSendStatus =
+        if (this) AwaitedSendStatus.ACCEPTED else AwaitedSendStatus.REJECTED
+
+    private suspend fun completePendingResponses(status: AwaitedSendStatus) {
+        responseMutex.withLock {
+            queueResponse.values.forEach { pending -> pending.deferred.complete(status) }
+            queueResponse.clear()
+        }
     }
 
     private fun insertMeshLog(packetToSave: MeshLog) {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -21,9 +21,11 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.capture.capture
 import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -36,6 +38,8 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.PacketHandler
@@ -162,7 +166,7 @@ class CommandSenderImplTest {
     fun sendData_setsIdWhenZero() = runTest {
         val packet = DataPacket(to = "^all", bytes = "hi".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
         packet.id = 0
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.sendData(packet)
         assertNotEquals(0, packet.id)
@@ -171,7 +175,7 @@ class CommandSenderImplTest {
     @Test
     fun sendData_setsStatusQueued() = runTest {
         val packet = DataPacket(to = "^all", bytes = "hello".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.sendData(packet)
         assertEquals(MessageStatus.QUEUED, packet.status)
@@ -199,11 +203,38 @@ class CommandSenderImplTest {
     fun sendAdmin_injectsSessionPasskey() = runTest {
         val passkey = "secret".encodeUtf8()
         every { sessionManager.getPasskey(DEST_NODE) } returns passkey
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
 
-        commandSender.sendAdmin(DEST_NODE) { org.meshtastic.proto.AdminMessage(get_owner_request = true) }
+        commandSender.sendAdmin(DEST_NODE) { AdminMessage(get_owner_request = true) }
 
-        verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
+        val adminMessage = AdminMessage.ADAPTER.decode(requireNotNull(packets.single().decoded).payload)
+        assertEquals(passkey, adminMessage.session_passkey)
+    }
+
+    @Test
+    fun sendAdmin_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
+
+        commandSender.sendAdmin(DEST_NODE, requestId = 0) {
+            org.meshtastic.proto.AdminMessage(get_owner_request = true)
+        }
+
+        assertNotEquals(0, packets.single().id)
+    }
+
+    @Test
+    fun sendAdminAwaitResult_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadioAndAwaitResult(capture(packets)) } returns
+            AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
+        commandSender.sendAdminAwaitResult(DEST_NODE, requestId = 0) {
+            org.meshtastic.proto.AdminMessage(get_owner_request = true)
+        }
+
+        assertNotEquals(0, packets.single().id)
     }
 
     // --- sendAdminImmediate ---
@@ -238,11 +269,32 @@ class CommandSenderImplTest {
 
     @Test
     fun requestTraceroute_recordsStartTime() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
 
         verify { tracerouteHandler.recordStartTime(42) }
+    }
+
+    @Test
+    fun requestTraceroute_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
+
+        verify(exactly(0)) { tracerouteHandler.recordStartTime(any()) }
+    }
+
+    @Test
+    fun requestTraceroute_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
+
+        commandSender.requestTraceroute(requestId = 0, destNum = DEST_NODE)
+
+        val generatedId = packets.single().id
+        assertNotEquals(0, generatedId)
+        verify { tracerouteHandler.recordStartTime(generatedId) }
     }
 
     // --- requestNeighborInfo ---
@@ -251,7 +303,7 @@ class CommandSenderImplTest {
     fun requestNeighborInfo_localNode_usesCachedNeighborInfo() = runTest {
         val cached = NeighborInfo(node_id = MY_NODE_NUM, last_sent_by_id = MY_NODE_NUM)
         every { neighborInfoHandler.lastNeighborInfo } returns cached
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
@@ -261,7 +313,7 @@ class CommandSenderImplTest {
     @Test
     fun requestNeighborInfo_localNode_generatesDummyWhenNoCached() = runTest {
         every { neighborInfoHandler.lastNeighborInfo } returns null
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
@@ -270,7 +322,7 @@ class CommandSenderImplTest {
 
     @Test
     fun requestNeighborInfo_remoteNode_sendsRequest() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
 
@@ -281,7 +333,7 @@ class CommandSenderImplTest {
 
     @Test
     fun sendPosition_updatesLocalPositionWhenNotFixed() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
         commandSender.sendPosition(pos)
@@ -308,7 +360,7 @@ class CommandSenderImplTest {
                 scope = testScope.asServiceScope(),
             )
         testScope.testScheduler.advanceUntilIdle()
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
         fixedSender.sendPosition(pos)

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -329,6 +329,25 @@ class CommandSenderImplTest {
         verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
     }
 
+    @Test
+    fun requestNeighborInfo_localNode_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
+        every { neighborInfoHandler.lastNeighborInfo } returns null
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
+
+        verify(exactly(0)) { neighborInfoHandler.recordStartTime(any()) }
+    }
+
+    @Test
+    fun requestNeighborInfo_remoteNode_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
+
+        verify(exactly(0)) { neighborInfoHandler.recordStartTime(any()) }
+    }
+
     // --- sendPosition ---
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -38,6 +38,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AwaitedSendResult
 import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.NeighborInfoHandler
@@ -182,6 +183,16 @@ class CommandSenderImplTest {
     }
 
     @Test
+    fun sendData_marksPacketErrorWhenQueueRejectsIt() = runTest {
+        val packet = DataPacket(to = "^all", bytes = "hello".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        commandSender.sendData(packet)
+
+        assertEquals(MessageStatus.ERROR, packet.status)
+    }
+
+    @Test
     fun sendData_rejectsOversizedPayload() = runTest {
         val oversizedBytes = ByteString.of(*ByteArray(300) { 0x42 })
         val packet = DataPacket(to = "^all", bytes = oversizedBytes, dataType = PortNum.TEXT_MESSAGE_APP.value)
@@ -217,11 +228,19 @@ class CommandSenderImplTest {
         val packets = mutableListOf<MeshPacket>()
         everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
 
-        commandSender.sendAdmin(DEST_NODE, requestId = 0) {
-            org.meshtastic.proto.AdminMessage(get_owner_request = true)
-        }
+        commandSender.sendAdmin(DEST_NODE, requestId = 0) { AdminMessage(get_owner_request = true) }
 
         assertNotEquals(0, packets.single().id)
+    }
+
+    @Test
+    fun sendAdminSurfacesQueueRejection() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        val failure =
+            assertFailsWith<PacketQueueRejectedException> { commandSender.sendAdmin(DEST_NODE) { AdminMessage() } }
+
+        assertEquals("Admin command was rejected by the outbound packet queue", failure.message)
     }
 
     @Test
@@ -230,9 +249,7 @@ class CommandSenderImplTest {
         everySuspend { packetHandler.sendToRadioAndAwaitResult(capture(packets)) } returns
             AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
 
-        commandSender.sendAdminAwaitResult(DEST_NODE, requestId = 0) {
-            org.meshtastic.proto.AdminMessage(get_owner_request = true)
-        }
+        commandSender.sendAdminAwaitResult(DEST_NODE, requestId = 0) { AdminMessage(get_owner_request = true) }
 
         assertNotEquals(0, packets.single().id)
     }
@@ -280,7 +297,9 @@ class CommandSenderImplTest {
     fun requestTraceroute_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
         everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
 
-        commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
+        }
 
         verify(exactly(0)) { tracerouteHandler.recordStartTime(any()) }
     }
@@ -337,7 +356,9 @@ class CommandSenderImplTest {
         every { neighborInfoHandler.lastNeighborInfo } returns null
         everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
 
-        commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
+        }
 
         verify(exactly(0)) { neighborInfoHandler.recordStartTime(any()) }
     }
@@ -346,7 +367,9 @@ class CommandSenderImplTest {
     fun requestNeighborInfo_remoteNode_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
         everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
 
-        commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
+        }
 
         verify(exactly(0)) { neighborInfoHandler.recordStartTime(any()) }
     }
@@ -361,6 +384,27 @@ class CommandSenderImplTest {
         commandSender.sendPosition(pos)
 
         verify { nodeManager.handleReceivedPosition(MY_NODE_NUM, MY_NODE_NUM, any(), any()) }
+    }
+
+    @Test
+    fun sendPosition_doesNotUpdateLocalPositionWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+        val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
+
+        assertFailsWith<PacketQueueRejectedException> { commandSender.sendPosition(pos) }
+
+        verify(exactly(0)) { nodeManager.handleReceivedPosition(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun setFixedPosition_doesNotUpdateLocalPositionWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.setFixedPosition(DEST_NODE, Position(latitude = 1.0, longitude = 2.0, altitude = 3))
+        }
+
+        verify(exactly(0)) { nodeManager.handleReceivedPosition(any(), any(), any(), any()) }
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -308,6 +308,7 @@ class CommandSenderImplTest {
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
         verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
+        verify { neighborInfoHandler.recordStartTime(1) }
     }
 
     @Test
@@ -318,6 +319,7 @@ class CommandSenderImplTest {
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
         verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
+        verify { neighborInfoHandler.recordStartTime(1) }
     }
 
     @Test
@@ -327,6 +329,7 @@ class CommandSenderImplTest {
         commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
 
         verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
+        verify { neighborInfoHandler.recordStartTime(1) }
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
@@ -16,20 +16,13 @@
  */
 package org.meshtastic.core.data.manager
 
-import org.meshtastic.core.model.DataPacket
-import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.service.LockdownState
-import org.meshtastic.core.repository.AwaitedSendResult
-import org.meshtastic.core.repository.AwaitedSendStatus
-import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MeshConnectionManager
 import org.meshtastic.core.repository.StoredPassphrase
+import org.meshtastic.core.testing.FakeCommandSender
 import org.meshtastic.core.testing.FakeRadioInterfaceService
 import org.meshtastic.core.testing.FakeServiceRepository
-import org.meshtastic.proto.AdminMessage
-import org.meshtastic.proto.ChannelSet
-import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LockdownStatus
 import org.meshtastic.proto.Telemetry
 import kotlin.test.Test
@@ -70,73 +63,6 @@ class LockdownCoordinatorImplTest {
             clearThrows?.let { throw it }
             saved.remove(deviceAddress)
         }
-    }
-
-    private class FakeCommandSender : CommandSender {
-        var lastPassphrase: String? = null
-        var lastBoots: Int = 0
-        var lastHours: Int = 0
-        var lastMaxSessionSeconds: Int = 0
-        var lastDisable: Boolean = false
-        var lockNowCalled = false
-
-        override fun sendLockdownPassphrase(
-            passphrase: String,
-            boots: Int,
-            hours: Int,
-            maxSessionSeconds: Int,
-            disable: Boolean,
-        ) {
-            lastPassphrase = passphrase
-            lastBoots = boots
-            lastHours = hours
-            lastMaxSessionSeconds = maxSessionSeconds
-            lastDisable = disable
-        }
-
-        override fun sendLockNow() {
-            lockNowCalled = true
-        }
-
-        // Unused stubs
-        override fun getCurrentPacketId(): Long = 0L
-
-        override fun getCachedLocalConfig(): LocalConfig = LocalConfig()
-
-        override fun getCachedChannelSet(): ChannelSet = ChannelSet()
-
-        override fun generatePacketId(): Int = 0
-
-        override suspend fun sendData(p: DataPacket) = Unit
-
-        override suspend fun sendAdmin(
-            destNum: Int,
-            requestId: Int,
-            wantResponse: Boolean,
-            initFn: () -> AdminMessage,
-        ) = Unit
-
-        override suspend fun sendAdminAwaitResult(
-            destNum: Int,
-            requestId: Int,
-            wantResponse: Boolean,
-            initFn: () -> AdminMessage,
-        ) = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
-
-        override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) =
-            Unit
-
-        override suspend fun requestPosition(destNum: Int, currentPosition: Position) = Unit
-
-        override suspend fun setFixedPosition(destNum: Int, pos: Position) = Unit
-
-        override suspend fun requestUserInfo(destNum: Int) = Unit
-
-        override suspend fun requestTraceroute(requestId: Int, destNum: Int) = Unit
-
-        override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) = Unit
-
-        override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) = Unit
     }
 
     private class FakeConnectionManager : MeshConnectionManager {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
@@ -19,6 +19,8 @@ package org.meshtastic.core.data.manager
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.service.LockdownState
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MeshConnectionManager
@@ -114,14 +116,12 @@ class LockdownCoordinatorImplTest {
             initFn: () -> AdminMessage,
         ) = Unit
 
-        override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) = Unit
-
-        override suspend fun sendAdminAwait(
+        override suspend fun sendAdminAwaitResult(
             destNum: Int,
             requestId: Int,
             wantResponse: Boolean,
             initFn: () -> AdminMessage,
-        ) = true
+        ) = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
 
         override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) =
             Unit

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -451,6 +451,24 @@ class PacketHandlerImplTest {
         }
 
     @Test
+    fun `completed packet id can be reused by a later retry`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        assertTrue(handler.sendToRadio(MeshPacket(id = 810)))
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 810, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertTrue(handler.sendToRadio(MeshPacket(id = 810)))
+        testScheduler.runCurrent()
+
+        verify(exactly(2)) { radioInterfaceService.trySendToRadio(any()) }
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+    }
+
+    @Test
     fun `handleQueueStatus property test`() = runTest(testDispatcher) {
         checkAll(Arb.int(0, 10), Arb.int(0, 32), Arb.int(0, 100000)) { res, free, packetId ->
             val status = QueueStatus(res = res, free = free, mesh_packet_id = packetId)

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -17,22 +17,29 @@
 package org.meshtastic.core.data.manager
 
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.common.di.asServiceScope
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioInterfaceService
@@ -44,6 +51,7 @@ import org.meshtastic.proto.QueueStatus
 import org.meshtastic.proto.ToRadio
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -65,6 +73,7 @@ class PacketHandlerImplTest {
     @BeforeTest
     fun setUp() {
         every { serviceRepository.connectionState } returns connectionStateFlow
+        every { radioInterfaceService.trySendToRadio(any()) } returns true
 
         handler =
             PacketHandlerImpl(
@@ -87,7 +96,7 @@ class PacketHandlerImplTest {
 
         handler.sendToRadio(toRadio)
 
-        verify { radioInterfaceService.sendToRadio(any()) }
+        verify { radioInterfaceService.trySendToRadio(any()) }
     }
 
     @Test
@@ -98,7 +107,51 @@ class PacketHandlerImplTest {
         handler.sendToRadio(packet)
         testScheduler.runCurrent()
 
-        verify { radioInterfaceService.sendToRadio(any()) }
+        verify { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `awaited send rejects when service scope is already stopped`() = runTest(testDispatcher) {
+        val stoppedScope = TestScope(StandardTestDispatcher(testScheduler))
+        stoppedScope.cancel()
+        val stoppedHandler =
+            PacketHandlerImpl(
+                lazy { packetRepository },
+                radioInterfaceService,
+                lazy { meshLogRepository },
+                serviceRepository,
+                stoppedScope.asServiceScope(),
+            )
+
+        val result = stoppedHandler.sendToRadioAndAwaitResult(MeshPacket(id = 457))
+
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, result.status)
+        assertFalse(result.dispatched)
+    }
+
+    @Test
+    fun `awaited send is released when service scope stops before worker starts`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val serviceScope = TestScope(StandardTestDispatcher(testScheduler))
+        val stoppedHandler =
+            PacketHandlerImpl(
+                lazy { packetRepository },
+                radioInterfaceService,
+                lazy { meshLogRepository },
+                serviceRepository,
+                serviceScope.asServiceScope(),
+            )
+
+        val result =
+            async(start = CoroutineStart.UNDISPATCHED) {
+                stoppedHandler.sendToRadioAndAwaitResult(MeshPacket(id = 458))
+            }
+        serviceScope.cancel()
+        testScheduler.runCurrent()
+        val completed = result.await()
+
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, completed.status)
+        assertFalse(completed.dispatched)
     }
 
     @Test
@@ -163,6 +216,239 @@ class PacketHandlerImplTest {
 
         assertFalse(result.await())
     }
+
+    @Test
+    fun `await response timeout starts after earlier queued packets`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 800))
+        handler.sendToRadio(MeshPacket(id = 801))
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 802)) }
+        testScheduler.runCurrent()
+
+        // Let both earlier packets consume their full response windows. The awaited packet has not timed out
+        // because
+        // it has not reached the head of the queue yet.
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+        assertFalse(result.isCompleted)
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+        assertFalse(result.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 802, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertEquals(AwaitedSendStatus.ACCEPTED, result.await().status)
+    }
+
+    @Test
+    fun `stopping the queue completes an awaiting packet still behind the backlog`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        // Packet 803 owns the queue head, so 804 is stopped before the transport receives it.
+        handler.sendToRadio(MeshPacket(id = 803))
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 804)) }
+        testScheduler.runCurrent()
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+    }
+
+    @Test
+    fun `stopping the queue reports an awaited packet that was already dispatched`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        // With no backlog, packet 807 reaches the transport before stopPacketQueue() drains its response.
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 807)) }
+        testScheduler.runCurrent()
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertTrue(stopped.dispatched)
+    }
+
+    @Test
+    fun `disconnect drains queued responses without restarting the processor`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val first = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 813)) }
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 814)) }
+        testScheduler.runCurrent()
+
+        connectionStateFlow.value = ConnectionState.Disconnected
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 813, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertEquals(AwaitedSendStatus.ACCEPTED, first.await().status)
+        val stopped = queued.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+        verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `queue response timeout completes awaiting caller with failure`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 805)) }
+        testScheduler.runCurrent()
+
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+
+        val timedOut = result.await()
+        assertEquals(AwaitedSendStatus.TIMED_OUT, timedOut.status)
+        assertTrue(timedOut.dispatched)
+    }
+
+    @Test
+    fun `transport refusing dispatch completes awaiting caller with failure`() = runTest(testDispatcher) {
+        every { radioInterfaceService.trySendToRadio(any()) } returns false
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 808)) }
+        testScheduler.runCurrent()
+
+        val failed = result.await()
+        assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
+        assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `queue send failure completes awaiting caller with failure`() = runTest(testDispatcher) {
+        every { radioInterfaceService.trySendToRadio(any()) } calls { error("test send failure") }
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 806)) }
+        testScheduler.runCurrent()
+
+        val failed = result.await()
+        assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
+        assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `cancelled queue handoff releases its reservation before restarting queued work`() = runTest(testDispatcher) {
+        var sendAttempts = 0
+        every { radioInterfaceService.trySendToRadio(any()) } calls
+            {
+                sendAttempts++
+                if (sendAttempts == 1) throw CancellationException("transport stopped")
+                true
+            }
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val interrupted = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 815)) }
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 816)) }
+        testScheduler.runCurrent()
+
+        val stopped = interrupted.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 816, res = 0, free = 16))
+        testScheduler.runCurrent()
+        val accepted = queued.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+        assertTrue(accepted.dispatched)
+
+        assertTrue(handler.sendToRadio(MeshPacket(id = 815)))
+        testScheduler.runCurrent()
+        verify(exactly(3)) { radioInterfaceService.trySendToRadio(any()) }
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 815, res = 0, free = 16))
+        testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `awaited packet without an id is rejected before dispatch`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = handler.sendToRadioAndAwaitResult(MeshPacket())
+
+        assertEquals(AwaitedSendStatus.REJECTED, result.status)
+        assertFalse(result.dispatched)
+        verify(exactly(0)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `duplicate awaited packet id is rejected without replacing the original waiter`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val original = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 809)) }
+        testScheduler.runCurrent()
+
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 809))
+
+        assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
+        assertFalse(duplicate.dispatched)
+        assertFalse(original.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 809, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        val accepted = original.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+        assertTrue(accepted.dispatched)
+    }
+
+    @Test
+    fun `early response completion retains the queued id and still transmits the packet`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 816))
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 817)) }
+        testScheduler.runCurrent()
+
+        handler.removeResponse(dataRequestId = 817, complete = true)
+        testScheduler.runCurrent()
+
+        val completed = queued.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, completed.status)
+        assertFalse(completed.dispatched)
+
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 817))
+        assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 816, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        verify(exactly(2)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `cancelling an awaiting caller does not release its queued packet id`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 811))
+        val awaiting = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 812)) }
+        testScheduler.runCurrent()
+
+        awaiting.cancelAndJoin()
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 812))
+
+        assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
+        assertFalse(duplicate.dispatched)
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `fire and forget rejects invalid packet ids without throwing or replacing queued work`() =
+        runTest(testDispatcher) {
+            connectionStateFlow.value = ConnectionState.Connected
+            assertTrue(handler.sendToRadio(MeshPacket(id = 810)))
+            testScheduler.runCurrent()
+
+            assertFalse(handler.sendToRadio(MeshPacket(id = 810)))
+            assertFalse(handler.sendToRadio(MeshPacket()))
+            testScheduler.runCurrent()
+
+            verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+
+            handler.stopPacketQueue()
+            testScheduler.runCurrent()
+        }
 
     @Test
     fun `handleQueueStatus property test`() = runTest(testDispatcher) {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -20,6 +20,7 @@ import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
@@ -39,6 +40,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.common.di.asServiceScope
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketRepository
@@ -208,13 +211,15 @@ class PacketHandlerImplTest {
     fun `handleQueueStatus treats other nonzero res as failure`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
 
-        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 791)) }
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 791)) }
         testScheduler.runCurrent()
 
         handler.handleQueueStatus(QueueStatus(mesh_packet_id = 791, res = 33, free = 16))
         testScheduler.runCurrent()
 
-        assertFalse(result.await())
+        val rejected = result.await()
+        assertEquals(AwaitedSendStatus.RADIO_REJECTED, rejected.status)
+        assertTrue(rejected.dispatched)
     }
 
     @Test
@@ -245,6 +250,15 @@ class PacketHandlerImplTest {
     fun `stopping the queue completes an awaiting packet still behind the backlog`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         // Packet 803 owns the queue head, so 804 is stopped before the transport receives it.
+        val storedPacket =
+            DataPacket(
+                bytes = null,
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 804,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.getPacketById(804) } returns storedPacket
+        everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
         handler.sendToRadio(MeshPacket(id = 803))
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 804)) }
         testScheduler.runCurrent()
@@ -255,12 +269,22 @@ class PacketHandlerImplTest {
         val stopped = result.await()
         assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
         assertFalse(stopped.dispatched)
+        verifySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
     }
 
     @Test
     fun `stopping the queue reports an awaited packet that was already dispatched`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         // With no backlog, packet 807 reaches the transport before stopPacketQueue() drains its response.
+        val storedPacket =
+            DataPacket(
+                bytes = null,
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 807,
+                status = MessageStatus.ENROUTE,
+            )
+        everySuspend { packetRepository.getPacketById(807) } returns storedPacket
+        everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 807)) }
         testScheduler.runCurrent()
 
@@ -270,7 +294,37 @@ class PacketHandlerImplTest {
         val stopped = result.await()
         assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
         assertTrue(stopped.dispatched)
+        verifySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
     }
+
+    @Test
+    fun `queue stop does not overwrite an accepted packet while its reservation is still present`() =
+        runTest(testDispatcher) {
+            connectionStateFlow.value = ConnectionState.Connected
+            val storedPacket =
+                DataPacket(
+                    bytes = null,
+                    dataType = PortNum.TEXT_MESSAGE_APP.value,
+                    id = 817,
+                    status = MessageStatus.ENROUTE,
+                )
+            everySuspend { packetRepository.getPacketById(817) } returns storedPacket
+            everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
+            val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 817)) }
+            testScheduler.runCurrent()
+
+            // Queue the response callback first, then queue shutdown before either scheduled launch runs. The response
+            // completion resumes the worker behind the already-scheduled shutdown, reproducing the completed-but-still-
+            // reserved window that must not be reclassified as an error.
+            handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
+            handler.stopPacketQueue()
+            testScheduler.runCurrent()
+
+            val accepted = result.await()
+            assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+            assertTrue(accepted.dispatched)
+            verifySuspend(exactly(0)) { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
+        }
 
     @Test
     fun `disconnect drains queued responses without restarting the processor`() = runTest(testDispatcher) {
@@ -305,9 +359,29 @@ class PacketHandlerImplTest {
     }
 
     @Test
+    fun `disconnected queue admission reports transport stopped`() = runTest(testDispatcher) {
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 805)) }
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+        verify(exactly(0)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
     fun `transport refusing dispatch completes awaiting caller with failure`() = runTest(testDispatcher) {
         every { radioInterfaceService.trySendToRadio(any()) } returns false
         connectionStateFlow.value = ConnectionState.Connected
+        val storedPacket =
+            DataPacket(
+                bytes = null,
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 808,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.getPacketById(808) } returns storedPacket
+        everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
 
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 808)) }
         testScheduler.runCurrent()
@@ -315,6 +389,7 @@ class PacketHandlerImplTest {
         val failed = result.await()
         assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
         assertFalse(failed.dispatched)
+        verifySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
     }
 
     @Test
@@ -328,6 +403,42 @@ class PacketHandlerImplTest {
         val failed = result.await()
         assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
         assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `queue status without a packet id completes the oldest dispatched response`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val first = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 820)) }
+        val second = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 821)) }
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 0, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        val firstResult = first.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, firstResult.status)
+        assertTrue(firstResult.dispatched)
+        assertFalse(second.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 0, res = 0, free = 16))
+        testScheduler.runCurrent()
+        val secondResult = second.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, secondResult.status)
+        assertTrue(secondResult.dispatched)
+    }
+
+    @Test
+    fun `queue resumes after a stop and a later send`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        assertTrue(handler.sendToRadio(MeshPacket(id = 822)))
+        testScheduler.runCurrent()
+
+        verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 822, res = 0, free = 16))
+        testScheduler.runCurrent()
     }
 
     @Test
@@ -394,18 +505,17 @@ class PacketHandlerImplTest {
     }
 
     @Test
-    fun `early response completion retains the queued id and still transmits the packet`() = runTest(testDispatcher) {
+    fun `response received before dispatch is ignored and retains the queued id`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         handler.sendToRadio(MeshPacket(id = 816))
         val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 817)) }
         testScheduler.runCurrent()
 
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
         handler.removeResponse(dataRequestId = 817, complete = true)
         testScheduler.runCurrent()
 
-        val completed = queued.await()
-        assertEquals(AwaitedSendStatus.ACCEPTED, completed.status)
-        assertFalse(completed.dispatched)
+        assertFalse(queued.isCompleted)
 
         val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 817))
         assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
@@ -414,6 +524,16 @@ class PacketHandlerImplTest {
         testScheduler.runCurrent()
 
         verify(exactly(2)) { radioInterfaceService.trySendToRadio(any()) }
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        val accepted = queued.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+        assertTrue(accepted.dispatched)
+        assertTrue(handler.sendToRadio(MeshPacket(id = 817)))
+        testScheduler.runCurrent()
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
+        testScheduler.runCurrent()
     }
 
     @Test

--- a/core/domain/src/androidHostTest/kotlin/org/meshtastic/core/domain/usecase/settings/ModuleConfigFieldsHostTest.kt
+++ b/core/domain/src/androidHostTest/kotlin/org/meshtastic/core/domain/usecase/settings/ModuleConfigFieldsHostTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.ModuleConfig
+import java.lang.reflect.Modifier
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModuleConfigFieldsHostTest {
+    @Test
+    fun registryMatchesEveryGeneratedLocalModuleConfigField() {
+        val instanceFields =
+            LocalModuleConfig::class
+                .java
+                .declaredFields
+                .asSequence()
+                .filterNot { Modifier.isStatic(it.modifiers) }
+                .toList()
+        val nonArmFields = setOf("version", "unknownFields")
+        val generatedFields =
+            instanceFields.filter { it.type.enclosingClass == ModuleConfig::class.java }.map { it.name }.toSet()
+        val unexpectedFields = instanceFields.map { it.name }.toSet() - generatedFields - nonArmFields
+        val registeredFields = ModuleConfigField.entries.map { it.name.lowercase() }.toSet()
+
+        assertEquals(emptySet(), unexpectedFields, "new generated fields must be classified as module arms or metadata")
+        assertEquals(generatedFields, registeredFields)
+    }
+}

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCase.kt
@@ -68,7 +68,8 @@ constructor(
      * before the next write.
      *
      * The profile is applied in this order:
-     * 1. owner, channels, non-terminal config, fixed position, and non-disruptive modules in one edit transaction;
+     * 1. owner, channels, non-terminal config, fixed position, and non-transport-sensitive modules in one edit
+     *    transaction;
      * 2. MQTT as a standalone stage;
      * 3. configuration for transports other than the active one;
      * 4. the active transport's own configuration last, because it may prevent that transport from reconnecting.
@@ -228,7 +229,7 @@ constructor(
         // afterward would miss that real stage departure. The post-departure handshake ordering check below prevents an
         // older reconnect from satisfying this stage even when rapid lifecycle states are conflated.
         val baselineLifecycle = radioController.connectionLifecycle.value
-        nodeRestartTracker.expectRestart()
+        nodeRestartTracker.expectRestart(PROFILE_DEPARTURE_TIMEOUT + PROFILE_RECONNECT_TIMEOUT)
         var completed = false
         try {
             action()
@@ -254,7 +255,7 @@ constructor(
                     "Device did not reconnect after the ${stage.logName} profile stage"
                 }
             }
-            nodeRestartTracker.onConnected()
+            if (expectReconnect) nodeRestartTracker.onConnected()
             completed = true
             Logger.i { "Installed device profile stage=${stage.logName}" }
         } finally {

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCase.kt
@@ -16,97 +16,290 @@
  */
 package org.meshtastic.core.domain.usecase.settings
 
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
-import org.meshtastic.core.model.Position
-import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.model.ConnectionLifecycle
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.DeviceType
+import org.meshtastic.core.model.util.ChannelReplacementPlan
+import org.meshtastic.core.repository.ChannelCacheReconciliationScope
+import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.NodeRestartTracker
+import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
+import org.meshtastic.core.repository.RadioInterfaceService
+import org.meshtastic.core.repository.withChannelCacheReconciliation
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.DeviceProfile
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.User
+import kotlin.time.Duration.Companion.seconds
 
-/** Use case for installing a device profile onto a radio. */
+/** Progress for a staged device-profile installation. */
+data class ProfileInstallProgress(val currentStage: Int, val totalStages: Int)
+
+/** Installs a local device profile using firmware-compatible, restart-aware phases. */
 @Single
-open class InstallProfileUseCase constructor(private val radioController: RadioController) {
+open class InstallProfileUseCase
+constructor(
+    private val radioController: RadioController,
+    private val radioInterfaceService: RadioInterfaceService,
+    private val radioConfigRepository: RadioConfigRepository,
+    private val nodeRepository: NodeRepository,
+    private val nodeRestartTracker: NodeRestartTracker,
+) {
+    private val installMutex = Mutex()
+
     /**
-     * Installs the provided [DeviceProfile] onto the radio at [destNum].
+     * Installs [profile] onto the locally connected radio at [destNum].
      *
-     * @param destNum The destination node number.
-     * @param profile The device profile to install.
-     * @param currentUser The current user configuration of the destination node (to preserve names if not in profile).
+     * Firmware edit transactions defer normal config persistence until `commit_edit_settings`, but firmware versions
+     * already in the field can interrupt Bluetooth as soon as MQTT or Serial configuration is processed. Those
+     * transport-sensitive commands therefore cannot be sent inside the transaction: a BLE link can disappear before the
+     * remaining writes and commit reach the device. Every committed edit and standalone config write also schedules a
+     * firmware reboot, regardless of transport, so each non-terminal stage must complete a fresh application handshake
+     * before the next write.
+     *
+     * The profile is applied in this order:
+     * 1. owner, channels, non-terminal config, fixed position, and non-disruptive modules in one edit transaction;
+     * 2. MQTT as a standalone stage;
+     * 3. configuration for transports other than the active one;
+     * 4. the active transport's own configuration last, because it may prevent that transport from reconnecting.
+     *
+     * Bluetooth and Network are always kept out of the ordinary transaction. If more than one general-config write
+     * would end the active transport, those writes share one final edit transaction so firmware accepts all of them
+     * before the connection disappears. This covers, for example, enabling Wi-Fi while disabling Bluetooth over BLE.
+     *
+     * Every stage observes the firmware restart. Stages that need another write also wait for the application handshake
+     * to return to [ConnectionState.Connected], then resolve the current local node number so a security restore that
+     * changes identity cannot strand later writes on the old destination.
      */
-    open suspend operator fun invoke(destNum: Int, profile: DeviceProfile, currentUser: User?) {
-        radioController.editSettings(destNum) {
-            installOwner(profile, currentUser)
-            installConfig(profile.config)
-            installFixedPosition(profile.fixed_position)
-            installModuleConfig(profile.module_config)
+    open suspend operator fun invoke(
+        destNum: Int,
+        profile: DeviceProfile,
+        currentUser: User?,
+        isLocal: Boolean,
+        onProgress: (ProfileInstallProgress) -> Unit = {},
+    ) = installMutex.withLock {
+        require(isLocal) { "Device profiles can only be installed on the locally connected node" }
+        val admissionLifecycle = radioController.connectionLifecycle.value
+        require(admissionLifecycle.state is ConnectionState.Connected) {
+            "A connected local node is required to install a device profile"
+        }
+        val admissionAddress =
+            checkNotNull(radioInterfaceService.getDeviceAddress()) { "The connected node transport is unavailable" }
+        val activeTransport =
+            checkNotNull(DeviceType.fromAddress(admissionAddress)) { "The connected node transport is unavailable" }
+        require(destNum == currentLocalNodeNum()) {
+            "The profile destination no longer matches the connected local node"
+        }
+
+        validateOwnerRestore(profile, currentUser)
+        val (currentConfig, currentModuleConfig, currentChannels) =
+            checkNotNull(
+                withTimeoutOrNull(PROFILE_SNAPSHOT_TIMEOUT) {
+                    combine(
+                        radioConfigRepository.localConfigFlow,
+                        radioConfigRepository.moduleConfigFlow,
+                        radioConfigRepository.channelSetFlow,
+                    ) { config, moduleConfig, channelSet ->
+                        Triple(config, moduleConfig, channelSet.settings)
+                    }
+                        .first()
+                },
+            ) {
+                "Timed out waiting for the connected device configuration before profile installation"
+            }
+        requireInstallationAdmissionCurrent(admissionLifecycle, admissionAddress, destNum)
+        val plan =
+            ProfileInstallPlanner.create(
+                profile = profile,
+                currentConfig = currentConfig,
+                currentModuleConfig = currentModuleConfig,
+                currentChannels = currentChannels,
+                currentUser = currentUser,
+                activeTransport = activeTransport,
+            )
+
+        val progress = ProfileInstallProgressReporter(plan.stageCount, onProgress)
+        if (plan.hasTransactionalWrites) {
+            progress.startNextStage()
+            installTransactionStage(
+                profile = plan.profile,
+                currentUser = currentUser,
+                config = plan.config,
+                moduleConfig = plan.moduleConfig,
+                channelRestore = plan.channelRestore,
+            )
+        }
+
+        installTransportSensitiveStages(plan.transportPlan, progress)
+    }
+
+    /**
+     * Applies the ordinary edit transaction while keeping the local channel cache aligned with commands that were
+     * actually issued. A failure before the first channel command leaves the cache untouched. After a successful send,
+     * the imported authoritative set is reconciled on both normal and exceptional exits.
+     */
+    private suspend fun installTransactionStage(
+        profile: DeviceProfile,
+        currentUser: User?,
+        config: LocalConfig?,
+        moduleConfig: LocalModuleConfig?,
+        channelRestore: ChannelReplacementPlan?,
+    ) {
+        suspend fun runStage(reconciliation: ChannelCacheReconciliationScope?) {
+            runInstallStage(stage = ProfileInstallStage.TRANSACTION, expectReconnect = true) {
+                radioController.editLocalSettings {
+                    installOwner(profile, currentUser)
+                    installConfig(config)
+                    installChannels(channelRestore) { reconciliation?.markChannelWriteIssued() }
+                    installFixedPosition(profile.fixed_position)
+                    installModuleConfig(moduleConfig)
+                }
+                // Reconcile before waiting for the reboot handshake. Incoming channel packets can then only refine the
+                // authoritative imported set instead of merging into the pre-import cache.
+                reconciliation?.reconcileChannelCache()
+            }
+        }
+
+        if (channelRestore == null) {
+            runStage(reconciliation = null)
+        } else {
+            radioConfigRepository.withChannelCacheReconciliation(channelRestore.normalizedSettings) { runStage(this) }
         }
     }
 
-    // is_licensed is deliberately not installed here: enabling ham mode is a dedicated onboarding flow
-    // (set_ham_mode — rewrites the owner, disables encryption, applies tx power/frequency) that a plain
-    // set_owner would bypass, leaving the radio flagged licensed without those required side effects.
-    private suspend fun AdminEditScope.installOwner(profile: DeviceProfile, currentUser: User?) {
-        if (profile.long_name != null || profile.short_name != null || profile.is_unmessagable != null) {
-            currentUser?.let {
-                setOwner(
-                    it.copy(
-                        long_name = profile.long_name ?: it.long_name,
-                        short_name = profile.short_name ?: it.short_name,
-                        is_unmessagable = profile.is_unmessagable ?: it.is_unmessagable,
-                    ),
-                )
+    private suspend fun installTransportSensitiveStages(
+        plan: TransportSensitivePlan,
+        progress: ProfileInstallProgressReporter,
+    ) {
+        plan.mqtt?.let { mqtt ->
+            progress.startNextStage()
+            installModuleConfigStage(ProfileInstallStage.MQTT, mqtt, expectReconnect = true)
+        }
+
+        (plan.continuingStages + plan.terminalStages).forEach { stage ->
+            progress.startNextStage()
+            when (stage) {
+                is TransportSensitiveStage.ConfigWrite ->
+                    installConfigStage(stage.profileStage, stage.config, stage.activeTransportReconnects)
+
+                is TransportSensitiveStage.ModuleConfigWrite ->
+                    installModuleConfigStage(stage.profileStage, stage.config, stage.activeTransportReconnects)
+            }
+        }
+
+        if (plan.groupedTerminalConfig.isNotEmpty()) {
+            progress.startNextStage()
+            runInstallStage(ProfileInstallStage.TRANSPORT_CONFIG, expectReconnect = false) {
+                radioController.editLocalSettings { plan.groupedTerminalConfig.forEach { setConfig(it.config) } }
             }
         }
     }
 
-    private suspend fun AdminEditScope.installConfig(config: LocalConfig?) {
-        config?.let { lc ->
-            lc.device?.let { setConfig(Config(device = it)) }
-            lc.position?.let { setConfig(Config(position = it)) }
-            lc.power?.let { setConfig(Config(power = it)) }
-            lc.network?.let { setConfig(Config(network = it)) }
-            lc.display?.let { setConfig(Config(display = it)) }
-            lc.lora?.let { setConfig(Config(lora = it)) }
-            lc.bluetooth?.let { setConfig(Config(bluetooth = it)) }
-            lc.security?.let { setConfig(Config(security = it)) }
+    private suspend fun installConfigStage(stage: ProfileInstallStage, config: Config, expectReconnect: Boolean) =
+        runInstallStage(stage, expectReconnect) {
+            radioController.setConfig(currentLocalNodeNum(), config, radioController.generatePacketId())
+        }
+
+    private suspend fun installModuleConfigStage(
+        stage: ProfileInstallStage,
+        config: ModuleConfig,
+        expectReconnect: Boolean,
+    ) = runInstallStage(stage, expectReconnect) {
+        radioController.setModuleConfig(currentLocalNodeNum(), config, radioController.generatePacketId())
+    }
+
+    private suspend fun runInstallStage(
+        stage: ProfileInstallStage,
+        expectReconnect: Boolean,
+        action: suspend () -> Unit,
+    ) {
+        Logger.i { "Installing device profile stage=${stage.logName}" }
+        // Capture before the write: firmware can disconnect synchronously while action() is committing, and sampling
+        // afterward would miss that real stage departure. The post-departure handshake ordering check below prevents an
+        // older reconnect from satisfying this stage even when rapid lifecycle states are conflated.
+        val baselineLifecycle = radioController.connectionLifecycle.value
+        nodeRestartTracker.expectRestart()
+        var completed = false
+        try {
+            action()
+            val departureEpochs =
+                checkNotNull(
+                    withTimeoutOrNull(PROFILE_DEPARTURE_TIMEOUT) {
+                        radioController.connectionLifecycle.first {
+                            it.epochs.departures > baselineLifecycle.epochs.departures
+                        }
+                    },
+                ) {
+                    "Device did not begin the ${stage.logName} profile restart"
+                }
+            if (expectReconnect) {
+                checkNotNull(
+                    withTimeoutOrNull(PROFILE_RECONNECT_TIMEOUT) {
+                        radioController.connectionLifecycle.first { lifecycle ->
+                            lifecycle.epochs.departures >= departureEpochs.epochs.departures &&
+                                lifecycle.epochs.completedHandshakes > lifecycle.epochs.handshakesAtLastDeparture
+                        }
+                    },
+                ) {
+                    "Device did not reconnect after the ${stage.logName} profile stage"
+                }
+            }
+            nodeRestartTracker.onConnected()
+            completed = true
+            Logger.i { "Installed device profile stage=${stage.logName}" }
+        } finally {
+            if (!completed) nodeRestartTracker.cancelExpectedRestart()
         }
     }
 
-    private suspend fun AdminEditScope.installFixedPosition(fixedPosition: org.meshtastic.proto.Position?) {
-        if (fixedPosition != null) {
-            setFixedPosition(Position(fixedPosition))
+    private fun requireInstallationAdmissionCurrent(
+        admissionLifecycle: ConnectionLifecycle,
+        admissionAddress: String,
+        destNum: Int,
+    ) {
+        check(radioController.connectionLifecycle.value == admissionLifecycle) {
+            "The connected radio lifecycle changed while preparing profile installation"
+        }
+        check(radioInterfaceService.getDeviceAddress() == admissionAddress) {
+            "The connected radio transport changed while preparing profile installation"
+        }
+        require(destNum == currentLocalNodeNum()) {
+            "The profile destination changed while preparing profile installation"
         }
     }
 
-    private suspend fun AdminEditScope.installModuleConfig(moduleConfig: LocalModuleConfig?) {
-        moduleConfig?.let { lmc ->
-            installModuleConfigPart1(lmc)
-            installModuleConfigPart2(lmc)
+    private fun currentLocalNodeNum(): Int =
+        checkNotNull(nodeRepository.myNodeInfo.value?.myNodeNum) { "The connected local node identity is unavailable" }
+
+    private class ProfileInstallProgressReporter(
+        private val totalStages: Int,
+        private val onProgress: (ProfileInstallProgress) -> Unit,
+    ) {
+        private var currentStage = 0
+
+        fun startNextStage() {
+            currentStage += 1
+            onProgress(ProfileInstallProgress(currentStage, totalStages))
         }
     }
 
-    private suspend fun AdminEditScope.installModuleConfigPart1(lmc: LocalModuleConfig) {
-        lmc.mqtt?.let { setModuleConfig(ModuleConfig(mqtt = it)) }
-        lmc.serial?.let { setModuleConfig(ModuleConfig(serial = it)) }
-        lmc.external_notification?.let { setModuleConfig(ModuleConfig(external_notification = it)) }
-        lmc.store_forward?.let { setModuleConfig(ModuleConfig(store_forward = it)) }
-        lmc.range_test?.let { setModuleConfig(ModuleConfig(range_test = it)) }
-        lmc.telemetry?.let { setModuleConfig(ModuleConfig(telemetry = it)) }
-        lmc.canned_message?.let { setModuleConfig(ModuleConfig(canned_message = it)) }
-        lmc.audio?.let { setModuleConfig(ModuleConfig(audio = it)) }
-    }
+    private companion object {
+        val PROFILE_SNAPSHOT_TIMEOUT = 10.seconds
 
-    private suspend fun AdminEditScope.installModuleConfigPart2(lmc: LocalModuleConfig) {
-        lmc.remote_hardware?.let { setModuleConfig(ModuleConfig(remote_hardware = it)) }
-        lmc.neighbor_info?.let { setModuleConfig(ModuleConfig(neighbor_info = it)) }
-        lmc.ambient_lighting?.let { setModuleConfig(ModuleConfig(ambient_lighting = it)) }
-        lmc.detection_sensor?.let { setModuleConfig(ModuleConfig(detection_sensor = it)) }
-        lmc.paxcounter?.let { setModuleConfig(ModuleConfig(paxcounter = it)) }
-        lmc.statusmessage?.let { setModuleConfig(ModuleConfig(statusmessage = it)) }
-        lmc.tak?.let { setModuleConfig(ModuleConfig(tak = it)) }
+        // Firmware normally begins its seven-second reboot promptly. Bound only the departure separately so a rejected
+        // MQTT/Serial payload fails visibly instead of consuming the full reconnection allowance without ever
+        // rebooting.
+        val PROFILE_DEPARTURE_TIMEOUT = 20.seconds
+        val PROFILE_RECONNECT_TIMEOUT = 90.seconds
     }
 }

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ModuleConfigField.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ModuleConfigField.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.ModuleConfig
+
+/** Exhaustive registry for every installable [ModuleConfig] one-of arm. */
+internal enum class ModuleConfigField(val transportSensitive: Boolean = false) {
+    MQTT(transportSensitive = true),
+    SERIAL(transportSensitive = true),
+    EXTERNAL_NOTIFICATION,
+    STORE_FORWARD,
+    RANGE_TEST,
+    TELEMETRY,
+    CANNED_MESSAGE,
+    AUDIO,
+    REMOTE_HARDWARE,
+    NEIGHBOR_INFO,
+    AMBIENT_LIGHTING,
+    DETECTION_SENSOR,
+    PAXCOUNTER,
+    STATUSMESSAGE,
+    TRAFFIC_MANAGEMENT,
+    TAK,
+    MESH_BEACON,
+    ;
+
+    @Suppress("CyclomaticComplexMethod")
+    fun extract(config: LocalModuleConfig): ModuleConfig? = when (this) {
+        MQTT -> config.mqtt?.let { ModuleConfig(mqtt = it) }
+        SERIAL -> config.serial?.let { ModuleConfig(serial = it) }
+        EXTERNAL_NOTIFICATION -> config.external_notification?.let { ModuleConfig(external_notification = it) }
+        STORE_FORWARD -> config.store_forward?.let { ModuleConfig(store_forward = it) }
+        RANGE_TEST -> config.range_test?.let { ModuleConfig(range_test = it) }
+        TELEMETRY -> config.telemetry?.let { ModuleConfig(telemetry = it) }
+        CANNED_MESSAGE -> config.canned_message?.let { ModuleConfig(canned_message = it) }
+        AUDIO -> config.audio?.let { ModuleConfig(audio = it) }
+        REMOTE_HARDWARE -> config.remote_hardware?.let { ModuleConfig(remote_hardware = it) }
+        NEIGHBOR_INFO -> config.neighbor_info?.let { ModuleConfig(neighbor_info = it) }
+        AMBIENT_LIGHTING -> config.ambient_lighting?.let { ModuleConfig(ambient_lighting = it) }
+        DETECTION_SENSOR -> config.detection_sensor?.let { ModuleConfig(detection_sensor = it) }
+        PAXCOUNTER -> config.paxcounter?.let { ModuleConfig(paxcounter = it) }
+        STATUSMESSAGE -> config.statusmessage?.let { ModuleConfig(statusmessage = it) }
+        TRAFFIC_MANAGEMENT -> config.traffic_management?.let { ModuleConfig(traffic_management = it) }
+        TAK -> config.tak?.let { ModuleConfig(tak = it) }
+        MESH_BEACON -> config.mesh_beacon?.let { ModuleConfig(mesh_beacon = it) }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    fun merge(target: LocalModuleConfig, config: ModuleConfig): LocalModuleConfig = when (this) {
+        MQTT -> config.mqtt?.let { target.copy(mqtt = it) } ?: target
+
+        SERIAL -> config.serial?.let { target.copy(serial = it) } ?: target
+
+        EXTERNAL_NOTIFICATION ->
+            config.external_notification?.let { target.copy(external_notification = it) } ?: target
+
+        STORE_FORWARD -> config.store_forward?.let { target.copy(store_forward = it) } ?: target
+
+        RANGE_TEST -> config.range_test?.let { target.copy(range_test = it) } ?: target
+
+        TELEMETRY -> config.telemetry?.let { target.copy(telemetry = it) } ?: target
+
+        CANNED_MESSAGE -> config.canned_message?.let { target.copy(canned_message = it) } ?: target
+
+        AUDIO -> config.audio?.let { target.copy(audio = it) } ?: target
+
+        REMOTE_HARDWARE -> config.remote_hardware?.let { target.copy(remote_hardware = it) } ?: target
+
+        NEIGHBOR_INFO -> config.neighbor_info?.let { target.copy(neighbor_info = it) } ?: target
+
+        AMBIENT_LIGHTING -> config.ambient_lighting?.let { target.copy(ambient_lighting = it) } ?: target
+
+        DETECTION_SENSOR -> config.detection_sensor?.let { target.copy(detection_sensor = it) } ?: target
+
+        PAXCOUNTER -> config.paxcounter?.let { target.copy(paxcounter = it) } ?: target
+
+        STATUSMESSAGE -> config.statusmessage?.let { target.copy(statusmessage = it) } ?: target
+
+        TRAFFIC_MANAGEMENT -> config.traffic_management?.let { target.copy(traffic_management = it) } ?: target
+
+        TAK -> config.tak?.let { target.copy(tak = it) } ?: target
+
+        MESH_BEACON -> config.mesh_beacon?.let { target.copy(mesh_beacon = it) } ?: target
+    }
+}
+
+internal fun LocalModuleConfig.moduleConfigs(includeTransportSensitive: Boolean = false): List<ModuleConfig> =
+    ModuleConfigField.entries
+        .asSequence()
+        .filter { includeTransportSensitive || !it.transportSensitive }
+        .mapNotNull { it.extract(this) }
+        .toList()
+
+internal fun LocalModuleConfig.withoutUnchangedModuleFields(current: LocalModuleConfig): LocalModuleConfig? {
+    val changed =
+        ModuleConfigField.entries.mapNotNull { field ->
+            field.extract(this)?.takeUnless { it == field.extract(current) }
+        }
+    return changed
+        .fold(LocalModuleConfig()) { result, config -> result.updatedWithModuleConfig(config) }
+        .takeIf { changed.isNotEmpty() }
+}
+
+/**
+ * Applies every populated [ModuleConfig] arm to this aggregate using the same exhaustive registry as profile restore.
+ */
+fun LocalModuleConfig.updatedWithModuleConfig(config: ModuleConfig): LocalModuleConfig =
+    ModuleConfigField.entries.fold(this) { result, field -> field.merge(result, config) }

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallFields.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallFields.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.User
+
+internal fun validateOwnerRestore(profile: DeviceProfile, currentUser: User?) {
+    require(!profile.hasOwnerWrite() || currentUser != null) {
+        "The connected node owner must be loaded before restoring owner fields"
+    }
+}
+
+internal fun DeviceProfile.hasOwnerWrite(): Boolean = long_name != null || short_name != null || is_unmessagable != null
+
+/** Removes owner/config/module fields that already match the completed handshake snapshot. */
+internal fun DeviceProfile.withoutUnchangedFields(
+    currentConfig: LocalConfig,
+    currentModuleConfig: LocalModuleConfig,
+    currentUser: User?,
+): DeviceProfile = copy(
+    long_name = long_name?.takeUnless { it == currentUser?.long_name },
+    short_name = short_name?.takeUnless { it == currentUser?.short_name },
+    is_unmessagable = is_unmessagable?.takeUnless { it == currentUser?.is_unmessagable },
+    config = config.withoutUnchangedFields(currentConfig),
+    module_config = module_config.withoutUnchangedFields(currentModuleConfig),
+)
+
+/** Removes profile config sections already reported by the current handshake. */
+private fun LocalConfig?.withoutUnchangedFields(current: LocalConfig): LocalConfig? = this?.let { incoming ->
+    incoming
+        .copy(
+            device = incoming.device?.takeUnless { it == current.device },
+            position = incoming.position?.takeUnless { it == current.position },
+            power = incoming.power?.takeUnless { it == current.power },
+            network = incoming.network?.takeUnless { it == current.network },
+            display = incoming.display?.takeUnless { it == current.display },
+            lora = incoming.lora?.takeUnless { it == current.lora },
+            bluetooth = incoming.bluetooth?.takeUnless { it == current.bluetooth },
+            security = incoming.security?.takeUnless { it == current.security },
+        )
+        .takeIf { it.installableConfigs().isNotEmpty() || it.network != null || it.bluetooth != null }
+}
+
+/** Removes module sections already reported by the current handshake, including transport-disruptive modules. */
+private fun LocalModuleConfig?.withoutUnchangedFields(current: LocalModuleConfig): LocalModuleConfig? =
+    this?.let { incoming ->
+        incoming
+            .copy(
+                mqtt = incoming.mqtt?.takeUnless { it == current.mqtt },
+                serial = incoming.serial?.takeUnless { it == current.serial },
+                external_notification =
+                incoming.external_notification?.takeUnless { it == current.external_notification },
+                store_forward = incoming.store_forward?.takeUnless { it == current.store_forward },
+                range_test = incoming.range_test?.takeUnless { it == current.range_test },
+                telemetry = incoming.telemetry?.takeUnless { it == current.telemetry },
+                canned_message = incoming.canned_message?.takeUnless { it == current.canned_message },
+                audio = incoming.audio?.takeUnless { it == current.audio },
+                remote_hardware = incoming.remote_hardware?.takeUnless { it == current.remote_hardware },
+                neighbor_info = incoming.neighbor_info?.takeUnless { it == current.neighbor_info },
+                ambient_lighting = incoming.ambient_lighting?.takeUnless { it == current.ambient_lighting },
+                detection_sensor = incoming.detection_sensor?.takeUnless { it == current.detection_sensor },
+                paxcounter = incoming.paxcounter?.takeUnless { it == current.paxcounter },
+                statusmessage = incoming.statusmessage?.takeUnless { it == current.statusmessage },
+                traffic_management = incoming.traffic_management?.takeUnless { it == current.traffic_management },
+                tak = incoming.tak?.takeUnless { it == current.tak },
+                mesh_beacon = incoming.mesh_beacon?.takeUnless { it == current.mesh_beacon },
+            )
+            .takeIf { it.installableModuleConfigs().isNotEmpty() || it.mqtt != null || it.serial != null }
+    }
+
+internal fun LocalConfig?.withoutTransportSensitiveConfig(): LocalConfig? =
+    this?.copy(bluetooth = null, network = null)?.takeIf { it.hasInstallableWrites() }
+
+internal fun LocalConfig.hasInstallableWrites(): Boolean = installableConfigs().isNotEmpty()
+
+internal fun LocalModuleConfig?.withoutTransportDisruptiveModules(): LocalModuleConfig? =
+    this?.copy(mqtt = null, serial = null)?.takeIf { it.hasInstallableWrites() }
+
+internal fun LocalModuleConfig.hasInstallableWrites(): Boolean = installableModuleConfigs().isNotEmpty()

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallFields.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallFields.kt
@@ -58,39 +58,16 @@ private fun LocalConfig?.withoutUnchangedFields(current: LocalConfig): LocalConf
         .takeIf { it.installableConfigs().isNotEmpty() || it.network != null || it.bluetooth != null }
 }
 
-/** Removes module sections already reported by the current handshake, including transport-disruptive modules. */
+/** Removes module sections already reported by the current handshake, including transport-sensitive modules. */
 private fun LocalModuleConfig?.withoutUnchangedFields(current: LocalModuleConfig): LocalModuleConfig? =
-    this?.let { incoming ->
-        incoming
-            .copy(
-                mqtt = incoming.mqtt?.takeUnless { it == current.mqtt },
-                serial = incoming.serial?.takeUnless { it == current.serial },
-                external_notification =
-                incoming.external_notification?.takeUnless { it == current.external_notification },
-                store_forward = incoming.store_forward?.takeUnless { it == current.store_forward },
-                range_test = incoming.range_test?.takeUnless { it == current.range_test },
-                telemetry = incoming.telemetry?.takeUnless { it == current.telemetry },
-                canned_message = incoming.canned_message?.takeUnless { it == current.canned_message },
-                audio = incoming.audio?.takeUnless { it == current.audio },
-                remote_hardware = incoming.remote_hardware?.takeUnless { it == current.remote_hardware },
-                neighbor_info = incoming.neighbor_info?.takeUnless { it == current.neighbor_info },
-                ambient_lighting = incoming.ambient_lighting?.takeUnless { it == current.ambient_lighting },
-                detection_sensor = incoming.detection_sensor?.takeUnless { it == current.detection_sensor },
-                paxcounter = incoming.paxcounter?.takeUnless { it == current.paxcounter },
-                statusmessage = incoming.statusmessage?.takeUnless { it == current.statusmessage },
-                traffic_management = incoming.traffic_management?.takeUnless { it == current.traffic_management },
-                tak = incoming.tak?.takeUnless { it == current.tak },
-                mesh_beacon = incoming.mesh_beacon?.takeUnless { it == current.mesh_beacon },
-            )
-            .takeIf { it.installableModuleConfigs().isNotEmpty() || it.mqtt != null || it.serial != null }
-    }
+    this?.withoutUnchangedModuleFields(current)
 
 internal fun LocalConfig?.withoutTransportSensitiveConfig(): LocalConfig? =
     this?.copy(bluetooth = null, network = null)?.takeIf { it.hasInstallableWrites() }
 
 internal fun LocalConfig.hasInstallableWrites(): Boolean = installableConfigs().isNotEmpty()
 
-internal fun LocalModuleConfig?.withoutTransportDisruptiveModules(): LocalModuleConfig? =
+internal fun LocalModuleConfig?.withoutTransportSensitiveModules(): LocalModuleConfig? =
     this?.copy(mqtt = null, serial = null)?.takeIf { it.hasInstallableWrites() }
 
-internal fun LocalModuleConfig.hasInstallableWrites(): Boolean = installableModuleConfigs().isNotEmpty()
+internal fun LocalModuleConfig.hasInstallableWrites(): Boolean = moduleConfigs().isNotEmpty()

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallPlan.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallPlan.kt
@@ -40,11 +40,16 @@ internal object ProfileInstallPlanner {
     ): ProfileInstallPlan {
         val channelRestore = prepareChannelRestore(profile, currentConfig, currentChannels)
         val pendingProfile = profile.withoutUnchangedFields(currentConfig, currentModuleConfig, currentUser)
+        val pendingConfig = pendingProfile.config
+        val transactionConfig =
+            pendingConfig
+                ?.copy(lora = pendingConfig.lora.takeIf { channelRestore?.loraConfig == null })
+                .withoutTransportSensitiveConfig()
 
         return ProfileInstallPlan(
             profile = pendingProfile,
-            config = pendingProfile.config.withoutTransportSensitiveConfig(),
-            moduleConfig = pendingProfile.module_config.withoutTransportDisruptiveModules(),
+            config = transactionConfig,
+            moduleConfig = pendingProfile.module_config.withoutTransportSensitiveModules(),
             channelRestore = channelRestore,
             transportPlan = pendingProfile.transportSensitivePlan(activeTransport),
         )

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallPlan.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallPlan.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.core.common.util.CommonUri
+import org.meshtastic.core.model.DeviceType
+import org.meshtastic.core.model.util.ChannelReplacementPlan
+import org.meshtastic.core.model.util.planChannelReplacement
+import org.meshtastic.core.model.util.toChannelSet
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.User
+
+internal object ProfileInstallPlanner {
+    fun create(
+        profile: DeviceProfile,
+        currentConfig: LocalConfig,
+        currentModuleConfig: LocalModuleConfig,
+        currentChannels: List<ChannelSettings>,
+        currentUser: User?,
+        activeTransport: DeviceType,
+    ): ProfileInstallPlan {
+        val channelRestore = prepareChannelRestore(profile, currentConfig, currentChannels)
+        val pendingProfile = profile.withoutUnchangedFields(currentConfig, currentModuleConfig, currentUser)
+
+        return ProfileInstallPlan(
+            profile = pendingProfile,
+            config = pendingProfile.config.withoutTransportSensitiveConfig(),
+            moduleConfig = pendingProfile.module_config.withoutTransportDisruptiveModules(),
+            channelRestore = channelRestore,
+            transportPlan = pendingProfile.transportSensitivePlan(activeTransport),
+        )
+    }
+
+    private fun prepareChannelRestore(
+        profile: DeviceProfile,
+        currentConfig: LocalConfig,
+        currentChannels: List<ChannelSettings>,
+    ): ChannelReplacementPlan? {
+        val channelUrl = profile.channel_url ?: return null
+        return planChannelReplacement(
+            channelSet = CommonUri.parse(channelUrl).toChannelSet(),
+            currentSettings = currentChannels,
+            currentLoraConfig = currentConfig.lora,
+            explicitLoraConfig = profile.config?.lora,
+        )
+    }
+}
+
+internal data class ProfileInstallPlan(
+    val profile: DeviceProfile,
+    val config: LocalConfig?,
+    val moduleConfig: LocalModuleConfig?,
+    val channelRestore: ChannelReplacementPlan?,
+    val transportPlan: TransportSensitivePlan,
+) {
+    val hasTransactionalWrites: Boolean
+        get() =
+            profile.hasOwnerWrite() ||
+                config != null ||
+                profile.fixed_position != null ||
+                moduleConfig != null ||
+                channelRestore?.hasInstallableWrites == true
+
+    val stageCount: Int
+        get() = (if (hasTransactionalWrites) 1 else 0) + transportPlan.stageCount
+}
+
+internal enum class ProfileInstallStage(val logName: String) {
+    TRANSACTION("transaction"),
+    MQTT("mqtt"),
+    SERIAL("serial"),
+    BLUETOOTH("bluetooth"),
+    NETWORK("network"),
+    TRANSPORT_CONFIG("terminal transport configuration"),
+}
+
+internal data class TransportSensitivePlan(
+    val mqtt: ModuleConfig?,
+    val continuingStages: List<TransportSensitiveStage>,
+    val terminalStages: List<TransportSensitiveStage>,
+    val groupedTerminalConfig: List<TransportSensitiveStage.ConfigWrite>,
+) {
+    val stageCount: Int
+        get() =
+            (if (mqtt != null) 1 else 0) +
+                continuingStages.size +
+                terminalStages.size +
+                (if (groupedTerminalConfig.isNotEmpty()) 1 else 0)
+}
+
+internal sealed interface TransportSensitiveStage {
+    val profileStage: ProfileInstallStage
+    val activeTransportReconnects: Boolean
+
+    data class ConfigWrite(
+        override val profileStage: ProfileInstallStage,
+        val config: Config,
+        override val activeTransportReconnects: Boolean,
+    ) : TransportSensitiveStage
+
+    data class ModuleConfigWrite(
+        override val profileStage: ProfileInstallStage,
+        val config: ModuleConfig,
+        override val activeTransportReconnects: Boolean,
+    ) : TransportSensitiveStage
+}
+
+private fun DeviceProfile.transportSensitivePlan(activeTransport: DeviceType): TransportSensitivePlan {
+    val stages = transportSensitiveStages(activeTransport)
+    val configStages = stages.filterIsInstance<TransportSensitiveStage.ConfigWrite>()
+    val hasTerminalConfigWrite = configStages.any { !it.activeTransportReconnects }
+    // General-config writes share one firmware edit transaction when any of them ends the active transport. This lets
+    // every requested config reach firmware before Bluetooth or Network tears the session down; continuing config
+    // writes do not need a separate reconnect check because the grouped terminal boundary verifies the final outcome.
+    val groupedTerminalConfig = configStages.takeIf { it.size > 1 && hasTerminalConfigWrite }.orEmpty()
+    val individualStages = stages - groupedTerminalConfig.toSet()
+    val (continuingStages, terminalStages) =
+        individualStages.partition(TransportSensitiveStage::activeTransportReconnects)
+    val terminalStageCount = terminalStages.size + if (groupedTerminalConfig.isEmpty()) 0 else 1
+
+    require(terminalStageCount <= 1) {
+        val names =
+            (
+                terminalStages.map { it.profileStage.logName } +
+                    groupedTerminalConfig.filterNot { it.activeTransportReconnects }.map { it.profileStage.logName }
+                )
+                .distinct()
+        "Profile contains multiple settings that end the active transport: $names"
+    }
+
+    return TransportSensitivePlan(
+        mqtt = module_config?.mqtt?.let { ModuleConfig(mqtt = it) },
+        continuingStages = continuingStages,
+        terminalStages = terminalStages,
+        groupedTerminalConfig = groupedTerminalConfig,
+    )
+}
+
+private fun DeviceProfile.transportSensitiveStages(activeTransport: DeviceType): List<TransportSensitiveStage> =
+    buildList {
+        module_config?.serial?.let { serial ->
+            add(
+                TransportSensitiveStage.ModuleConfigWrite(
+                    profileStage = ProfileInstallStage.SERIAL,
+                    config = ModuleConfig(serial = serial),
+                    activeTransportReconnects = activeTransport != DeviceType.USB,
+                ),
+            )
+        }
+        config?.bluetooth?.let { bluetooth ->
+            add(
+                TransportSensitiveStage.ConfigWrite(
+                    profileStage = ProfileInstallStage.BLUETOOTH,
+                    config = Config(bluetooth = bluetooth),
+                    activeTransportReconnects = activeTransport != DeviceType.BLE || bluetooth.enabled,
+                ),
+            )
+        }
+        config?.network?.let { network ->
+            add(
+                TransportSensitiveStage.ConfigWrite(
+                    profileStage = ProfileInstallStage.NETWORK,
+                    config = Config(network = network),
+                    activeTransportReconnects = network.activeTransportReconnects(activeTransport),
+                ),
+            )
+        }
+    }
+
+private fun Config.NetworkConfig.activeTransportReconnects(activeTransport: DeviceType): Boolean =
+    when (activeTransport) {
+        DeviceType.BLE -> !wifi_enabled && !eth_enabled
+        DeviceType.TCP -> false
+        DeviceType.USB -> true
+    }

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallWrites.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallWrites.kt
@@ -23,7 +23,6 @@ import org.meshtastic.proto.Config
 import org.meshtastic.proto.DeviceProfile
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
-import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.User
 
 // is_licensed is deliberately excluded: enabling ham mode is a dedicated onboarding flow with additional side effects.
@@ -44,6 +43,7 @@ internal suspend fun AdminEditScope.installConfig(config: LocalConfig?) {
     config?.installableConfigs()?.forEach { setConfig(it) }
 }
 
+// Network and Bluetooth are emitted as restart-aware TransportSensitiveStage.ConfigWrite stages.
 internal fun LocalConfig.installableConfigs(): List<Config> = listOfNotNull(
     device?.let { Config(device = it) },
     position?.let { Config(position = it) },
@@ -66,26 +66,7 @@ internal suspend fun AdminEditScope.installFixedPosition(fixedPosition: org.mesh
     fixedPosition?.let { setFixedPosition(Position(it)) }
 }
 
-/** Writes module configurations safe for the ordinary transaction; MQTT and Serial are staged separately. */
+/** Writes ordinary module configuration; MQTT and Serial are restart-aware transport-sensitive stages. */
 internal suspend fun AdminEditScope.installModuleConfig(moduleConfig: LocalModuleConfig?) {
-    moduleConfig?.installableModuleConfigs()?.forEach { setModuleConfig(it) }
+    moduleConfig?.moduleConfigs()?.forEach { setModuleConfig(it) }
 }
-
-@Suppress("CyclomaticComplexMethod")
-internal fun LocalModuleConfig.installableModuleConfigs(): List<ModuleConfig> = listOfNotNull(
-    external_notification?.let { ModuleConfig(external_notification = it) },
-    store_forward?.let { ModuleConfig(store_forward = it) },
-    range_test?.let { ModuleConfig(range_test = it) },
-    telemetry?.let { ModuleConfig(telemetry = it) },
-    canned_message?.let { ModuleConfig(canned_message = it) },
-    audio?.let { ModuleConfig(audio = it) },
-    remote_hardware?.let { ModuleConfig(remote_hardware = it) },
-    neighbor_info?.let { ModuleConfig(neighbor_info = it) },
-    ambient_lighting?.let { ModuleConfig(ambient_lighting = it) },
-    detection_sensor?.let { ModuleConfig(detection_sensor = it) },
-    paxcounter?.let { ModuleConfig(paxcounter = it) },
-    statusmessage?.let { ModuleConfig(statusmessage = it) },
-    traffic_management?.let { ModuleConfig(traffic_management = it) },
-    tak?.let { ModuleConfig(tak = it) },
-    mesh_beacon?.let { ModuleConfig(mesh_beacon = it) },
-)

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallWrites.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ProfileInstallWrites.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.core.model.Position
+import org.meshtastic.core.model.util.ChannelReplacementPlan
+import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.User
+
+// is_licensed is deliberately excluded: enabling ham mode is a dedicated onboarding flow with additional side effects.
+internal suspend fun AdminEditScope.installOwner(profile: DeviceProfile, currentUser: User?) {
+    if (profile.hasOwnerWrite()) {
+        setOwner(
+            checkNotNull(currentUser)
+                .copy(
+                    long_name = profile.long_name ?: currentUser.long_name,
+                    short_name = profile.short_name ?: currentUser.short_name,
+                    is_unmessagable = profile.is_unmessagable ?: currentUser.is_unmessagable,
+                ),
+        )
+    }
+}
+
+internal suspend fun AdminEditScope.installConfig(config: LocalConfig?) {
+    config?.installableConfigs()?.forEach { setConfig(it) }
+}
+
+internal fun LocalConfig.installableConfigs(): List<Config> = listOfNotNull(
+    device?.let { Config(device = it) },
+    position?.let { Config(position = it) },
+    power?.let { Config(power = it) },
+    display?.let { Config(display = it) },
+    lora?.let { Config(lora = it) },
+    security?.let { Config(security = it) },
+)
+
+/** Writes an authoritative channel replacement and reports each successfully issued channel command. */
+internal suspend fun AdminEditScope.installChannels(restore: ChannelReplacementPlan?, onWriteIssued: () -> Unit) {
+    restore?.writes?.forEach { channel ->
+        setChannel(channel)
+        onWriteIssued()
+    }
+    restore?.loraConfig?.let { setConfig(Config(lora = it)) }
+}
+
+internal suspend fun AdminEditScope.installFixedPosition(fixedPosition: org.meshtastic.proto.Position?) {
+    fixedPosition?.let { setFixedPosition(Position(it)) }
+}
+
+/** Writes module configurations safe for the ordinary transaction; MQTT and Serial are staged separately. */
+internal suspend fun AdminEditScope.installModuleConfig(moduleConfig: LocalModuleConfig?) {
+    moduleConfig?.installableModuleConfigs()?.forEach { setModuleConfig(it) }
+}
+
+@Suppress("CyclomaticComplexMethod")
+internal fun LocalModuleConfig.installableModuleConfigs(): List<ModuleConfig> = listOfNotNull(
+    external_notification?.let { ModuleConfig(external_notification = it) },
+    store_forward?.let { ModuleConfig(store_forward = it) },
+    range_test?.let { ModuleConfig(range_test = it) },
+    telemetry?.let { ModuleConfig(telemetry = it) },
+    canned_message?.let { ModuleConfig(canned_message = it) },
+    audio?.let { ModuleConfig(audio = it) },
+    remote_hardware?.let { ModuleConfig(remote_hardware = it) },
+    neighbor_info?.let { ModuleConfig(neighbor_info = it) },
+    ambient_lighting?.let { ModuleConfig(ambient_lighting = it) },
+    detection_sensor?.let { ModuleConfig(detection_sensor = it) },
+    paxcounter?.let { ModuleConfig(paxcounter = it) },
+    statusmessage?.let { ModuleConfig(statusmessage = it) },
+    traffic_management?.let { ModuleConfig(traffic_management = it) },
+    tak?.let { ModuleConfig(tak = it) },
+    mesh_beacon?.let { ModuleConfig(mesh_beacon = it) },
+)

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
@@ -16,8 +16,34 @@
  */
 package org.meshtastic.core.domain.usecase.settings
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.util.CHANNEL_REPLACEMENT_SLOT_COUNT
+import org.meshtastic.core.model.util.MalformedMeshtasticUrlException
+import org.meshtastic.core.model.util.getChannelUrl
+import org.meshtastic.core.repository.NodeRestartTracker
+import org.meshtastic.core.repository.RadioConfigRepository
+import org.meshtastic.core.testing.FakeNodeRepository
+import org.meshtastic.core.testing.FakeRadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioController
+import org.meshtastic.core.testing.FakeRadioInterfaceService
+import org.meshtastic.core.testing.TestDataFactory
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config.BluetoothConfig
 import org.meshtastic.proto.Config.DeviceConfig
 import org.meshtastic.proto.Config.DisplayConfig
@@ -27,95 +53,830 @@ import org.meshtastic.proto.Config.PositionConfig
 import org.meshtastic.proto.Config.PowerConfig
 import org.meshtastic.proto.Config.SecurityConfig
 import org.meshtastic.proto.DeviceProfile
-import org.meshtastic.proto.ModuleConfig.AmbientLightingConfig
-import org.meshtastic.proto.ModuleConfig.AudioConfig
-import org.meshtastic.proto.ModuleConfig.CannedMessageConfig
-import org.meshtastic.proto.ModuleConfig.DetectionSensorConfig
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.ModuleConfig.ExternalNotificationConfig
 import org.meshtastic.proto.ModuleConfig.MQTTConfig
-import org.meshtastic.proto.ModuleConfig.NeighborInfoConfig
-import org.meshtastic.proto.ModuleConfig.PaxcounterConfig
-import org.meshtastic.proto.ModuleConfig.RangeTestConfig
-import org.meshtastic.proto.ModuleConfig.RemoteHardwareConfig
+import org.meshtastic.proto.ModuleConfig.MeshBeaconConfig
 import org.meshtastic.proto.ModuleConfig.SerialConfig
-import org.meshtastic.proto.ModuleConfig.StatusMessageConfig
-import org.meshtastic.proto.ModuleConfig.StoreForwardConfig
-import org.meshtastic.proto.ModuleConfig.TAKConfig
-import org.meshtastic.proto.ModuleConfig.TelemetryConfig
+import org.meshtastic.proto.ModuleConfig.TrafficManagementConfig
 import org.meshtastic.proto.User
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class InstallProfileUseCaseTest {
 
     private lateinit var radioController: FakeRadioController
+    private lateinit var radioInterfaceService: FakeRadioInterfaceService
+    private lateinit var radioConfigRepository: FakeRadioConfigRepository
+    private lateinit var nodeRepository: FakeNodeRepository
+    private lateinit var testDispatcher: TestDispatcher
+    private lateinit var restartTrackerScope: CoroutineScope
+    private lateinit var restartTracker: NodeRestartTracker
     private lateinit var useCase: InstallProfileUseCase
 
     @BeforeTest
     fun setUp() {
-        radioController = FakeRadioController()
-        useCase = InstallProfileUseCase(radioController)
+        testDispatcher = StandardTestDispatcher()
+        restartTrackerScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        radioController = FakeRadioController().apply { setConnectionState(ConnectionState.Connected) }
+        radioInterfaceService =
+            FakeRadioInterfaceService(restartTrackerScope).apply { setDeviceAddress("x00:11:22:33:44:55") }
+        radioConfigRepository = FakeRadioConfigRepository()
+        nodeRepository =
+            FakeNodeRepository().apply { setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = 1234)) }
+        restartTracker = NodeRestartTracker(restartTrackerScope)
+        useCase =
+            InstallProfileUseCase(
+                radioController,
+                radioInterfaceService,
+                radioConfigRepository,
+                nodeRepository,
+                restartTracker,
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        restartTrackerScope.cancel()
     }
 
     @Test
-    fun `invoke calls begin and commit edit settings`() = runTest {
-        useCase(1234, DeviceProfile(), User())
+    fun `empty profile performs no restart or writes`() = runTest(testDispatcher) {
+        useCase(1234, DeviceProfile(), User(), isLocal = true)
 
-        assertTrue(radioController.editSettingsCalled)
+        assertNoDeviceWrites()
+        assertFalse(restartTracker.restartExpected.value)
     }
 
     @Test
-    fun `invoke installs all sections of a full profile`() = runTest {
+    fun `profile installation reports each planned stage`() = runTest(testDispatcher) {
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        radioController.onStandaloneModuleConfig = { emitRestartCycle() }
+        val progress = mutableListOf<ProfileInstallProgress>()
         val profile =
             DeviceProfile(
-                long_name = "Full Node",
-                short_name = "FULL",
-                config =
-                org.meshtastic.proto.LocalConfig(
-                    device = DeviceConfig(),
-                    position = PositionConfig(),
-                    power = PowerConfig(),
-                    network = NetworkConfig(),
-                    display = DisplayConfig(),
-                    lora = LoRaConfig(),
-                    bluetooth = BluetoothConfig(),
-                    security = SecurityConfig(),
-                ),
-                module_config =
-                org.meshtastic.proto.LocalModuleConfig(
-                    mqtt = MQTTConfig(),
-                    serial = SerialConfig(),
-                    external_notification = ExternalNotificationConfig(),
-                    store_forward = StoreForwardConfig(),
-                    range_test = RangeTestConfig(),
-                    telemetry = TelemetryConfig(),
-                    canned_message = CannedMessageConfig(),
-                    audio = AudioConfig(),
-                    remote_hardware = RemoteHardwareConfig(),
-                    neighbor_info = NeighborInfoConfig(),
-                    ambient_lighting = AmbientLightingConfig(),
-                    detection_sensor = DetectionSensorConfig(),
-                    paxcounter = PaxcounterConfig(),
-                    statusmessage = StatusMessageConfig(),
-                    tak = TAKConfig(),
-                ),
-                fixed_position = org.meshtastic.proto.Position(),
+                long_name = "Updated node",
+                module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true)),
             )
 
-        useCase(1234, profile, org.meshtastic.proto.User(long_name = "Old"))
+        useCase(1234, profile, User(long_name = "Old node"), isLocal = true, progress::add)
 
-        assertTrue(radioController.editSettingsCalled)
+        assertEquals(listOf(ProfileInstallProgress(1, 2), ProfileInstallProgress(2, 2)), progress)
     }
 
     @Test
-    fun `invoke installs is_unmessagable but never auto-installs is_licensed`() = runTest {
+    fun `profile snapshot wait is bounded before any device write`() = runTest(testDispatcher) {
+        val stalledRepository =
+            object : RadioConfigRepository by radioConfigRepository {
+                override val localConfigFlow = MutableSharedFlow<LocalConfig>()
+            }
+        useCase =
+            InstallProfileUseCase(
+                radioController,
+                radioInterfaceService,
+                stalledRepository,
+                nodeRepository,
+                restartTracker,
+            )
+
+        val result = async { runCatching { useCase(1234, DeviceProfile(), User(), isLocal = true) } }
+        advanceTimeBy(10_001)
+
+        val failure = result.await().exceptionOrNull()
+        assertTrue(failure is IllegalStateException)
+        assertTrue(failure.message.orEmpty().contains("Timed out waiting"))
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `profile snapshot is rejected after connection lifecycle rollover`() = runTest(testDispatcher) {
+        val snapshotStarted = CompletableDeferred<Unit>()
+        val releaseSnapshot = CompletableDeferred<Unit>()
+        val delayedRepository =
+            object : RadioConfigRepository by radioConfigRepository {
+                override val localConfigFlow = flow {
+                    snapshotStarted.complete(Unit)
+                    releaseSnapshot.await()
+                    emit(LocalConfig())
+                }
+            }
+        useCase =
+            InstallProfileUseCase(
+                radioController,
+                radioInterfaceService,
+                delayedRepository,
+                nodeRepository,
+                restartTracker,
+            )
+
+        val result = async { runCatching { useCase(1234, DeviceProfile(), User(), isLocal = true) } }
+        snapshotStarted.await()
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        radioController.setConnectionState(ConnectionState.Connected)
+        releaseSnapshot.complete(Unit)
+
+        val failure = result.await().exceptionOrNull()
+        assertTrue(failure is IllegalStateException)
+        assertTrue(failure.message.orEmpty().contains("lifecycle changed"))
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `profile snapshot is rejected after transport selection changes`() = runTest(testDispatcher) {
+        val snapshotStarted = CompletableDeferred<Unit>()
+        val releaseSnapshot = CompletableDeferred<Unit>()
+        val delayedRepository =
+            object : RadioConfigRepository by radioConfigRepository {
+                override val localConfigFlow = flow {
+                    snapshotStarted.complete(Unit)
+                    releaseSnapshot.await()
+                    emit(LocalConfig())
+                }
+            }
+        useCase =
+            InstallProfileUseCase(
+                radioController,
+                radioInterfaceService,
+                delayedRepository,
+                nodeRepository,
+                restartTracker,
+            )
+
+        val result = async { runCatching { useCase(1234, DeviceProfile(), User(), isLocal = true) } }
+        snapshotStarted.await()
+        radioInterfaceService.setDeviceAddress("t192.0.2.1")
+        releaseSnapshot.complete(Unit)
+
+        val failure = result.await().exceptionOrNull()
+        assertTrue(failure is IllegalStateException)
+        assertTrue(failure.message.orEmpty().contains("transport changed"))
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `transaction on TCP waits for the firmware reboot and handshake`() = runTest(testDispatcher) {
+        radioInterfaceService.setDeviceAddress("t192.0.2.1")
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        val profile = DeviceProfile(config = LocalConfig(lora = LoRaConfig(region = LoRaConfig.RegionCode.US)))
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertTrue(radioController.editSettingsCalled)
+        assertEquals(ConnectionState.Connected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `fast restart cycle cannot be lost to connection state conflation`() = runTest(testDispatcher) {
+        radioController.onEditSettingsCommitted = { emitFastRestartCycle() }
+        val profile = DeviceProfile(config = LocalConfig(device = DeviceConfig()))
+        val baselineEpochs = radioController.connectionEpochs.value
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(ConnectionState.Connected, radioController.connectionState.value)
+        assertEquals(baselineEpochs.departures + 1, radioController.connectionEpochs.value.departures)
+        assertEquals(
+            baselineEpochs.completedHandshakes + 1,
+            radioController.connectionEpochs.value.completedHandshakes,
+        )
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `reconnect must follow the latest departure rather than an older handshake`() = runTest(testDispatcher) {
+        val allowLatestReconnect = CompletableDeferred<Unit>()
+        radioController.onEditSettingsCommitted = {
+            emitFastRestartCycle()
+            radioController.setConnectionState(ConnectionState.Disconnected)
+            backgroundScope.launch {
+                allowLatestReconnect.await()
+                radioController.setConnectionState(ConnectionState.Connected)
+            }
+        }
+        radioController.onStandaloneModuleConfig = { emitFastRestartCycle() }
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(device = DeviceConfig()),
+                module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true)),
+            )
+
+        val installation = async { useCase(1234, profile, User(), isLocal = true) }
+        testScheduler.runCurrent()
+
+        assertFalse(installation.isCompleted)
+        assertTrue(radioController.moduleConfigWrites.isEmpty())
+
+        allowLatestReconnect.complete(Unit)
+        testScheduler.runCurrent()
+        installation.await()
+
+        assertEquals(MQTTConfig(enabled = true), radioController.moduleConfigs.single().mqtt)
+    }
+
+    @Test
+    fun `version-only remnants do not open an empty transaction`() = runTest(testDispatcher) {
+        radioController.onStandaloneModuleConfig = { emitFastRestartCycle() }
+        radioController.onStandaloneConfig = { emitDeparture() }
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(bluetooth = BluetoothConfig(enabled = false), version = 1),
+                module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true), version = 1),
+            )
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertFalse(radioController.editSettingsCalled)
+        assertEquals(listOf("module:update", "config:update"), radioController.adminOperations)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `unchanged profile config is skipped without restart or writes`() = runTest(testDispatcher) {
+        val currentConfig =
+            LocalConfig(
+                device = DeviceConfig(),
+                position = PositionConfig(),
+                power = PowerConfig(),
+                network = NetworkConfig(wifi_enabled = true, wifi_ssid = "existing"),
+                display = DisplayConfig(compass_north_top = true),
+                lora = LoRaConfig(region = LoRaConfig.RegionCode.US),
+                bluetooth = BluetoothConfig(enabled = true),
+                security = SecurityConfig(),
+                version = 7,
+            )
+        val currentModuleConfig =
+            LocalModuleConfig(
+                mqtt = MQTTConfig(enabled = true),
+                serial = SerialConfig(enabled = true),
+                external_notification = ExternalNotificationConfig(enabled = true),
+                traffic_management = TrafficManagementConfig(position_min_interval_secs = 30),
+                mesh_beacon = MeshBeaconConfig(broadcast_message = "existing beacon"),
+                version = 9,
+            )
+        radioConfigRepository.setLocalConfigDirect(currentConfig)
+        radioConfigRepository.setLocalModuleConfigDirect(currentModuleConfig)
+
+        val currentUser = User(long_name = "Current User", short_name = "CUR", is_unmessagable = true)
+        useCase(
+            1234,
+            DeviceProfile(
+                long_name = currentUser.long_name,
+                short_name = currentUser.short_name,
+                is_unmessagable = currentUser.is_unmessagable,
+                config = currentConfig,
+                module_config = currentModuleConfig,
+            ),
+            currentUser,
+            isLocal = true,
+        )
+
+        assertNoDeviceWrites()
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `mixed profile sends only changed ordinary and transport settings`() = runTest(testDispatcher) {
+        val currentConfig =
+            LocalConfig(
+                device = DeviceConfig(),
+                display = DisplayConfig(compass_north_top = false),
+                network = NetworkConfig(wifi_enabled = false),
+                bluetooth = BluetoothConfig(enabled = true),
+            )
+        val currentModuleConfig =
+            LocalModuleConfig(
+                mqtt = MQTTConfig(enabled = true),
+                serial = SerialConfig(enabled = false),
+                external_notification = ExternalNotificationConfig(enabled = true),
+                mesh_beacon = MeshBeaconConfig(broadcast_message = "old beacon"),
+            )
+        radioConfigRepository.setLocalConfigDirect(currentConfig)
+        radioConfigRepository.setLocalModuleConfigDirect(currentModuleConfig)
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        radioController.onStandaloneModuleConfig = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(
+                config = currentConfig.copy(display = DisplayConfig(compass_north_top = true)),
+                module_config =
+                currentModuleConfig.copy(
+                    serial = SerialConfig(enabled = true),
+                    mesh_beacon = MeshBeaconConfig(broadcast_message = "new beacon"),
+                ),
+            ),
+            User(),
+            isLocal = true,
+        )
+
+        assertEquals(
+            listOf(DisplayConfig(compass_north_top = true)),
+            radioController.localConfigs.mapNotNull { it.display },
+        )
+        assertEquals(
+            listOf(MeshBeaconConfig(broadcast_message = "new beacon"), SerialConfig(enabled = true)),
+            radioController.moduleConfigs.mapNotNull { it.mesh_beacon ?: it.serial },
+        )
+        assertEquals(
+            listOf("begin", "config:update", "module:update", "commit", "module:update"),
+            radioController.adminOperations,
+        )
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `mesh beacon profile is restored inside the ordinary transaction`() = runTest(testDispatcher) {
+        val meshBeacon = MeshBeaconConfig(broadcast_message = "restored beacon")
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(module_config = LocalModuleConfig(mesh_beacon = meshBeacon)),
+            User(),
+            isLocal = true,
+        )
+
+        assertTrue(radioController.editSettingsCalled)
+        assertEquals(meshBeacon, radioController.moduleConfigs.single().mesh_beacon)
+        assertEquals(listOf("begin", "module:update", "commit"), radioController.adminOperations)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `traffic management profile is restored inside the ordinary transaction`() = runTest(testDispatcher) {
+        val trafficManagement = TrafficManagementConfig(position_min_interval_secs = 30)
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(module_config = LocalModuleConfig(traffic_management = trafficManagement)),
+            User(),
+            isLocal = true,
+        )
+
+        assertTrue(radioController.editSettingsCalled)
+        assertEquals(trafficManagement, radioController.moduleConfigs.single().traffic_management)
+        assertEquals(listOf("begin", "module:update", "commit"), radioController.adminOperations)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `matching channel profile skips the transaction and restart`() = runTest(testDispatcher) {
+        val settings =
+            (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).map { index ->
+                ChannelSettings(name = "Channel $index", psk = byteArrayOf(index.toByte()).toByteString())
+            }
+        radioConfigRepository.setChannelSet(ChannelSet(settings = settings))
+        val profile = DeviceProfile(channel_url = ChannelSet(settings = settings).getChannelUrl().toString())
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertNoDeviceWrites()
+        assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `TCP profile restores network last after reconnecting from earlier stages`() = runTest(testDispatcher) {
+        val mqtt = MQTTConfig(enabled = true)
+        val serial = SerialConfig(enabled = true)
+        val bluetooth = BluetoothConfig(enabled = true)
+        val network = NetworkConfig(wifi_enabled = true, wifi_ssid = "new-network")
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(network = network, bluetooth = bluetooth),
+                module_config = LocalModuleConfig(mqtt = mqtt, serial = serial),
+            )
+        radioInterfaceService.setDeviceAddress("t192.0.2.1")
+        radioController.onStandaloneModuleConfig = { emitRestartCycle() }
+        radioController.onEditSettingsCommitted = { emitDeparture() }
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(listOf(mqtt, serial), radioController.moduleConfigs.mapNotNull { it.mqtt ?: it.serial })
+        assertEquals(bluetooth, radioController.localConfigs.first().bluetooth)
+        assertEquals(network, radioController.localConfigs.last().network)
+        assertEquals(
+            listOf("module:update", "module:update", "begin", "config:update", "config:update", "commit"),
+            radioController.adminOperations,
+        )
+        assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `USB profile restores serial last after reconnecting from earlier stages`() = runTest(testDispatcher) {
+        val mqtt = MQTTConfig(enabled = true)
+        val serial = SerialConfig(enabled = true)
+        val bluetooth = BluetoothConfig(enabled = true)
+        val network = NetworkConfig(wifi_enabled = true, wifi_ssid = "new-network")
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(bluetooth = bluetooth, network = network),
+                module_config = LocalModuleConfig(mqtt = mqtt, serial = serial),
+            )
+        radioInterfaceService.setDeviceAddress("s/dev/ttyUSB0")
+        radioController.onStandaloneModuleConfig = { config ->
+            if (config.serial != null) emitDeparture() else emitRestartCycle()
+        }
+        radioController.onStandaloneConfig = { emitRestartCycle() }
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(listOf(mqtt, serial), radioController.moduleConfigs.mapNotNull { it.mqtt ?: it.serial })
+        assertEquals(listOf(bluetooth, null), radioController.localConfigs.map { it.bluetooth })
+        assertEquals(listOf(null, network), radioController.localConfigs.map { it.network })
+        assertEquals(
+            listOf("module:update", "config:update", "config:update", "module:update"),
+            radioController.adminOperations,
+        )
+        assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `BLE terminal transport settings commit together before the connection ends`() = runTest(testDispatcher) {
+        val bluetooth = BluetoothConfig(enabled = false)
+        val network = NetworkConfig(wifi_enabled = true, wifi_ssid = "new-network")
+        radioController.onEditSettingsCommitted = { emitDeparture() }
+
+        useCase(
+            1234,
+            DeviceProfile(config = LocalConfig(bluetooth = bluetooth, network = network)),
+            User(),
+            isLocal = true,
+        )
+
+        assertEquals(listOf(bluetooth, null), radioController.localConfigs.map { it.bluetooth })
+        assertEquals(listOf(null, network), radioController.localConfigs.map { it.network })
+        assertEquals(listOf("begin", "config:update", "config:update", "commit"), radioController.adminOperations)
+        assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `rejected standalone module config fails after the bounded departure wait`() = runTest(testDispatcher) {
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                useCase(
+                    1234,
+                    DeviceProfile(module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true))),
+                    User(),
+                    isLocal = true,
+                )
+            }
+
+        assertEquals("Device did not begin the mqtt profile restart", failure.message)
+        assertEquals(20_000L, testScheduler.currentTime)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `failed reconnect clears the expected restart window while disconnected`() = runTest(testDispatcher) {
+        radioController.onStandaloneModuleConfig = { emitDeparture() }
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                useCase(
+                    1234,
+                    DeviceProfile(module_config = LocalModuleConfig(mqtt = MQTTConfig(enabled = true))),
+                    User(),
+                    isLocal = true,
+                )
+            }
+
+        assertEquals("Device did not reconnect after the mqtt profile stage", failure.message)
+        assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `full profile commits ordinary settings before transport disruptive stages`() = runTest(testDispatcher) {
+        val importedChannels =
+            listOf(
+                ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()),
+                ChannelSettings(name = "Private", psk = byteArrayOf(2).toByteString()),
+            )
+        val channelUrl =
+            ChannelSet(settings = importedChannels, lora_config = LoRaConfig(region = LoRaConfig.RegionCode.US))
+                .getChannelUrl()
+                .toString()
+        radioConfigRepository.setChannelSet(
+            ChannelSet(settings = listOf(ChannelSettings(name = "Old"), ChannelSettings(name = "Stale"))),
+        )
+        radioConfigRepository.setLocalConfigDirect(
+            LocalConfig(lora = LoRaConfig(region = LoRaConfig.RegionCode.EU_868)),
+        )
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+        radioController.onStandaloneModuleConfig = {
+            assertEquals(importedChannels, radioConfigRepository.currentChannelSet.settings)
+            emitRestartCycle()
+        }
+        radioController.onStandaloneConfig = { emitRestartCycle() }
+
+        useCase(1234, fullProfile(channelUrl), User(long_name = "Old"), isLocal = true)
+
+        assertFullProfileWriteOrder()
+        assertFullProfileResult(importedChannels)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `channel cache remains unchanged when the first transactional channel write fails`() = runTest(testDispatcher) {
+        val original = listOf(ChannelSettings(name = "Original", psk = byteArrayOf(9).toByteString()))
+        val imported = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        radioConfigRepository.setChannelSet(ChannelSet(settings = original))
+        radioController.failChannelWriteAfter = 0
+        val profile = DeviceProfile(channel_url = ChannelSet(settings = imported).getChannelUrl().toString())
+
+        assertFails { useCase(1234, profile, User(), isLocal = true) }
+
+        assertTrue(radioController.localChannels.isEmpty())
+        assertTrue("commit" in radioController.adminOperations)
+        assertEquals(original, radioConfigRepository.currentChannelSet.settings)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `channel cache reconciles the authoritative import after a partial transaction failure`() =
+        runTest(testDispatcher) {
+            val original = listOf(ChannelSettings(name = "Original", psk = byteArrayOf(9).toByteString()))
+            val imported =
+                listOf(
+                    ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()),
+                    ChannelSettings(name = "Private", psk = byteArrayOf(2).toByteString()),
+                )
+            radioConfigRepository.setChannelSet(ChannelSet(settings = original))
+            radioController.failChannelWriteAfter = 2
+            val profile = DeviceProfile(channel_url = ChannelSet(settings = imported).getChannelUrl().toString())
+
+            assertFails { useCase(1234, profile, User(), isLocal = true) }
+
+            assertEquals(listOf(0, 1), radioController.localChannels.map(Channel::index))
+            assertTrue("commit" in radioController.adminOperations)
+            assertEquals(imported, radioConfigRepository.currentChannelSet.settings)
+            assertFalse(restartTracker.restartExpected.value)
+        }
+
+    @Test
+    fun `transaction failure remains primary when channel cache reconciliation also fails`() = runTest(testDispatcher) {
+        val imported = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        radioController.failChannelWriteAfter = 1
+        radioConfigRepository.replaceAllSettingsFailure = IllegalStateException("cache reconciliation failed")
+        val profile = DeviceProfile(channel_url = ChannelSet(settings = imported).getChannelUrl().toString())
+
+        val failure = assertFailsWith<IllegalStateException> { useCase(1234, profile, User(), isLocal = true) }
+
+        assertEquals("Fake channel write failure", failure.message)
+        assertEquals(listOf("cache reconciliation failed"), failure.suppressedExceptions.map(Throwable::message))
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `transport stages retarget the current local identity after each reconnect`() = runTest(testDispatcher) {
+        radioController.onEditSettingsCommitted = {
+            nodeRepository.setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = 5678))
+            emitRestartCycle()
+        }
+        radioController.onStandaloneModuleConfig = { moduleConfig ->
+            val nextNodeNum = if (moduleConfig.mqtt != null) 9012 else 3456
+            nodeRepository.setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = nextNodeNum))
+            emitRestartCycle()
+        }
+        radioController.onStandaloneConfig = { emitRestartCycle() }
+        val profile =
+            DeviceProfile(
+                config = LocalConfig(security = SecurityConfig(), bluetooth = BluetoothConfig(enabled = true)),
+                module_config =
+                LocalModuleConfig(mqtt = MQTTConfig(enabled = true), serial = SerialConfig(enabled = true)),
+            )
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(listOf(0), radioController.editSettingsDestinations)
+        assertEquals(listOf(5678, 9012), radioController.moduleConfigDestinations.takeLast(2))
+        assertEquals(3456, radioController.configWrites.last().destination)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `profile install rejects a stale local destination before writes`() = runTest(testDispatcher) {
+        nodeRepository.setMyNodeInfo(TestDataFactory.createMyNodeInfo(myNodeNum = 5678))
+
+        assertFailsWith<IllegalArgumentException> {
+            useCase(1234, DeviceProfile(long_name = "Stale"), User(), isLocal = true)
+        }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `bluetooth disable is the final stage and does not wait for an impossible reconnect`() =
+        runTest(testDispatcher) {
+            radioController.onEditSettingsCommitted = { emitRestartCycle() }
+            radioController.onStandaloneConfig = {
+                radioController.setConnectionState(ConnectionState.Disconnected)
+                yield()
+            }
+            val profile =
+                DeviceProfile(
+                    config = LocalConfig(device = DeviceConfig(), bluetooth = BluetoothConfig(enabled = false)),
+                )
+
+            useCase(1234, profile, User(), isLocal = true)
+
+            assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
+            assertEquals(BluetoothConfig(enabled = false), radioController.localConfigs.last().bluetooth)
+            assertFalse(restartTracker.restartExpected.value)
+        }
+
+    @Test
+    fun `unchanged explicit profile LoRa still overrides channel URL LoRa`() = runTest(testDispatcher) {
+        val currentLora = LoRaConfig(region = LoRaConfig.RegionCode.US, hop_limit = 3)
+        val channelLora = LoRaConfig(region = LoRaConfig.RegionCode.EU_868, hop_limit = 5)
+        val settings = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        val channelUrl = ChannelSet(settings = settings, lora_config = channelLora).getChannelUrl().toString()
+        radioConfigRepository.setLocalConfigDirect(LocalConfig(lora = currentLora))
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(
+            1234,
+            DeviceProfile(config = LocalConfig(lora = currentLora), channel_url = channelUrl),
+            User(),
+            isLocal = true,
+        )
+
+        assertTrue(radioController.localConfigs.none { it.lora != null })
+        assertEquals(
+            (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(),
+            radioController.localChannels.map(Channel::index),
+        )
+        assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `channel URL without profile LoRa restores its channel LoRa config`() = runTest(testDispatcher) {
+        val channelLora = LoRaConfig(region = LoRaConfig.RegionCode.US, hop_limit = 4)
+        val settings = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+        val channelUrl = ChannelSet(settings = settings, lora_config = channelLora).getChannelUrl().toString()
+        val profile = DeviceProfile(channel_url = channelUrl)
+        radioConfigRepository.setLocalConfigDirect(
+            LocalConfig(lora = LoRaConfig(region = LoRaConfig.RegionCode.EU_868)),
+        )
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+        useCase(1234, profile, User(), isLocal = true)
+
+        assertEquals(channelLora, radioController.localConfigs.single().lora)
+        assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
+    }
+
+    @Test
+    fun `owner fields fail before writes when current owner is unavailable`() = runTest(testDispatcher) {
+        val profile = DeviceProfile(long_name = "Restored")
+
+        assertFailsWith<IllegalArgumentException> { useCase(1234, profile, currentUser = null, isLocal = true) }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `malformed channel URL fails before any device write`() = runTest(testDispatcher) {
+        val profile = DeviceProfile(channel_url = "https://example.com/not-a-channel")
+
+        assertFailsWith<MalformedMeshtasticUrlException> { useCase(1234, profile, User(), isLocal = true) }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `channel URL without payload fails before any device write`() = runTest(testDispatcher) {
+        val profile = DeviceProfile(channel_url = ChannelSet().getChannelUrl().toString())
+
+        assertFailsWith<MalformedMeshtasticUrlException> { useCase(1234, profile, User(), isLocal = true) }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `profile install rejects remote administration`() = runTest(testDispatcher) {
+        assertFailsWith<IllegalArgumentException> {
+            useCase(1234, DeviceProfile(long_name = "Remote"), User(), isLocal = false)
+        }
+
+        assertNoDeviceWrites()
+    }
+
+    @Test
+    fun `invoke installs is_unmessagable but never auto-installs is_licensed`() = runTest(testDispatcher) {
+        radioController.onEditSettingsCommitted = { emitRestartCycle() }
         val profile = DeviceProfile(is_unmessagable = true, is_licensed = true)
 
-        useCase(1234, profile, User(long_name = "Old"))
+        useCase(1234, profile, User(long_name = "Old"), isLocal = true)
 
         assertEquals(true, radioController.lastSetOwnerUser?.is_unmessagable)
         assertEquals(false, radioController.lastSetOwnerUser?.is_licensed)
+    }
+
+    private fun fullProfile(channelUrl: String) = DeviceProfile(
+        long_name = "Full Node",
+        short_name = "FULL",
+        channel_url = channelUrl,
+        config =
+        LocalConfig(
+            device = DeviceConfig(),
+            position = PositionConfig(),
+            power = PowerConfig(),
+            network = NetworkConfig(),
+            display = DisplayConfig(),
+            lora = LoRaConfig(region = LoRaConfig.RegionCode.US),
+            bluetooth = BluetoothConfig(enabled = true),
+            security = SecurityConfig(),
+        ),
+        module_config =
+        LocalModuleConfig(
+            mqtt = MQTTConfig(enabled = true),
+            serial = SerialConfig(enabled = true),
+            external_notification = ExternalNotificationConfig(enabled = true),
+            mesh_beacon = MeshBeaconConfig(broadcast_message = "restored beacon"),
+        ),
+        fixed_position = org.meshtastic.proto.Position(latitude_i = 1, longitude_i = 2),
+    )
+
+    private fun assertFullProfileWriteOrder() {
+        assertEquals(listOf("begin", "owner"), radioController.adminOperations.take(2))
+        val commitIndex = radioController.adminOperations.indexOf("commit")
+        assertTrue(commitIndex > radioController.adminOperations.indexOf("fixed-position"))
+        val moduleOperationIndexes =
+            radioController.adminOperations.mapIndexedNotNull { index, operation ->
+                index.takeIf { operation.startsWith("module:") }
+            }
+        val firstTransportSensitiveModuleIndex =
+            radioController.moduleConfigs.indexOfFirst { it.mqtt != null || it.serial != null }
+        assertTrue(firstTransportSensitiveModuleIndex > 0)
+        assertTrue(moduleOperationIndexes.take(firstTransportSensitiveModuleIndex).all { it < commitIndex })
+        assertTrue(moduleOperationIndexes.drop(firstTransportSensitiveModuleIndex).all { it > commitIndex })
+    }
+
+    private fun assertFullProfileResult(importedChannels: List<ChannelSettings>) {
+        assertEquals(
+            listOf(
+                ExternalNotificationConfig(enabled = true),
+                MeshBeaconConfig(broadcast_message = "restored beacon"),
+                MQTTConfig(enabled = true),
+                SerialConfig(enabled = true),
+            ),
+            radioController.moduleConfigs.mapNotNull {
+                it.external_notification ?: it.mesh_beacon ?: it.mqtt ?: it.serial
+            },
+        )
+        assertEquals(BluetoothConfig(enabled = true), radioController.localConfigs.mapNotNull { it.bluetooth }.last())
+        assertEquals(NetworkConfig(), radioController.localConfigs.mapNotNull { it.network }.last())
+        assertEquals(1e-7, radioController.fixedPositions.single().latitude, absoluteTolerance = 1e-12)
+        assertEquals(2e-7, radioController.fixedPositions.single().longitude, absoluteTolerance = 1e-12)
+        assertEquals(
+            (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(),
+            radioController.localChannels.map(Channel::index),
+        )
+        assertEquals(importedChannels, radioConfigRepository.currentChannelSet.settings)
+    }
+
+    private fun assertNoDeviceWrites() {
+        assertFalse(radioController.editSettingsCalled)
+        assertTrue(radioController.adminOperations.isEmpty())
+        assertTrue(radioController.configWrites.isEmpty())
+        assertTrue(radioController.localChannels.isEmpty())
+        assertTrue(radioController.moduleConfigs.isEmpty())
+        assertTrue(radioController.fixedPositions.isEmpty())
+        assertEquals(null, radioController.lastSetOwnerUser)
+    }
+
+    private suspend fun emitRestartCycle() {
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        yield()
+        radioController.setConnectionState(ConnectionState.Connecting)
+        yield()
+        radioController.setConnectionState(ConnectionState.Connected)
+        yield()
+    }
+
+    private fun emitFastRestartCycle() {
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        radioController.setConnectionState(ConnectionState.Connecting)
+        radioController.setConnectionState(ConnectionState.Connected)
+    }
+
+    private suspend fun emitDeparture() {
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        yield()
     }
 }

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
@@ -137,14 +137,7 @@ class InstallProfileUseCaseTest {
             object : RadioConfigRepository by radioConfigRepository {
                 override val localConfigFlow = MutableSharedFlow<LocalConfig>()
             }
-        useCase =
-            InstallProfileUseCase(
-                radioController,
-                radioInterfaceService,
-                stalledRepository,
-                nodeRepository,
-                restartTracker,
-            )
+        useCase = useCaseWith(stalledRepository)
 
         val result = async { runCatching { useCase(1234, DeviceProfile(), User(), isLocal = true) } }
         advanceTimeBy(10_001)
@@ -159,22 +152,7 @@ class InstallProfileUseCaseTest {
     fun `profile snapshot is rejected after connection lifecycle rollover`() = runTest(testDispatcher) {
         val snapshotStarted = CompletableDeferred<Unit>()
         val releaseSnapshot = CompletableDeferred<Unit>()
-        val delayedRepository =
-            object : RadioConfigRepository by radioConfigRepository {
-                override val localConfigFlow = flow {
-                    snapshotStarted.complete(Unit)
-                    releaseSnapshot.await()
-                    emit(LocalConfig())
-                }
-            }
-        useCase =
-            InstallProfileUseCase(
-                radioController,
-                radioInterfaceService,
-                delayedRepository,
-                nodeRepository,
-                restartTracker,
-            )
+        useCase = useCaseWith(gatedConfigRepository(snapshotStarted, releaseSnapshot))
 
         val result = async { runCatching { useCase(1234, DeviceProfile(), User(), isLocal = true) } }
         snapshotStarted.await()
@@ -192,22 +170,7 @@ class InstallProfileUseCaseTest {
     fun `profile snapshot is rejected after transport selection changes`() = runTest(testDispatcher) {
         val snapshotStarted = CompletableDeferred<Unit>()
         val releaseSnapshot = CompletableDeferred<Unit>()
-        val delayedRepository =
-            object : RadioConfigRepository by radioConfigRepository {
-                override val localConfigFlow = flow {
-                    snapshotStarted.complete(Unit)
-                    releaseSnapshot.await()
-                    emit(LocalConfig())
-                }
-            }
-        useCase =
-            InstallProfileUseCase(
-                radioController,
-                radioInterfaceService,
-                delayedRepository,
-                nodeRepository,
-                restartTracker,
-            )
+        useCase = useCaseWith(gatedConfigRepository(snapshotStarted, releaseSnapshot))
 
         val result = async { runCatching { useCase(1234, DeviceProfile(), User(), isLocal = true) } }
         snapshotStarted.await()
@@ -786,6 +749,24 @@ class InstallProfileUseCaseTest {
         assertEquals(true, radioController.lastSetOwnerUser?.is_unmessagable)
         assertEquals(false, radioController.lastSetOwnerUser?.is_licensed)
     }
+
+    private fun useCaseWith(repository: RadioConfigRepository) =
+        InstallProfileUseCase(
+            radioController,
+            radioInterfaceService,
+            repository,
+            nodeRepository,
+            restartTracker,
+        )
+
+    private fun gatedConfigRepository(started: CompletableDeferred<Unit>, release: CompletableDeferred<Unit>) =
+        object : RadioConfigRepository by radioConfigRepository {
+            override val localConfigFlow = flow {
+                started.complete(Unit)
+                release.await()
+                emit(LocalConfig())
+            }
+        }
 
     private fun fullProfile(channelUrl: String) = DeviceProfile(
         long_name = "Full Node",

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
@@ -112,6 +113,55 @@ class InstallProfileUseCaseTest {
         useCase(1234, DeviceProfile(), User(), isLocal = true)
 
         assertNoDeviceWrites()
+        assertFalse(restartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `concurrent profile installations are serialized without interleaved writes`() = runTest(testDispatcher) {
+        val firstCommitReached = CompletableDeferred<Unit>()
+        val releaseFirstCommit = CompletableDeferred<Unit>()
+        var commitCount = 0
+        radioController.onEditSettingsCommitted = {
+            commitCount += 1
+            if (commitCount == 1) {
+                firstCommitReached.complete(Unit)
+                releaseFirstCommit.await()
+            }
+            emitRestartCycle()
+        }
+
+        val first = async { useCase(1234, DeviceProfile(long_name = "First"), User(), isLocal = true) }
+        firstCommitReached.await()
+        val second = async { useCase(1234, DeviceProfile(short_name = "Second"), User(), isLocal = true) }
+        testScheduler.runCurrent()
+
+        assertEquals(1, radioController.adminOperations.count { it == "begin" })
+        assertEquals(listOf("begin", "owner", "commit"), radioController.adminOperations)
+
+        releaseFirstCommit.complete(Unit)
+        first.await()
+        second.await()
+
+        assertEquals(2, radioController.adminOperations.count { it == "begin" })
+        assertEquals(
+            listOf("begin", "owner", "commit", "begin", "owner", "commit"),
+            radioController.adminOperations,
+        )
+    }
+
+    @Test
+    fun `cancellation while waiting for restart clears the expected-restart state`() = runTest(testDispatcher) {
+        val departureObserved = CompletableDeferred<Unit>()
+        radioController.onEditSettingsCommitted = {
+            emitDeparture()
+            departureObserved.complete(Unit)
+        }
+        val installation = launch { useCase(1234, DeviceProfile(long_name = "Cancelled"), User(), isLocal = true) }
+
+        departureObserved.await()
+        assertTrue(restartTracker.restartExpected.value)
+        installation.cancelAndJoin()
+
         assertFalse(restartTracker.restartExpected.value)
     }
 
@@ -258,7 +308,7 @@ class InstallProfileUseCaseTest {
 
         assertFalse(radioController.editSettingsCalled)
         assertEquals(listOf("module:update", "config:update"), radioController.adminOperations)
-        assertFalse(restartTracker.restartExpected.value)
+        assertTrue(restartTracker.restartExpected.value)
     }
 
     @Test
@@ -432,7 +482,7 @@ class InstallProfileUseCaseTest {
             radioController.adminOperations,
         )
         assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
-        assertFalse(restartTracker.restartExpected.value)
+        assertTrue(restartTracker.restartExpected.value)
     }
 
     @Test
@@ -462,7 +512,7 @@ class InstallProfileUseCaseTest {
             radioController.adminOperations,
         )
         assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
-        assertFalse(restartTracker.restartExpected.value)
+        assertTrue(restartTracker.restartExpected.value)
     }
 
     @Test
@@ -482,7 +532,7 @@ class InstallProfileUseCaseTest {
         assertEquals(listOf(null, network), radioController.adminConfigs.map { it.network })
         assertEquals(listOf("begin", "config:update", "config:update", "commit"), radioController.adminOperations)
         assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
-        assertFalse(restartTracker.restartExpected.value)
+        assertTrue(restartTracker.restartExpected.value)
     }
 
     @Test
@@ -658,7 +708,7 @@ class InstallProfileUseCaseTest {
 
             assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
             assertEquals(BluetoothConfig(enabled = false), radioController.adminConfigs.last().bluetooth)
-            assertFalse(restartTracker.restartExpected.value)
+            assertTrue(restartTracker.restartExpected.value)
         }
 
     @Test
@@ -685,6 +735,28 @@ class InstallProfileUseCaseTest {
         assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
         assertFalse(restartTracker.restartExpected.value)
     }
+
+    @Test
+    fun `changed explicit profile LoRa is written exactly once when a channel URL is restored`() =
+        runTest(testDispatcher) {
+            val currentLora = LoRaConfig(region = LoRaConfig.RegionCode.EU_868, hop_limit = 3)
+            val profileLora = LoRaConfig(region = LoRaConfig.RegionCode.US, hop_limit = 5)
+            val channelLora = LoRaConfig(region = LoRaConfig.RegionCode.ANZ, hop_limit = 2)
+            val settings = listOf(ChannelSettings(name = "Imported", psk = byteArrayOf(1).toByteString()))
+            val channelUrl = ChannelSet(settings = settings, lora_config = channelLora).getChannelUrl().toString()
+            radioConfigRepository.setLocalConfigDirect(LocalConfig(lora = currentLora))
+            radioController.onEditSettingsCommitted = { emitRestartCycle() }
+
+            useCase(
+                1234,
+                DeviceProfile(config = LocalConfig(lora = profileLora), channel_url = channelUrl),
+                User(),
+                isLocal = true,
+            )
+
+            assertEquals(listOf(profileLora), radioController.adminConfigs.mapNotNull { it.lora })
+            assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
+        }
 
     @Test
     fun `channel URL without profile LoRa restores its channel LoRa config`() = runTest(testDispatcher) {
@@ -751,13 +823,7 @@ class InstallProfileUseCaseTest {
     }
 
     private fun useCaseWith(repository: RadioConfigRepository) =
-        InstallProfileUseCase(
-            radioController,
-            radioInterfaceService,
-            repository,
-            nodeRepository,
-            restartTracker,
-        )
+        InstallProfileUseCase(radioController, radioInterfaceService, repository, nodeRepository, restartTracker)
 
     private fun gatedConfigRepository(started: CompletableDeferred<Unit>, release: CompletableDeferred<Unit>) =
         object : RadioConfigRepository by radioConfigRepository {
@@ -801,6 +867,7 @@ class InstallProfileUseCaseTest {
             radioController.adminOperations.mapIndexedNotNull { index, operation ->
                 index.takeIf { operation.startsWith("module:") }
             }
+        assertEquals(radioController.moduleConfigs.size, moduleOperationIndexes.size)
         val firstTransportSensitiveModuleIndex =
             radioController.moduleConfigs.indexOfFirst { it.mqtt != null || it.serial != null }
         assertTrue(firstTransportSensitiveModuleIndex > 0)

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/InstallProfileUseCaseTest.kt
@@ -379,7 +379,7 @@ class InstallProfileUseCaseTest {
 
         assertEquals(
             listOf(DisplayConfig(compass_north_top = true)),
-            radioController.localConfigs.mapNotNull { it.display },
+            radioController.adminConfigs.mapNotNull { it.display },
         )
         assertEquals(
             listOf(MeshBeaconConfig(broadcast_message = "new beacon"), SerialConfig(enabled = true)),
@@ -462,8 +462,8 @@ class InstallProfileUseCaseTest {
         useCase(1234, profile, User(), isLocal = true)
 
         assertEquals(listOf(mqtt, serial), radioController.moduleConfigs.mapNotNull { it.mqtt ?: it.serial })
-        assertEquals(bluetooth, radioController.localConfigs.first().bluetooth)
-        assertEquals(network, radioController.localConfigs.last().network)
+        assertEquals(bluetooth, radioController.adminConfigs.first().bluetooth)
+        assertEquals(network, radioController.adminConfigs.last().network)
         assertEquals(
             listOf("module:update", "module:update", "begin", "config:update", "config:update", "commit"),
             radioController.adminOperations,
@@ -492,8 +492,8 @@ class InstallProfileUseCaseTest {
         useCase(1234, profile, User(), isLocal = true)
 
         assertEquals(listOf(mqtt, serial), radioController.moduleConfigs.mapNotNull { it.mqtt ?: it.serial })
-        assertEquals(listOf(bluetooth, null), radioController.localConfigs.map { it.bluetooth })
-        assertEquals(listOf(null, network), radioController.localConfigs.map { it.network })
+        assertEquals(listOf(bluetooth, null), radioController.adminConfigs.map { it.bluetooth })
+        assertEquals(listOf(null, network), radioController.adminConfigs.map { it.network })
         assertEquals(
             listOf("module:update", "config:update", "config:update", "module:update"),
             radioController.adminOperations,
@@ -515,8 +515,8 @@ class InstallProfileUseCaseTest {
             isLocal = true,
         )
 
-        assertEquals(listOf(bluetooth, null), radioController.localConfigs.map { it.bluetooth })
-        assertEquals(listOf(null, network), radioController.localConfigs.map { it.network })
+        assertEquals(listOf(bluetooth, null), radioController.adminConfigs.map { it.bluetooth })
+        assertEquals(listOf(null, network), radioController.adminConfigs.map { it.network })
         assertEquals(listOf("begin", "config:update", "config:update", "commit"), radioController.adminOperations)
         assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
         assertFalse(restartTracker.restartExpected.value)
@@ -694,7 +694,7 @@ class InstallProfileUseCaseTest {
             useCase(1234, profile, User(), isLocal = true)
 
             assertEquals(ConnectionState.Disconnected, radioController.connectionState.value)
-            assertEquals(BluetoothConfig(enabled = false), radioController.localConfigs.last().bluetooth)
+            assertEquals(BluetoothConfig(enabled = false), radioController.adminConfigs.last().bluetooth)
             assertFalse(restartTracker.restartExpected.value)
         }
 
@@ -714,7 +714,7 @@ class InstallProfileUseCaseTest {
             isLocal = true,
         )
 
-        assertTrue(radioController.localConfigs.none { it.lora != null })
+        assertTrue(radioController.adminConfigs.none { it.lora != null })
         assertEquals(
             (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(),
             radioController.localChannels.map(Channel::index),
@@ -736,7 +736,7 @@ class InstallProfileUseCaseTest {
 
         useCase(1234, profile, User(), isLocal = true)
 
-        assertEquals(channelLora, radioController.localConfigs.single().lora)
+        assertEquals(channelLora, radioController.adminConfigs.single().lora)
         assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
     }
 
@@ -839,8 +839,8 @@ class InstallProfileUseCaseTest {
                 it.external_notification ?: it.mesh_beacon ?: it.mqtt ?: it.serial
             },
         )
-        assertEquals(BluetoothConfig(enabled = true), radioController.localConfigs.mapNotNull { it.bluetooth }.last())
-        assertEquals(NetworkConfig(), radioController.localConfigs.mapNotNull { it.network }.last())
+        assertEquals(BluetoothConfig(enabled = true), radioController.adminConfigs.mapNotNull { it.bluetooth }.last())
+        assertEquals(NetworkConfig(), radioController.adminConfigs.mapNotNull { it.network }.last())
         assertEquals(1e-7, radioController.fixedPositions.single().latitude, absoluteTolerance = 1e-12)
         assertEquals(2e-7, radioController.fixedPositions.single().longitude, absoluteTolerance = 1e-12)
         assertEquals(

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/ModuleConfigFieldsTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/ModuleConfigFieldsTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.domain.usecase.settings
+
+import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.ModuleConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ModuleConfigFieldsTest {
+    @Test
+    fun `ordinary writes exclude transport sensitive arms`() {
+        val config =
+            LocalModuleConfig(
+                mqtt = ModuleConfig.MQTTConfig(enabled = true),
+                serial = ModuleConfig.SerialConfig(enabled = true),
+                telemetry = ModuleConfig.TelemetryConfig(device_update_interval = 30),
+            )
+
+        assertEquals(listOf(ModuleConfig(telemetry = config.telemetry)), config.moduleConfigs())
+        assertEquals(3, config.moduleConfigs(includeTransportSensitive = true).size)
+    }
+
+    @Test
+    fun `unchanged filtering and cache updates use the same arm registry`() {
+        val current = LocalModuleConfig(telemetry = ModuleConfig.TelemetryConfig(device_update_interval = 30))
+        val updated =
+            LocalModuleConfig(
+                telemetry = current.telemetry,
+                neighbor_info = ModuleConfig.NeighborInfoConfig(enabled = true),
+            )
+
+        val changed = updated.withoutUnchangedModuleFields(current)
+
+        assertEquals(updated.neighbor_info, changed?.neighbor_info)
+        assertNull(changed?.telemetry)
+        assertEquals(updated, current.updatedWithModuleConfig(ModuleConfig(neighbor_info = updated.neighbor_info)))
+    }
+}

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
@@ -29,12 +29,20 @@ import kotlin.test.assertTrue
  * attempt anonymised the hand-written log statements in `core/ble` and missed the Kable `identifier`, which stamps the
  * address onto *every* line the BLE library emits, plus further sites in the DFU transports and WiFi provisioning.
  *
- * Scoped to the BLE-adjacent modules so matching on the `address` suffix stays low-noise.
+ * Scoped to BLE-adjacent modules and the two address-bearing transport/history sources so matching on the `address`
+ * suffix stays low-noise.
  */
 class BleAddressLoggingTest {
 
     private val scannedPathFragments =
-        listOf("/core/ble/", "/feature/firmware/", "/feature/wifi-provision/", "/feature/connections/")
+        listOf(
+            "/core/ble/",
+            "/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/HistoryManagerImpl.kt",
+            "/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt",
+            "/feature/firmware/",
+            "/feature/wifi-provision/",
+            "/feature/connections/",
+        )
 
     /**
      * Files where an address is used as an identity rather than as diagnostic text — building the connection string or
@@ -42,8 +50,11 @@ class BleAddressLoggingTest {
      */
     private val identityUseAllowlist = listOf("DeviceListEntry.kt")
 
-    /** Interpolation of anything ending in `address`, e.g. `${device.address}` or `$address`. */
-    private val interpolatedAddress = Regex("""\$\{?[A-Za-z0-9_.]*[aA]ddress}?""")
+    /** Kotlin identifiers inside a braced interpolation. */
+    private val interpolationIdentifier = Regex("""\b[A-Za-z_][A-Za-z0-9_]*\b""")
+
+    /** Identifiers whose values are already anonymized before interpolation. */
+    private val safeAddressIdentifiers = setOf("logAddress", "anonymizedAddress")
 
     /**
      * Files this rule covers.
@@ -68,27 +79,205 @@ class BleAddressLoggingTest {
             paths.any { it.endsWith("KableBleConnection.kt") },
             "expected core/ble sources in scope; got ${paths.size} files, e.g. ${paths.take(3)}",
         )
+        assertTrue(paths.any { it.endsWith("BleRadioTransport.kt") }, "BLE transport logging escaped the scan")
+        assertTrue(paths.any { it.endsWith("HistoryManagerImpl.kt") }, "history logging escaped the scan")
     }
 
     @Test
     fun `a BLE address is never interpolated into log or exception text without anonymize`() {
         val offenders =
             scannedFiles().flatMap { file ->
-                file.text.lines().withIndex().mapNotNull { (index, line) ->
-                    val isDiagnostic = "Logger." in line || "throw " in line || "check(" in line || "require(" in line
-                    val interpolates = interpolatedAddress.containsMatchIn(line)
-                    val anonymised = "anonymize" in line
-                    if (isDiagnostic && interpolates && !anonymised) {
-                        "${file.path.substringAfterLast("/kotlin/")}:${index + 1}: ${line.trim()}"
-                    } else {
-                        null
-                    }
-                }
+                rawAddressDiagnosticOffenders(file.path.substringAfterLast("/kotlin/"), file.text)
             }
 
         assertTrue(
             offenders.isEmpty(),
             "BLE addresses must be anonymised in diagnostic text. Offending lines:\n" + offenders.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun `an anonymized prefix cannot hide a raw address on the same diagnostic line`() {
+        val sources =
+            listOf(
+                """Logger.w { "${'$'}logAddress failed for ${'$'}address" }""",
+                """Logger.w { "${'$'}{address.anonymize()} failed for ${'$'}address" }""",
+            )
+
+        sources.forEach { source ->
+            val offenders = rawAddressDiagnosticOffenders("MixedAddressFixture.kt", source)
+
+            assertTrue(
+                offenders.isNotEmpty(),
+                "the privacy guard must reject mixed anonymized and raw address tokens: $source",
+            )
+        }
+    }
+
+    @Test
+    fun `a raw address on a diagnostic continuation line is rejected`() {
+        val source =
+            """
+            Logger.w {
+                "connection failed for " +
+                    "${'$'}address"
+            }
+            """
+                .trimIndent()
+
+        val offenders = rawAddressDiagnosticOffenders("ContinuationFixture.kt", source)
+
+        assertTrue(offenders.isNotEmpty(), "the privacy guard must scan the complete multi-line diagnostic")
+    }
+
+    @Test
+    fun `explicitly anonymized address expressions remain valid diagnostics`() {
+        val sources =
+            listOf(
+                """Logger.i { "Targets: ${'$'}{targetAddresses.map { it.anonymize() }}" }""",
+                """Logger.i { "Bonding ${'$'}{entry.device.address.anonymize}" }""",
+                """Logger.i { "${'$'}logAddress connected" }""",
+            )
+
+        sources.forEach { source ->
+            assertTrue(
+                rawAddressDiagnosticOffenders("AnonymizedAddressFixture.kt", source).isEmpty(),
+                "the privacy guard rejected an explicitly anonymized expression: $source",
+            )
+        }
+    }
+
+    private val diagnosticMarkers = listOf("Logger.", "logger.", "historyLog(", "addr=", "throw ", "check(", "require(")
+
+    private fun rawAddressDiagnosticOffenders(path: String, source: String): List<String> {
+        val lines = source.lines()
+        val offenders = mutableListOf<String>()
+        var index = 0
+        while (index < lines.size) {
+            val line = lines[index]
+            if (diagnosticMarkers.any { it in line }) {
+                val block = collectDiagnosticBlock(lines, index)
+                if (containsRawAddressInterpolation(block.joinToString("\n"))) {
+                    offenders += "$path:${index + 1}: ${line.trim()}"
+                }
+                index += block.size
+            } else {
+                index += 1
+            }
+        }
+        return offenders
+    }
+
+    /** Collects one multi-line diagnostic expression, including Logger lambdas and parenthesized calls. */
+    private fun collectDiagnosticBlock(lines: List<String>, start: Int): List<String> {
+        val block = mutableListOf<String>()
+        var delimiterDepth = 0
+        var cursor = start
+        do {
+            val line = lines[cursor]
+            block += line
+            delimiterDepth += delimiterDelta(line)
+            cursor += 1
+        } while (cursor < lines.size && (delimiterDepth > 0 || block.last().trimEnd().endsWith("+")))
+        return block
+    }
+
+    private fun delimiterDelta(line: String): Int =
+        line.count { it == '(' || it == '[' || it == '{' } - line.count { it == ')' || it == ']' || it == '}' }
+
+    /**
+     * Returns true when a string-template interpolation contains more address references than explicit anonymization
+     * operations. Braced expressions are scanned with balanced braces so collection expressions with lambdas remain
+     * intact, while a mixed expression such as `${address.anonymize()} / $address` still exposes the second reference.
+     */
+    private fun containsRawAddressInterpolation(line: String): Boolean {
+        var cursor = 0
+        var rawAddressFound = false
+        while (cursor < line.length && !rawAddressFound) {
+            val dollar = line.indexOf('$', startIndex = cursor)
+            if (dollar < 0 || dollar + 1 >= line.length) {
+                cursor = line.length
+            } else if (line[dollar + 1] == '{') {
+                val end = findInterpolationEnd(line, expressionStart = dollar + 2)
+                if (end < 0) {
+                    rawAddressFound = true
+                } else {
+                    val expression = line.substring(dollar + 2, end)
+                    val residual =
+                        safeAddressIdentifiers.fold(expression) { current, identifier ->
+                            current.replace(Regex("""\b$identifier\b"""), "")
+                        }
+                    val addressReferences =
+                        interpolationIdentifier.findAll(residual).count { match ->
+                            match.value.endsWith("address", ignoreCase = true) ||
+                                match.value.endsWith("addresses", ignoreCase = true)
+                        }
+                    val anonymizations = Regex("""\banonymize\b""").findAll(residual).count()
+                    rawAddressFound = addressReferences > anonymizations
+                    cursor = end + 1
+                }
+            } else {
+                val identifier = line.substring(dollar + 1).takeWhile { it == '_' || it.isLetterOrDigit() }
+                val safe = identifier in safeAddressIdentifiers
+                val addressLike =
+                    identifier.endsWith("address", ignoreCase = true) ||
+                        identifier.endsWith("addresses", ignoreCase = true)
+                rawAddressFound = identifier.isNotEmpty() && addressLike && !safe
+                cursor = dollar + 1 + identifier.length
+            }
+        }
+        return rawAddressFound
+    }
+
+    private fun findInterpolationEnd(line: String, expressionStart: Int): Int {
+        var depth = 1
+        for (index in expressionStart until line.length) {
+            when (line[index]) {
+                '{' -> depth += 1
+
+                '}' -> {
+                    depth -= 1
+                    if (depth == 0) return index
+                }
+            }
+        }
+        return -1
+    }
+
+    @Test
+    fun `privacy-sensitive BLE diagnostics never forward arbitrary throwable text`() {
+        val throwableLoggerCall = Regex("""(?:Logger|logger)\.[vdiwe]\s*\(""")
+        val protectedFiles = setOf("BleRadioTransport.kt", "HistoryManagerImpl.kt")
+        val offenders =
+            scannedFiles()
+                .filter { file -> protectedFiles.any { file.path.endsWith(it) } }
+                .flatMap { file ->
+                    file.text.lines().withIndex().mapNotNull { (index, line) ->
+                        line.takeIf(throwableLoggerCall::containsMatchIn)?.let {
+                            "${file.path.substringAfterLast("/kotlin/")}:${index + 1}: ${line.trim()}"
+                        }
+                    }
+                }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "BLE diagnostics must log curated failure types, not throwable messages. Offending lines:\n" +
+                offenders.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun `BLE transport diagnostic identifiers are derived from the anonymized address`() {
+        val source =
+            scannedFiles().single { it.path.endsWith("BleRadioTransport.kt") }.text.replace(Regex("""\s+"""), " ")
+
+        assertTrue(
+            Regex("""val\s+anonymizedAddress\s*=\s*address\.anonymize\(\)""").containsMatchIn(source),
+            "BLE transport must derive its diagnostic identifier through anonymize()",
+        )
+        assertTrue(
+            Regex("""val\s+logAddress\s*=\s*"\[\$\{?anonymizedAddress}?]"""").containsMatchIn(source),
+            "BLE transport log prefix must use only the anonymized identifier",
         )
     }
 

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/KablePlatformLoggingTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/KablePlatformLoggingTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class KablePlatformLoggingTest {
+    @Test
+    fun `Kable platform diagnostics never forward arbitrary throwable text`() {
+        val matches =
+            Konsist.scopeFromProject().files.filter {
+                "/androidMain/" in it.path && it.path.endsWith("KablePlatformSetup.kt")
+            }
+        assertTrue(
+            matches.size == 1,
+            "expected exactly one androidMain KablePlatformSetup.kt in scope; found ${matches.map { it.path }}",
+        )
+        val source = matches.single().text
+        val throwableLoggerCall = Regex("""(?:Logger|logger)\.[vdiwe]\s*\(""")
+        val offenders =
+            source.lines().withIndex().mapNotNull { (index, line) ->
+                line.takeIf(throwableLoggerCall::containsMatchIn)?.let {
+                    "KablePlatformSetup.kt:${index + 1}: ${line.trim()}"
+                }
+            }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "Kable platform diagnostics must log curated failure types, not throwable messages. Offending lines:\n" +
+                offenders.joinToString("\n"),
+        )
+    }
+}

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
@@ -83,6 +83,9 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
      */
     val supportsLoraRegionPresetMap = atLeast(V2_8_0)
 
+    /** Whether the connected firmware uses the 2.8 LoRa defaults, independent of debug feature overrides. */
+    val usesV28LoraDefaults = version != null && version >= V2_8_0
+
     /**
      * Support for runtime lockdown mode (per-connection passphrase auth). Supported since firmware v2.8.0. Note:
      * lockdown is also hardware-gated (nRF52 only) — the device advertises real support by sending a `LockdownStatus`,

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ConnectionState.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ConnectionState.kt
@@ -29,3 +29,49 @@ sealed interface ConnectionState {
     /** The device is in a light sleep state, and we are waiting for it to wake up and reconnect to us. */
     data object DeviceSleep : ConnectionState
 }
+
+/**
+ * One atomically published view of canonical connection state and its lifecycle evidence.
+ *
+ * Consumers that need to correlate a state with departure or handshake counters must observe this snapshot instead of
+ * reading [ConnectionState] and [ConnectionEpochs] flows independently.
+ */
+data class ConnectionLifecycle(
+    val version: Long = 0,
+    val state: ConnectionState = ConnectionState.Disconnected,
+    val epochs: ConnectionEpochs = ConnectionEpochs(),
+)
+
+/**
+ * Monotonic counters for connection lifecycle events that cannot be inferred reliably from transient [ConnectionState]
+ * values. A fast disconnect/reconnect may be observed only as the final state, while these counters retain both
+ * lifecycle boundaries.
+ *
+ * @property departures Number of transitions away from [ConnectionState.Connected].
+ * @property completedHandshakes Number of transitions into [ConnectionState.Connected].
+ * @property handshakesAtLastDeparture Completed-handshake count captured at the most recent departure. This preserves
+ *   event ordering when a fast departure/reconnect pair is conflated into one observed state-flow value.
+ * @property lastDepartureState State entered by the most recent departure. Consumers that react after a fast reconnect
+ *   can use this event evidence instead of rereading the already-advanced live connection state.
+ */
+data class ConnectionEpochs(
+    val departures: Long = 0,
+    val completedHandshakes: Long = 0,
+    val handshakesAtLastDeparture: Long = 0,
+    val lastDepartureState: ConnectionState? = null,
+) {
+    /** Returns the counters after applying one canonical connection-state transition. */
+    fun advance(previous: ConnectionState, current: ConnectionState): ConnectionEpochs = when {
+        previous is ConnectionState.Connected && current !is ConnectionState.Connected ->
+            copy(
+                departures = departures + 1,
+                handshakesAtLastDeparture = completedHandshakes,
+                lastDepartureState = current,
+            )
+
+        previous !is ConnectionState.Connected && current is ConnectionState.Connected ->
+            copy(completedHandshakes = completedHandshakes + 1)
+
+        else -> this
+    }
+}

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
@@ -76,13 +76,23 @@ fun LoRaRegionPresetMap?.repairPresetFor(region: RegionCode, current: ModemPrese
 
 /**
  * The app's built-in default modem presets for regions whose default differs from the global [ChannelOption.DEFAULT].
- * Mirrors the per-region defaults newer firmware advertises in [LoRaRegionPresetMap], so the default channel and a
- * fresh setup over old firmware (which sends no map) land on the same preset a new node would.
+ * Mirrors the per-region defaults firmware 2.8 and later advertises in [LoRaRegionPresetMap]. Older firmware retains
+ * the global [ChannelOption.DEFAULT] instead.
  */
 private val REGION_DEFAULT_PRESETS = mapOf(RegionCode.US to ModemPreset.LONG_TURBO)
 
 /**
- * The app's preferred default preset for [region], or `null` when it has no region-specific default and the caller
- * should fall back to [ChannelOption.DEFAULT] / the current preset.
+ * The app's preferred 2.8 default preset for [region], or `null` when the target firmware predates 2.8 or there is no
+ * region-specific default.
  */
-fun defaultPresetFor(region: RegionCode): ModemPreset? = REGION_DEFAULT_PRESETS[region]
+fun defaultPresetFor(region: RegionCode, capabilities: Capabilities): ModemPreset? =
+    REGION_DEFAULT_PRESETS[region].takeIf { capabilities.usesV28LoraDefaults }
+
+/** Selects the recommended preset when a previously-unset LoRa region is configured for the first time. */
+fun LoRaRegionPresetMap?.presetForFreshRegion(region: RegionCode, capabilities: Capabilities): ModemPreset {
+    val constraint = constraintFor(region)
+    if (constraint != null) {
+        return constraint.defaultPreset.takeIf { it in constraint.presets } ?: constraint.presets.first()
+    }
+    return defaultPresetFor(region, capabilities) ?: ChannelOption.DEFAULT.modemPreset
+}

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelReplacement.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelReplacement.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model.util
+
+import okio.ByteString
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.core.model.Channel as ModelChannel
+
+/** Firmware channel files expose one primary plus seven secondary slots. */
+const val CHANNEL_REPLACEMENT_SLOT_COUNT = 8
+
+/** One authoritative channel replacement, reduced to only writes that would change device state. */
+data class ChannelReplacementPlan(
+    val writes: List<Channel>,
+    val normalizedSettings: List<ChannelSettings>,
+    val loraConfig: Config.LoRaConfig?,
+) {
+    val hasInstallableWrites: Boolean
+        get() = writes.isNotEmpty() || loraConfig != null
+}
+
+/**
+ * Plans the shared REPLACE behavior used by QR imports and device-profile restores.
+ *
+ * [explicitLoraConfig] is the profile-level LoRa config when one exists. It controls semantic channel identity and
+ * suppresses the channel URL's LoRa write because the profile config is installed by its normal config path. Channel
+ * slots remain authoritative when they differ. A no-op is safe only when all eight active slots are observable and
+ * byte-identical: the local cache intentionally omits disabled slots, so a shorter matching list cannot prove that
+ * hidden trailing slots are already canonical.
+ */
+fun planChannelReplacement(
+    channelSet: ChannelSet,
+    currentSettings: List<ChannelSettings>,
+    currentLoraConfig: Config.LoRaConfig?,
+    explicitLoraConfig: Config.LoRaConfig? = null,
+): ChannelReplacementPlan {
+    require(channelSet.settings.isNotEmpty()) { "Imported channel set must contain at least one channel" }
+    val identityLoraConfig = explicitLoraConfig ?: channelSet.lora_config ?: currentLoraConfig
+    val normalizedSettings = normalizeReplacementSettings(channelSet.settings, identityLoraConfig)
+    require(normalizedSettings.size <= CHANNEL_REPLACEMENT_SLOT_COUNT) {
+        "Imported channel set exceeds supported channel slot count"
+    }
+    val allSlotsAreObservableAndEqual =
+        normalizedSettings.size == CHANNEL_REPLACEMENT_SLOT_COUNT && normalizedSettings == currentSettings
+    val writes =
+        if (allSlotsAreObservableAndEqual) {
+            emptyList()
+        } else {
+            getChannelReplacementList(
+                new = normalizedSettings,
+                minimumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
+                maximumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
+            )
+        }
+    val loraConfig = channelSet.lora_config?.takeIf { explicitLoraConfig == null && it != currentLoraConfig }
+    return ChannelReplacementPlan(writes = writes, normalizedSettings = normalizedSettings, loraConfig = loraConfig)
+}
+
+/**
+ * Builds the authoritative channel writes needed to replace a radio's complete channel set.
+ *
+ * Every imported slot is written, and any remaining firmware slots are explicitly disabled so stale channels cannot
+ * survive a restore. A blank primary means the firmware's default primary; blank secondary entries are disabled. Values
+ * in [currentSettings] are intentionally ignored; only its size contributes to the number of trailing slots that must
+ * be cleared. Inputs larger than [maximumSlotCount] are rejected rather than silently truncated.
+ */
+fun getChannelReplacementList(
+    new: List<ChannelSettings>,
+    currentSettings: List<ChannelSettings> = emptyList(),
+    minimumSlotCount: Int = 0,
+    maximumSlotCount: Int = Int.MAX_VALUE,
+): List<Channel> = buildList {
+    require(minimumSlotCount <= maximumSlotCount) { "minimumSlotCount must be <= maximumSlotCount" }
+    require(new.size <= maximumSlotCount.coerceAtLeast(0)) {
+        "new.size (${new.size}) exceeds maximumSlotCount ($maximumSlotCount)"
+    }
+    val minimumLastIndex = minimumSlotCount.coerceAtLeast(0) - 1
+    val maximumLastIndex = maximumSlotCount.coerceAtLeast(0) - 1
+    val endIndex = maxOf(currentSettings.lastIndex, new.lastIndex, minimumLastIndex).coerceAtMost(maximumLastIndex)
+    if (endIndex < 0) return@buildList
+
+    for (index in 0..endIndex) {
+        val settings = new.getOrNull(index)?.takeUnless { it.isPlaceholder() }
+        add(
+            Channel(
+                role =
+                when {
+                    index == 0 -> Channel.Role.PRIMARY
+                    settings == null -> Channel.Role.DISABLED
+                    else -> Channel.Role.SECONDARY
+                },
+                index = index,
+                settings = settings ?: ChannelSettings(),
+            ),
+        )
+    }
+}
+
+/**
+ * Removes blank secondary placeholders and semantic duplicates from an authoritative channel replacement.
+ *
+ * The primary slot is always retained. Secondary channels are compared using their effective name and expanded PSK
+ * under [loraConfig], matching the identity used by firmware.
+ */
+fun normalizeReplacementSettings(
+    settings: List<ChannelSettings>,
+    loraConfig: Config.LoRaConfig?,
+): List<ChannelSettings> = buildList {
+    if (settings.isNotEmpty()) {
+        val effectiveLora = loraConfig ?: Config.LoRaConfig()
+        val primary = settings.first().takeUnless { it.isPlaceholder() } ?: ChannelSettings()
+        val seen = mutableSetOf<ChannelIdentity>()
+        if (!primary.isPlaceholder()) seen.add(primary.channelIdentity(effectiveLora))
+
+        add(primary)
+        for (index in 1..settings.lastIndex) {
+            val candidate = settings[index]
+            val identity = candidate.takeUnless { it.isPlaceholder() }?.channelIdentity(effectiveLora)
+            if (identity != null && seen.add(identity)) add(candidate)
+        }
+    }
+}
+
+/**
+ * Returns incoming channels that are neither blank placeholders nor semantic duplicates of existing or earlier entries.
+ *
+ * Blank existing slots are ignored when seeding identities so a disabled slot cannot suppress a real incoming channel.
+ * Identity uses each channel's effective name and expanded PSK under [loraConfig], matching firmware behavior.
+ */
+fun getUniqueChannelAdditions(
+    existing: List<ChannelSettings>,
+    incoming: List<ChannelSettings>,
+    loraConfig: Config.LoRaConfig,
+): List<ChannelSettings> {
+    val seen = existing.filterNot { it.isPlaceholder() }.map { it.channelIdentity(loraConfig) }.toMutableSet()
+    return incoming.filter { candidate ->
+        !candidate.isPlaceholder() && seen.add(candidate.channelIdentity(loraConfig))
+    }
+}
+
+private fun ChannelSettings.isPlaceholder(): Boolean = name.isNullOrBlank() && psk.size == 0
+
+private data class ChannelIdentity(val name: String, val psk: ByteString) {
+    override fun toString(): String = "ChannelIdentity(name=$name, psk=<redacted>)"
+}
+
+private fun ChannelSettings.channelIdentity(loraConfig: Config.LoRaConfig): ChannelIdentity {
+    val channel = ModelChannel(settings = this, loraConfig = loraConfig)
+    return ChannelIdentity(name = channel.name, psk = channel.psk)
+}

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
@@ -108,6 +108,14 @@ class CapabilitiesTest {
     }
 
     @Test
+    fun usesV28LoraDefaults_ignores_debug_capability_override() {
+        val capabilities = Capabilities(firmwareVersion = "2.7.21", forceEnableAll = true)
+
+        assertFalse(capabilities.usesV28LoraDefaults)
+        assertTrue(capabilities.supportsLoraRegionPresetMap)
+    }
+
+    @Test
     fun forceEnableAll_returns_true_regardless_of_version() {
         val c = Capabilities(firmwareVersion = null, forceEnableAll = true)
         assertTrue(c.canMuteNode)

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
@@ -173,8 +173,9 @@ class LoRaRegionPresetsTest {
     fun `fresh US region keeps LongFast on 2_7 and recommends LongTurbo on 2_8`() {
         val firmware27 = Capabilities("2.7.19", forceEnableAll = false)
         val firmware28 = Capabilities("2.8.0", forceEnableAll = false)
+        val unconstrained: LoRaRegionPresetMap? = null
 
-        assertEquals(ModemPreset.LONG_FAST, null.presetForFreshRegion(RegionCode.US, firmware27))
-        assertEquals(ModemPreset.LONG_TURBO, null.presetForFreshRegion(RegionCode.US, firmware28))
+        assertEquals(ModemPreset.LONG_FAST, unconstrained.presetForFreshRegion(RegionCode.US, firmware27))
+        assertEquals(ModemPreset.LONG_TURBO, unconstrained.presetForFreshRegion(RegionCode.US, firmware28))
     }
 }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
@@ -140,8 +140,41 @@ class LoRaRegionPresetsTest {
     }
 
     @Test
-    fun `region default preset is LongTurbo for US and absent for other regions`() {
-        assertEquals(ModemPreset.LONG_TURBO, defaultPresetFor(RegionCode.US))
-        assertNull(defaultPresetFor(RegionCode.EU_868))
+    fun `fresh region falls back to the first legal preset when advertised default is malformed`() {
+        val malformedMap =
+            LoRaRegionPresetMap(
+                groups =
+                listOf(
+                    LoRaPresetGroup(
+                        presets = listOf(ModemPreset.MEDIUM_FAST, ModemPreset.MEDIUM_SLOW),
+                        default_preset = ModemPreset.LONG_FAST,
+                    ),
+                ),
+                region_groups = listOf(LoRaRegionPresets(region = RegionCode.US, group_index = 0)),
+            )
+
+        assertEquals(
+            ModemPreset.MEDIUM_FAST,
+            malformedMap.presetForFreshRegion(RegionCode.US, Capabilities("2.8.0", forceEnableAll = false)),
+        )
+    }
+
+    @Test
+    fun `region default preset changes with the target firmware generation`() {
+        val firmware27 = Capabilities("2.7.19", forceEnableAll = false)
+        val firmware28 = Capabilities("2.8.0", forceEnableAll = false)
+
+        assertNull(defaultPresetFor(RegionCode.US, firmware27))
+        assertEquals(ModemPreset.LONG_TURBO, defaultPresetFor(RegionCode.US, firmware28))
+        assertNull(defaultPresetFor(RegionCode.EU_868, firmware28))
+    }
+
+    @Test
+    fun `fresh US region keeps LongFast on 2_7 and recommends LongTurbo on 2_8`() {
+        val firmware27 = Capabilities("2.7.19", forceEnableAll = false)
+        val firmware28 = Capabilities("2.8.0", forceEnableAll = false)
+
+        assertEquals(ModemPreset.LONG_FAST, null.presetForFreshRegion(RegionCode.US, firmware27))
+        assertEquals(ModemPreset.LONG_TURBO, null.presetForFreshRegion(RegionCode.US, firmware28))
     }
 }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelReplacementTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelReplacementTest.kt
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model.util
+
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.meshtastic.core.model.Channel as ModelChannel
+
+class ChannelReplacementTest {
+
+    @Test
+    fun `shared plan rejects an empty channel set`() {
+        assertFailsWith<IllegalArgumentException> {
+            planChannelReplacement(channelSet = ChannelSet(), currentSettings = emptyList(), currentLoraConfig = null)
+        }
+    }
+
+    @Test
+    fun `shared plan rejects normalized settings beyond the supported slot count`() {
+        val oversized =
+            (0..CHANNEL_REPLACEMENT_SLOT_COUNT).map { index ->
+                ChannelSettings(name = "Channel $index", psk = byteArrayOf(index.toByte(), 1).toByteString())
+            }
+
+        assertFailsWith<IllegalArgumentException> {
+            planChannelReplacement(
+                channelSet = ChannelSet(settings = oversized),
+                currentSettings = emptyList(),
+                currentLoraConfig = null,
+            )
+        }
+    }
+
+    @Test
+    fun `shared plan skips a byte-identical channel set`() {
+        val settings = (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).map { ChannelSettings(name = "Channel $it") }
+
+        val plan =
+            planChannelReplacement(
+                channelSet = ChannelSet(settings = settings),
+                currentSettings = settings,
+                currentLoraConfig = Config.LoRaConfig(),
+            )
+
+        assertTrue(plan.writes.isEmpty())
+        assertFalse(plan.hasInstallableWrites)
+        assertEquals(settings, plan.normalizedSettings)
+    }
+
+    @Test
+    fun `shared plan rewrites a matching partial set to clear unobserved slots`() {
+        val settings = listOf(ChannelSettings(name = "Primary"), ChannelSettings(name = "Private"))
+
+        val plan =
+            planChannelReplacement(
+                channelSet = ChannelSet(settings = settings),
+                currentSettings = settings,
+                currentLoraConfig = null,
+            )
+
+        assertEquals(CHANNEL_REPLACEMENT_SLOT_COUNT, plan.writes.size)
+        assertTrue(plan.hasInstallableWrites)
+    }
+
+    @Test
+    fun `shared plan keeps authoritative writes when any current slot differs`() {
+        val imported = listOf(ChannelSettings(name = "Primary"))
+
+        val plan =
+            planChannelReplacement(
+                channelSet = ChannelSet(settings = imported),
+                currentSettings = listOf(ChannelSettings(name = "Old")),
+                currentLoraConfig = null,
+            )
+
+        assertEquals(CHANNEL_REPLACEMENT_SLOT_COUNT, plan.writes.size)
+        assertTrue(plan.hasInstallableWrites)
+    }
+
+    @Test
+    fun `explicit profile LoRa suppresses the channel URL LoRa write`() {
+        val currentLora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.US)
+        val channelLora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.EU_868)
+        val settings = (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).map { ChannelSettings(name = "Channel $it") }
+
+        val plan =
+            planChannelReplacement(
+                channelSet = ChannelSet(settings = settings, lora_config = channelLora),
+                currentSettings = settings,
+                currentLoraConfig = currentLora,
+                explicitLoraConfig = currentLora,
+            )
+
+        assertEquals(null, plan.loraConfig)
+        assertFalse(plan.hasInstallableWrites)
+    }
+
+    @Test
+    fun `replacement rejects imported channels beyond the maximum slot count`() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                getChannelReplacementList(
+                    new = List(3) { index -> ChannelSettings(name = "Channel $index") },
+                    currentSettings = emptyList(),
+                    maximumSlotCount = 2,
+                )
+            }
+
+        assertEquals("new.size (3) exceeds maximumSlotCount (2)", error.message)
+    }
+
+    @Test
+    fun `replacement accepts an imported set exactly at the maximum slot count`() {
+        val imported = List(2) { index -> ChannelSettings(name = "Channel $index") }
+
+        val replacement =
+            getChannelReplacementList(new = imported, currentSettings = emptyList(), maximumSlotCount = imported.size)
+
+        assertEquals(listOf(Channel.Role.PRIMARY, Channel.Role.SECONDARY), replacement.map { it.role })
+        assertEquals(imported, replacement.map { it.settings })
+    }
+
+    @Test
+    fun `zero maximum slot count accepts only an empty replacement`() {
+        assertEquals(
+            emptyList(),
+            getChannelReplacementList(new = emptyList(), currentSettings = emptyList(), maximumSlotCount = 0),
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            getChannelReplacementList(
+                new = listOf(ChannelSettings(name = "Primary")),
+                currentSettings = emptyList(),
+                maximumSlotCount = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `blank primary is emitted as the firmware default primary`() {
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(ChannelSettings()),
+                currentSettings = listOf(ChannelSettings(name = "Old primary")),
+            )
+
+        assertEquals(Channel.Role.PRIMARY, replacement.single().role)
+        assertEquals(ChannelSettings(), replacement.single().settings)
+    }
+
+    @Test
+    fun `blank imported secondary is emitted as a disabled slot`() {
+        val primary = ChannelSettings(name = "Primary")
+
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(primary, ChannelSettings()),
+                currentSettings = listOf(primary, ChannelSettings(name = "Old secondary")),
+            )
+
+        assertEquals(Channel.Role.PRIMARY, replacement[0].role)
+        assertEquals(Channel.Role.DISABLED, replacement[1].role)
+        assertEquals(ChannelSettings(), replacement[1].settings)
+    }
+
+    @Test
+    fun `dirty default-primary placeholders are canonicalized for firmware and cache`() {
+        val dirtyPlaceholder = ChannelSettings(uplink_enabled = true, downlink_enabled = true)
+
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(dirtyPlaceholder),
+                currentSettings = listOf(ChannelSettings(name = "Old primary")),
+            )
+        val normalized = normalizeReplacementSettings(listOf(dirtyPlaceholder), loraConfig = null)
+
+        assertEquals(Channel.Role.PRIMARY, replacement.single().role)
+        assertEquals(ChannelSettings(), replacement.single().settings)
+        assertEquals(listOf(ChannelSettings()), normalized)
+    }
+
+    @Test
+    fun `blank existing slot does not suppress a meaningful incoming channel`() {
+        val incoming = ChannelSettings(name = "LongFast")
+
+        val additions =
+            getUniqueChannelAdditions(
+                existing = listOf(ChannelSettings()),
+                incoming = listOf(incoming),
+                loraConfig = ModelChannel.default.loraConfig,
+            )
+
+        assertEquals(listOf(incoming), additions)
+    }
+
+    @Test
+    fun `replacement disables stale trailing slots`() {
+        val primary = ChannelSettings(name = "Primary")
+
+        val replacement =
+            getChannelReplacementList(
+                new = listOf(primary),
+                currentSettings = listOf(primary, ChannelSettings(name = "Old")),
+            )
+
+        assertEquals(listOf(Channel.Role.PRIMARY, Channel.Role.DISABLED), replacement.map(Channel::role))
+        assertEquals(ChannelSettings(), replacement.last().settings)
+    }
+
+    @Test
+    fun `empty authoritative set restores a default primary and disables trailing slots`() {
+        val replacement =
+            getChannelReplacementList(
+                new = emptyList(),
+                currentSettings = listOf(ChannelSettings(name = "Old primary"), ChannelSettings(name = "Old chat")),
+            )
+
+        assertEquals(listOf(Channel.Role.PRIMARY, Channel.Role.DISABLED), replacement.map(Channel::role))
+        assertEquals(listOf(ChannelSettings(), ChannelSettings()), replacement.map(Channel::settings))
+    }
+
+    @Test
+    fun `replacement rejects an invalid slot range`() {
+        assertFailsWith<IllegalArgumentException> {
+            getChannelReplacementList(
+                new = listOf(ChannelSettings(name = "Primary")),
+                currentSettings = emptyList(),
+                minimumSlotCount = 2,
+                maximumSlotCount = 1,
+            )
+        }
+    }
+
+    @Test
+    fun `normalization removes blank and duplicate secondaries while retaining primary`() {
+        val primary = ChannelSettings(name = "Primary", psk = byteArrayOf(1).toByteString())
+        val secondary = ChannelSettings(name = "Secondary", psk = byteArrayOf(2).toByteString())
+
+        val normalized =
+            normalizeReplacementSettings(
+                listOf(primary, ChannelSettings(), primary, secondary),
+                ModelChannel.default.loraConfig,
+            )
+
+        assertEquals(listOf(primary, secondary), normalized)
+    }
+
+    @Test
+    fun `normalization preserves a blank default primary without suppressing a public secondary`() {
+        val blankPrimary = ChannelSettings()
+        val publicSecondary = ChannelSettings(psk = byteArrayOf(1).toByteString())
+
+        val normalized =
+            normalizeReplacementSettings(listOf(blankPrimary, publicSecondary), ModelChannel.default.loraConfig)
+
+        assertEquals(listOf(blankPrimary, publicSecondary), normalized)
+    }
+
+    @Test
+    fun `normalization handles empty input and a missing LoRa config`() {
+        assertEquals(emptyList(), normalizeReplacementSettings(emptyList(), loraConfig = null))
+        val primary = ChannelSettings(name = "Primary")
+        assertEquals(listOf(primary), normalizeReplacementSettings(listOf(primary), loraConfig = null))
+    }
+}

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelReplacementTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelReplacementTest.kt
@@ -216,6 +216,21 @@ class ChannelReplacementTest {
     }
 
     @Test
+    fun `additions drop matches against existing and duplicates within incoming`() {
+        val existing = ChannelSettings(name = "Primary", psk = byteArrayOf(1).toByteString())
+        val fresh = ChannelSettings(name = "Fresh", psk = byteArrayOf(2).toByteString())
+
+        val additions =
+            getUniqueChannelAdditions(
+                existing = listOf(existing),
+                incoming = listOf(existing, fresh, fresh),
+                loraConfig = ModelChannel.default.loraConfig,
+            )
+
+        assertEquals(listOf(fresh), additions)
+    }
+
+    @Test
     fun `replacement disables stale trailing slots`() {
         val primary = ChannelSettings(name = "Primary")
 

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -65,6 +65,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private const val SCAN_RETRY_COUNT = 3
+private const val MAX_LOG_CAUSE_DEPTH = 6
 private val SCAN_RETRY_DELAY = 1.seconds
 private val CONNECTION_TIMEOUT = 15.seconds
 
@@ -148,8 +149,11 @@ class BleRadioTransport(
     private val bluetoothRepository: BluetoothRepository,
     private val connectionFactory: BleConnectionFactory,
     private val callback: RadioTransportCallback,
-    internal val address: String,
+    private val address: String,
 ) : RadioTransport {
+
+    private val anonymizedAddress = address.anonymize()
+    private val logAddress = "[$anonymizedAddress]"
 
     // Detached cleanup scope for last-ditch GATT teardown from the exception handler.
     // Must NOT be a child of `scope`: when an uncaught exception fires in connectionScope,
@@ -160,7 +164,7 @@ class BleRadioTransport(
     private val cleanupScope: CoroutineScope = CoroutineScope(SupervisorJob() + scope.coroutineContext.minusKey(Job))
 
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        Logger.w(throwable) { "[$address] Uncaught exception in connectionScope" }
+        Logger.w { "$logAddress Uncaught exception in connectionScope cause=${throwable.safeLogType()}" }
         if (throwable !is CancellationException) {
             // Record the cause BEFORE the CAS so there is no window where another coroutine
             // sees sessionFailed == true but sessionFailureCause == null. first-cause is
@@ -177,7 +181,7 @@ class BleRadioTransport(
             try {
                 bleConnection.disconnect()
             } catch (e: Exception) {
-                Logger.w(e) { "[$address] Failed to disconnect in exception handler" }
+                Logger.w { "$logAddress Failed to disconnect in exception handler cause=${e.safeLogType()}" }
             }
         }
     }
@@ -225,7 +229,7 @@ class BleRadioTransport(
                 delay(HEARTBEAT_DRAIN_DELAY)
                 radioService?.requestDrain()
             },
-            logTag = address,
+            logTag = anonymizedAddress,
         )
 
     override fun start() {
@@ -244,9 +248,9 @@ class BleRadioTransport(
             // Use one bounded, address-filtered scan. Splitting this into a short scan plus an escalated scan consumed
             // two Android scanner registrations per reconnect and could hit SCAN_FAILED_SCANNING_TOO_FREQUENTLY when a
             // user switched devices while the reconnect policy and the Connections screen were also scanning.
-            Logger.i { "[${address.anonymize()}] Bonded device found; scanning once for a fresh advertisement" }
+            Logger.i { "$logAddress Bonded device found; scanning once for a fresh advertisement" }
             scanForFreshDevice(SCAN_TIMEOUT)?.let {
-                Logger.i { "[${address.anonymize()}] Fresh advertisement found; using scanned device" }
+                Logger.i { "$logAddress Fresh advertisement found; using scanned device" }
                 return it
             }
 
@@ -255,14 +259,14 @@ class BleRadioTransport(
             // This remains bounded by CONNECTION_TIMEOUT in connectAndAwait(), after which BleReconnectPolicy owns
             // retry/backoff.
             Logger.w {
-                "[${address.anonymize()}] No fresh advertisement within $SCAN_TIMEOUT; " +
+                "$logAddress No fresh advertisement within $SCAN_TIMEOUT; " +
                     "falling back to bonded handle for bounded autoConnect"
             }
             return bondedDevice
         }
 
         // Non-bonded path: preserve existing retry behavior (SCAN_RETRY_COUNT attempts at SCAN_TIMEOUT).
-        Logger.i { "[${address.anonymize()}] Device not found in bonded list, scanning" }
+        Logger.i { "$logAddress Device not found in bonded list, scanning" }
         repeat(SCAN_RETRY_COUNT) { attempt ->
             scanForFreshDevice(SCAN_TIMEOUT)?.let {
                 return it
@@ -271,7 +275,8 @@ class BleRadioTransport(
                 delay(SCAN_RETRY_DELAY)
             }
         }
-        throw RadioNotConnectedException("Device not found at address $address")
+        Logger.w { "$logAddress Selected radio was not found after BLE scan retries" }
+        throw RadioNotConnectedException("Selected radio was not found")
     }
 
     /**
@@ -300,7 +305,7 @@ class BleRadioTransport(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        Logger.v(e) { "[${address.anonymize()}] Scan failed (timeout=$timeout)" }
+        Logger.v { "$logAddress Scan failed (timeout=$timeout) cause=${e.safeLogType()}" }
         null
     }
 
@@ -315,7 +320,7 @@ class BleRadioTransport(
                             throw e
                         } catch (e: Exception) {
                             val failureTime = (nowMillis - connectionStartTime).milliseconds
-                            Logger.w(e) { "[$address] Failed to connect after $failureTime" }
+                            Logger.w { "$logAddress Failed to connect after $failureTime cause=${e.safeLogType()}" }
                             BleReconnectPolicy.Outcome.Failed(e)
                         }
                     },
@@ -326,8 +331,11 @@ class BleRadioTransport(
                         // a modal dialog would just confuse the user. The warning log is the
                         // observability surface for this transient event.
                         if (!sessionFailed.value) {
-                            error?.let {
-                                Logger.w(it) { "[$address] BLE reconnect attempt failed; continuing automatic retry" }
+                            error?.let { failure ->
+                                Logger.w {
+                                    "$logAddress BLE reconnect attempt failed; continuing automatic retry " +
+                                        "cause=${failure.safeLogType()}"
+                                }
                             }
                             callback.onDisconnect(isPermanent = false)
                         }
@@ -353,7 +361,7 @@ class BleRadioTransport(
         connectionStartTime = nowMillis
         sessionFailed.value = false
         sessionFailureCause = null
-        Logger.i { "[$address] BLE connection attempt started" }
+        Logger.i { "$logAddress BLE connection attempt started" }
 
         val device = findDevice()
 
@@ -362,7 +370,8 @@ class BleRadioTransport(
         val state = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
 
         if (state !is BleConnectionState.Connected) {
-            throw RadioNotConnectedException("Failed to connect to device at address $address")
+            Logger.w { "$logAddress BLE connection completed without a connected state: $state" }
+            throw RadioNotConnectedException("Failed to connect to the selected radio")
         }
 
         // Post-OTA GATT cache invalidation: the device rebooted with potentially different
@@ -371,11 +380,9 @@ class BleRadioTransport(
         val radioServiceForCache = callback as? RadioInterfaceService
         if (radioServiceForCache?.consumeGattCacheInvalidationRequest() == true) {
             val invalidated = bleConnection.invalidateServiceCache()
-            Logger.d { "[${address.anonymize()}] Post-OTA GATT cache invalidation requested: $invalidated" }
+            Logger.d { "$logAddress Post-OTA GATT cache invalidation requested: $invalidated" }
             if (invalidated) {
-                Logger.i {
-                    "[${address.anonymize()}] Reconnecting after GATT cache refresh to force service rediscovery"
-                }
+                Logger.i { "$logAddress Reconnecting after GATT cache refresh to force service rediscovery" }
                 bleConnection.disconnect()
                 delay(POST_INVALIDATION_RECONNECT_DELAY)
                 val reconnectState = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
@@ -384,7 +391,7 @@ class BleRadioTransport(
                         "Failed to reconnect after post-OTA GATT cache refresh (state=$reconnectState)",
                     )
                 }
-                Logger.i { "[${address.anonymize()}] Reconnected after GATT cache refresh" }
+                Logger.i { "$logAddress Reconnected after GATT cache refresh" }
             }
         }
 
@@ -396,11 +403,13 @@ class BleRadioTransport(
 
         // If a fatal session failure (fromRadio/logRadio error) forced disconnect during setup,
         // skip the Connected gate — return a retryable failure so BleReconnectPolicy handles it.
-        if (sessionFailureCause != null) {
-            Logger.w(sessionFailureCause) {
-                "[$address] Session failed during profile setup — returning failed outcome"
+        val setupFailure = sessionFailureCause
+        if (setupFailure != null) {
+            Logger.w {
+                "$logAddress Session failed during profile setup — returning failed outcome " +
+                    "cause=${setupFailure.safeLogType()}"
             }
-            return BleReconnectPolicy.Outcome.Failed(sessionFailureCause ?: RuntimeException("Session setup failed"))
+            return BleReconnectPolicy.Outcome.Failed(setupFailure)
         }
 
         // Wait for the StateFlow to actually reflect Connected before watching for the next
@@ -422,7 +431,10 @@ class BleRadioTransport(
             }
         if (connectedReached == null) {
             val failure = sessionFailureCause ?: RuntimeException("Timed out waiting for Connected state gate")
-            Logger.w(failure) { "[$address] Session failed before Connected gate — returning failed outcome" }
+            Logger.w {
+                "$logAddress Session failed before Connected gate — returning failed outcome " +
+                    "cause=${failure.safeLogType()}"
+            }
             // CRITICAL: force GATT cleanup before returning Failed so we don't start a new
             // attempt over an uncleared session. Without this, a timeout caused by flow lag or
             // a stale-Disconnected state mismatch would leave a live/half-live GATT handle behind.
@@ -432,7 +444,10 @@ class BleRadioTransport(
                 try {
                     bleConnection.disconnect()
                 } catch (ignored: Exception) {
-                    Logger.w(ignored) { "[$address] disconnect() failed during Connected-gate timeout cleanup" }
+                    Logger.w {
+                        "$logAddress disconnect() failed during Connected-gate timeout cleanup " +
+                            "cause=${ignored.safeLogType()}"
+                    }
                 }
             }
             return BleReconnectPolicy.Outcome.Failed(failure)
@@ -450,14 +465,16 @@ class BleRadioTransport(
             onDisconnected()
         }
 
-        Logger.i { "[$address] BLE connection dropped (reason: $disconnectReason), preparing to reconnect" }
+        Logger.i { "$logAddress BLE connection dropped (reason: $disconnectReason), preparing to reconnect" }
 
         // Internal session failures (write/read exceptions that triggered handleFailure →
         // disconnect) must NOT be treated as intentional/user disconnects — the reconnect policy
         // needs to escalate backoff for these.
         val internalFailure = sessionFailureCause
         if (internalFailure != null) {
-            Logger.w(internalFailure) { "[$address] Session forced disconnect due to internal failure" }
+            Logger.w {
+                "$logAddress Session forced disconnect due to internal failure cause=${internalFailure.safeLogType()}"
+            }
         }
         val wasIntentional =
             if (internalFailure != null) {
@@ -470,7 +487,7 @@ class BleRadioTransport(
 
         if (!wasStable && !wasIntentional) {
             Logger.w {
-                "[$address] Connection lasted only $connectionUptime " +
+                "$logAddress Connection lasted only $connectionUptime " +
                     "(< ${reconnectPolicy.minStableConnection}) — treating as unstable"
             }
         }
@@ -483,10 +500,10 @@ class BleRadioTransport(
 
         // Bond before connecting: firmware may require an encrypted link, and without a bond Android fails with
         // status 5 or 133. Non-Android targets use repository-specific no-op behavior.
-        Logger.i { "[$address] Device not bonded, initiating bonding" }
+        Logger.i { "$logAddress Device not bonded, initiating bonding" }
         try {
             bluetoothRepository.bond(device)
-            Logger.i { "[$address] Bonding successful" }
+            Logger.i { "$logAddress Bonding successful" }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -494,9 +511,14 @@ class BleRadioTransport(
             // setup. If the device is still not bonded, continuing would fail later with a cryptic status (5/133), so
             // stop now and let BleReconnectPolicy own the retry/backoff.
             if (bluetoothRepository.isBonded(address)) {
-                Logger.w(e) { "[$address] Bonding reported failure but device is bonded; continuing" }
+                Logger.w {
+                    "$logAddress Bonding reported failure but device is bonded; continuing cause=${e.safeLogType()}"
+                }
             } else {
-                Logger.w(e) { "[$address] Bonding failed and device is still not bonded; stopping connection attempt" }
+                Logger.w {
+                    "$logAddress Bonding failed and device is still not bonded; stopping connection attempt " +
+                        "cause=${e.safeLogType()}"
+                }
                 throw RadioNotConnectedException("Bonding failed and device is still not bonded", e)
             }
         }
@@ -505,16 +527,13 @@ class BleRadioTransport(
     private suspend fun onConnected() {
         try {
             bleConnection.deviceFlow.first()?.let { device ->
-                val rssi = retryBleOperation(tag = address) { device.readRssi() }
-                Logger.d {
-                    "[${address.anonymize()}] Connection confirmed. " +
-                        "Initial RSSI: ${rssi?.let { "$it dBm" } ?: "unknown"}"
-                }
+                val rssi = retryBleOperation(tag = anonymizedAddress) { device.readRssi() }
+                Logger.d { "$logAddress Connection confirmed. Initial RSSI: ${rssi?.let { "$it dBm" } ?: "unknown"}" }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Logger.w(e) { "[$address] Failed to read initial connection RSSI" }
+            Logger.w { "$logAddress Failed to read initial connection RSSI cause=${e.safeLogType()}" }
         }
     }
 
@@ -527,7 +546,7 @@ class BleRadioTransport(
         // onDisconnect calls (one with the real error message from handleFailure, one
         // generic from here).
         val firstWriter = sessionFailed.compareAndSet(expect = false, update = true)
-        Logger.i { "[$address] BLE disconnected - ${formatSessionStats()}" }
+        Logger.i { "$logAddress BLE disconnected - ${formatSessionStats()}" }
         if (firstWriter) {
             // Signal immediately so the UI reflects the disconnect while reconnect continues.
             callback.onDisconnect(isPermanent = false)
@@ -542,29 +561,29 @@ class BleRadioTransport(
 
                 radioService.fromRadio
                     .onEach { packet ->
-                        Logger.v { "[$address] Received packet fromRadio (${packet.size} bytes)" }
+                        Logger.v { "$logAddress Received packet fromRadio (${packet.size} bytes)" }
                         dispatchPacket(packet)
                     }
                     .catch { e ->
-                        Logger.w(e) { "[$address] Error in fromRadio flow" }
+                        Logger.w { "$logAddress Error in fromRadio flow cause=${e.safeLogType()}" }
                         handleFailure(e)
                     }
                     .launchIn(this)
 
                 radioService.logRadio
                     .onEach { packet ->
-                        Logger.v { "[$address] Received packet logRadio (${packet.size} bytes)" }
+                        Logger.v { "$logAddress Received packet logRadio (${packet.size} bytes)" }
                         dispatchPacket(packet)
                     }
                     .catch { e ->
-                        Logger.w(e) { "[$address] Error in logRadio flow" }
+                        Logger.w { "$logAddress Error in logRadio flow cause=${e.safeLogType()}" }
                         handleFailure(e)
                     }
                     .launchIn(this)
 
                 this@BleRadioTransport.radioService = radioService
 
-                Logger.i { "[$address] Profile service active and characteristics subscribed" }
+                Logger.i { "$logAddress Profile service active and characteristics subscribed" }
 
                 // Wait for FROMNUM CCCD write before triggering the Meshtastic handshake.
                 // Bounded: if fromRadio fails before subscriptionReady completes, handleFailure
@@ -580,16 +599,16 @@ class BleRadioTransport(
                 if (!subscriptionReady || sessionFailed.value) {
                     val cause =
                         sessionFailureCause ?: RuntimeException("Timed out waiting for FROMNUM subscription readiness")
-                    Logger.w(cause) {
+                    Logger.w {
                         val reason = if (!subscriptionReady) "timed out" else "failed"
-                        "[$address] Subscription wait $reason — aborting setup"
+                        "$logAddress Subscription wait $reason — aborting setup cause=${cause.safeLogType()}"
                     }
                     throw cause
                 }
 
                 // Log negotiated MTU for diagnostics
                 val maxLen = bleConnection.maximumWriteValueLength(BleWriteType.WITHOUT_RESPONSE)
-                Logger.i { "[$address] BLE Radio Session Ready. Max write length (WITHOUT_RESPONSE): $maxLen bytes" }
+                Logger.i { "$logAddress BLE Radio Session Ready. Max write length (WITHOUT_RESPONSE): $maxLen bytes" }
 
                 requestHighPriorityAndScheduleDowngrade()
 
@@ -617,7 +636,7 @@ class BleRadioTransport(
                 if (!sessionFailed.value) {
                     this@BleRadioTransport.callback.onConnect()
                 } else {
-                    Logger.w { "[$address] Session failed during setup — skipping onConnect" }
+                    Logger.w { "$logAddress Session failed during setup — skipping onConnect" }
                 }
             }
         } catch (e: CancellationException) {
@@ -629,12 +648,14 @@ class BleRadioTransport(
                 try {
                     bleConnection.disconnect()
                 } catch (ignored: Exception) {
-                    Logger.w(ignored) { "[$address] disconnect() failed during cancellation cleanup" }
+                    Logger.w {
+                        "$logAddress disconnect() failed during cancellation cleanup cause=${ignored.safeLogType()}"
+                    }
                 }
             }
             throw e
         } catch (e: Exception) {
-            Logger.w(e) { "[$address] Profile service discovery or operation failed" }
+            Logger.w { "$logAddress Profile service discovery or operation failed cause=${e.safeLogType()}" }
             // Clear stale state so the next attempt starts clean — if failure happened after
             // radioService assignment but before callback.onConnect(), stale state would survive.
             radioService = null
@@ -643,7 +664,7 @@ class BleRadioTransport(
                 try {
                     bleConnection.disconnect()
                 } catch (ignored: Exception) {
-                    Logger.w(ignored) { "[$address] disconnect() failed after profile error" }
+                    Logger.w { "$logAddress disconnect() failed after profile error cause=${ignored.safeLogType()}" }
                 }
             }
             throw e // Re-throw so attemptConnection() returns Outcome.Failed(e) for policy backoff.
@@ -656,14 +677,14 @@ class BleRadioTransport(
      */
     private suspend fun CoroutineScope.requestHighPriorityAndScheduleDowngrade() {
         if (bleConnection.requestHighConnectionPriority()) {
-            Logger.d { "[$address] Requested high BLE connection priority" }
+            Logger.d { "$logAddress Requested high BLE connection priority" }
             // Wait for the connection parameter update before starting heavy traffic.
             delay(1.seconds)
         }
         launch {
             delay(PRIORITY_DOWNGRADE_DELAY)
             if (bleConnection.requestBalancedConnectionPriority()) {
-                Logger.d { "[$address] Downgraded to balanced BLE connection priority" }
+                Logger.d { "$logAddress Downgraded to balanced BLE connection priority" }
             }
         }
     }
@@ -687,7 +708,7 @@ class BleRadioTransport(
     override fun handleSendToRadio(p: ByteArray) {
         // Fast-path check: skip coroutine launch entirely if no transport is active.
         if (radioService == null) {
-            Logger.w { "[$address] toRadio characteristic unavailable, can't send data" }
+            Logger.w { "$logAddress toRadio characteristic unavailable, can't send data" }
             return
         }
         connectionScope.launch {
@@ -698,17 +719,17 @@ class BleRadioTransport(
                 val currentService =
                     radioService
                         ?: run {
-                            Logger.w { "[$address] toRadio characteristic cleared during write queue" }
+                            Logger.w { "$logAddress toRadio characteristic cleared during write queue" }
                             return@withLock
                         }
                 try {
-                    retryBleOperation(tag = address, retryWhile = { currentService === radioService }) {
+                    retryBleOperation(tag = anonymizedAddress, retryWhile = { currentService === radioService }) {
                         currentService.sendToRadio(p)
                     }
                     val sent = packetsSent.incrementAndGet()
                     val txBytes = bytesSent.addAndGet(p.size.toLong())
                     Logger.v {
-                        "[$address] Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $txBytes bytes)"
+                        "$logAddress Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $txBytes bytes)"
                     }
                 } catch (e: CancellationException) {
                     throw e
@@ -717,13 +738,16 @@ class BleRadioTransport(
                     // If radioService was replaced (new reconnect cycle) or cleared (handleFailure
                     // already ran), this is a stale write from the old session — silently discard.
                     if (currentService === radioService) {
-                        Logger.w(e) {
-                            "[$address] Failed to write packet to toRadioCharacteristic after " +
-                                "${packetsSent.value} successful writes"
+                        Logger.w {
+                            "$logAddress Failed to write packet to toRadioCharacteristic after " +
+                                "${packetsSent.value} successful writes cause=${e.safeLogType()}"
                         }
                         handleFailure(e)
                     } else {
-                        Logger.d(e) { "[$address] Stale write failure ignored because the session was replaced" }
+                        Logger.d {
+                            "$logAddress Stale write failure ignored because the session was replaced " +
+                                "cause=${e.safeLogType()}"
+                        }
                     }
                 }
             }
@@ -739,7 +763,7 @@ class BleRadioTransport(
 
     /** Closes the connection to the device. */
     override suspend fun close() {
-        Logger.i { "[$address] Disconnecting. ${formatSessionStats()}" }
+        Logger.i { "$logAddress Disconnecting. ${formatSessionStats()}" }
         connectionScope.cancel()
         // GATT cleanup must run under NonCancellable so a cancelled caller cannot skip it,
         // which would leak BluetoothGatt and trigger status 133 on the next reconnect.
@@ -749,7 +773,7 @@ class BleRadioTransport(
             try {
                 withTimeoutOrNull(GATT_CLEANUP_TIMEOUT) { bleConnection.disconnect() }
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                Logger.w(e) { "[$address] Failed to disconnect in close()" }
+                Logger.w { "$logAddress Failed to disconnect in close() cause=${e.safeLogType()}" }
             }
         }
         // Our own disconnect succeeded — the exception-handler safety net is no longer
@@ -761,7 +785,7 @@ class BleRadioTransport(
     private fun dispatchPacket(packet: ByteArray) {
         val received = packetsReceived.incrementAndGet()
         val rxBytes = bytesReceived.addAndGet(packet.size.toLong())
-        Logger.v { "[$address] Dispatching packet #$received " + "(${packet.size} bytes, total RX: $rxBytes bytes)" }
+        Logger.v { "$logAddress Dispatching packet #$received " + "(${packet.size} bytes, total RX: $rxBytes bytes)" }
         callback.handleFromRadio(packet)
     }
 
@@ -801,7 +825,7 @@ class BleRadioTransport(
         // user-facing.
         callback.onDisconnect(isPermanent, errorMessage = if (isPermanent) msg else null)
 
-        Logger.w(throwable) { "[$address] Session failure — forcing cleanup for reconnect" }
+        Logger.w { "$logAddress Session failure — forcing cleanup for reconnect cause=${throwable.safeLogType()}" }
 
         // Force GATT disconnect on the detached cleanupScope (matching the pattern used by
         // the exceptionHandler defined above). This causes Kable's connectionState
@@ -810,7 +834,7 @@ class BleRadioTransport(
             try {
                 bleConnection.disconnect()
             } catch (e: Exception) {
-                Logger.w(e) { "[$address] Failed to disconnect after session failure" }
+                Logger.w { "$logAddress Failed to disconnect after session failure cause=${e.safeLogType()}" }
             }
         }
     }
@@ -839,5 +863,26 @@ class BleRadioTransport(
                 else -> this.message ?: this::class.simpleName ?: "Unknown"
             }
         return false to msg
+    }
+
+    /** Retains actionable BLE status and exception type without forwarding platform text or device identifiers. */
+    private fun Throwable.safeLogType(): String {
+        val outerType = this::class.simpleName ?: "Exception"
+        var current: Throwable? = this
+        var classifiedType: String? = null
+        var remainingDepth = MAX_LOG_CAUSE_DEPTH
+        while (current != null && classifiedType == null && remainingDepth > 0) {
+            val failure = current
+            val info = failure.classifyBleException()
+            if (info != null) {
+                val bleType = failure::class.simpleName ?: "BleException"
+                val classified = info.gattStatus?.let { "$bleType(status=$it)" } ?: bleType
+                classifiedType = if (failure === this) classified else "$outerType(cause=$classified)"
+            } else {
+                current = failure.cause
+            }
+            remainingDepth--
+        }
+        return classifiedType ?: outerType
     }
 }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.ble.MeshtasticBleConstants.FROMNUM_CHARACTERISTIC
 import org.meshtastic.core.ble.MeshtasticBleConstants.FROMRADIO_CHARACTERISTIC
@@ -72,7 +73,7 @@ class BleRadioTransportTest {
 
         val bleTransport =
             BleRadioTransport(
-                scope = testScope,
+                scope = backgroundScope,
                 scanner = scanner,
                 bluetoothRepository = bluetoothRepository,
                 connectionFactory = connectionFactory,
@@ -81,27 +82,12 @@ class BleRadioTransportTest {
             )
         bleTransport.start()
         try {
-            // start() begins connect() which is async
-            // In a real test we'd verify the connection state,
-            // but for now this confirms it works with the fakes.
-            assertEquals(address, bleTransport.address)
+            advanceTimeBy(BleReconnectPolicy.DEFAULT_SETTLE_DELAY.inWholeMilliseconds)
+            runCurrent()
+            assertEquals(address, scanner.lastScanAddress)
         } finally {
             bleTransport.close()
         }
-    }
-
-    @Test
-    fun `address returns correct value`() {
-        val bleTransport =
-            BleRadioTransport(
-                scope = testScope,
-                scanner = scanner,
-                bluetoothRepository = bluetoothRepository,
-                connectionFactory = connectionFactory,
-                callback = service,
-                address = address,
-            )
-        assertEquals(address, bleTransport.address)
     }
 
     /**

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.repository
 
+import kotlinx.coroutines.NonCancellable
 import org.meshtastic.core.model.Position
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.Config
@@ -145,7 +146,16 @@ interface AdminController {
      * SDK's `AdminApi.editSettings { }`.
      *
      * All admin packets for the session — begin, the [block]'s writes, and commit — are issued from the calling
-     * coroutine, which is required for the firmware to associate them with one transaction.
+     * coroutine, which is required for the firmware to associate them with one transaction. The implementation waits
+     * for radio queue acceptance at both boundaries, so callers cannot start a later rebooting stage while this
+     * transaction is still queued or uncommitted.
+     *
+     * For the locally connected node, a commit dispatched immediately before the expected transport departure is
+     * treated as accepted because the reboot can prevent an acknowledgement from returning.
+     *
+     * Firmware exposes no abort boundary, so commit is attempted in [NonCancellable] context even when [block] throws
+     * or the caller is cancelled. The original block failure is rethrown, with a distinct commit failure attached as a
+     * suppressed exception.
      */
     suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit)
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
@@ -18,16 +18,29 @@ package org.meshtastic.core.repository
 
 /** Outcome of a packet whose caller waited for radio acceptance. */
 enum class AwaitedSendStatus {
+    /** An active transport dispatched the packet and the radio acknowledged it. */
     ACCEPTED,
+
+    /** The app rejected the packet before it reached a transport, such as an invalid or duplicate packet ID. */
     REJECTED,
+
+    /** The transport dispatched the packet, but the radio rejected it. */
+    RADIO_REJECTED,
+
+    /** No radio response arrived within the response window after the packet reached the queue head. */
     TIMED_OUT,
+
+    /** The queue or owning service scope stopped before the radio answered; retry after the next connection. */
     TRANSPORT_STOPPED,
+
+    /** No transport accepted the bytes, or the send attempt raised an error. */
     SEND_FAILED,
 }
 
 /**
  * Detailed result for an awaited send. [dispatched] is true only when an active transport accepted the outbound bytes
- * for asynchronous delivery.
+ * for asynchronous delivery. Correlated responses received before dispatch are ignored, so an accepted result always
+ * belongs to an admitted transport send.
  */
 data class AwaitedSendResult(val status: AwaitedSendStatus, val dispatched: Boolean) {
     val accepted: Boolean

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
@@ -14,27 +14,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+package org.meshtastic.core.repository
 
-plugins {
-    alias(libs.plugins.meshtastic.kmp.library)
-    alias(libs.plugins.meshtastic.koin)
+/** Outcome of a packet whose caller waited for radio acceptance. */
+enum class AwaitedSendStatus {
+    ACCEPTED,
+    REJECTED,
+    TIMED_OUT,
+    TRANSPORT_STOPPED,
+    SEND_FAILED,
 }
 
-kotlin {
-    android { withHostTest {} }
-
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.core.model)
-            api(libs.meshtastic.protobufs)
-            implementation(projects.core.common)
-            implementation(projects.core.database)
-
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.atomicfu)
-            implementation(libs.kermit)
-            implementation(libs.androidx.paging.common)
-        }
-        commonTest.dependencies { implementation(projects.core.testing) }
-    }
+/**
+ * Detailed result for an awaited send. [dispatched] is true only when an active transport accepted the outbound bytes
+ * for asynchronous delivery.
+ */
+data class AwaitedSendResult(val status: AwaitedSendStatus, val dispatched: Boolean) {
+    val accepted: Boolean
+        get() = status == AwaitedSendStatus.ACCEPTED
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationScope.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationScope.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import org.meshtastic.proto.ChannelSettings
+
+/** Tracks whether an authoritative channel write requires one local-cache reconciliation. */
+class ChannelCacheReconciliationScope
+internal constructor(
+    private val repository: RadioConfigRepository,
+    private val normalizedSettings: List<ChannelSettings>,
+) {
+    private var channelWriteIssued = false
+    private var reconciliationCompleted = false
+
+    /** Marks that at least one channel command was accepted by the radio. */
+    fun markChannelWriteIssued() {
+        channelWriteIssued = true
+    }
+
+    /** Replaces the local channel cache once after the first accepted channel command. */
+    suspend fun reconcileChannelCache() {
+        if (!channelWriteIssued || reconciliationCompleted) return
+
+        // Handshake persistence omits DISABLED slots, so replayed packets cannot reliably clear stale trailing
+        // channels.
+        // Carry failures out as values so coroutine stack-trace recovery cannot replace their identity while crossing
+        // the NonCancellable context boundary.
+        val replacement =
+            withContext(NonCancellable) { runCatching { repository.replaceAllSettings(normalizedSettings) } }
+        replacement.getOrThrow()
+        reconciliationCompleted = true
+    }
+}
+
+/**
+ * Runs [block] with authoritative channel-cache cleanup on every normal, failed, or cancelled exit.
+ *
+ * A block failure remains primary. If cleanup also fails, the cleanup error is suppressed onto that original failure.
+ */
+suspend fun <T> RadioConfigRepository.withChannelCacheReconciliation(
+    normalizedSettings: List<ChannelSettings>,
+    block: suspend ChannelCacheReconciliationScope.() -> T,
+): T {
+    val reconciliation = ChannelCacheReconciliationScope(this, normalizedSettings)
+    val blockResult = runCatching { reconciliation.block() }
+    val reconciliationFailure = runCatching { reconciliation.reconcileChannelCache() }.exceptionOrNull()
+    val primaryFailure = blockResult.exceptionOrNull()
+
+    if (primaryFailure != null) {
+        if (reconciliationFailure != null && reconciliationFailure !== primaryFailure) {
+            primaryFailure.addSuppressed(reconciliationFailure)
+        }
+        throw primaryFailure
+    }
+
+    if (reconciliationFailure != null) throw reconciliationFailure
+    return blockResult.getOrThrow()
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationScope.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationScope.kt
@@ -20,7 +20,12 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.meshtastic.proto.ChannelSettings
 
-/** Tracks whether an authoritative channel write requires one local-cache reconciliation. */
+/**
+ * Tracks whether an authoritative channel write requires one local-cache reconciliation.
+ *
+ * Not thread-safe. Callers must invoke [markChannelWriteIssued] and [reconcileChannelCache] from one coroutine;
+ * concurrent calls can issue more than one cache replacement.
+ */
 class ChannelCacheReconciliationScope
 internal constructor(
     private val repository: RadioConfigRepository,

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -37,10 +37,12 @@ interface CommandSender {
     /** Generates a new unique packet ID. */
     fun generatePacketId(): Int
 
-    /** Sends a data packet to the mesh. */
+    /**
+     * Sends a data packet to the mesh, recording [org.meshtastic.core.model.MessageStatus.ERROR] if admission fails.
+     */
     suspend fun sendData(p: DataPacket)
 
-    /** Sends an admin message to a specific node. */
+    /** Sends an admin message to a specific node, or throws if the outbound queue rejects it. */
     suspend fun sendAdmin(
         destNum: Int,
         requestId: Int = generatePacketId(),
@@ -79,25 +81,25 @@ interface CommandSender {
         initFn: () -> AdminMessage,
     ): AwaitedSendResult
 
-    /** Sends our current position to the mesh. */
+    /** Sends our current position to the mesh, or throws if the outbound queue rejects it. */
     suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int? = null, wantResponse: Boolean = false)
 
-    /** Requests the position of a specific node. */
+    /** Requests the position of a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestPosition(destNum: Int, currentPosition: Position)
 
-    /** Sets a fixed position for a node. */
+    /** Sets a fixed position for a node, or throws if the outbound queue rejects the admin command. */
     suspend fun setFixedPosition(destNum: Int, pos: Position)
 
-    /** Requests user info from a specific node. */
+    /** Requests user info from a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestUserInfo(destNum: Int)
 
-    /** Requests a traceroute to a specific node. */
+    /** Requests a traceroute to a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestTraceroute(requestId: Int, destNum: Int)
 
-    /** Requests telemetry from a specific node. */
+    /** Requests telemetry from a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int)
 
-    /** Requests neighbor info from a specific node. */
+    /** Requests neighbor info from a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestNeighborInfo(requestId: Int, destNum: Int)
 
     /**

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -59,7 +59,8 @@ interface CommandSender {
      * Sends an admin message and suspends until the radio acknowledges it.
      *
      * This is used when the caller needs to guarantee a packet has been accepted by the radio before proceeding, such
-     * as sending a shared contact before the first DM to a node.
+     * as sending a shared contact before the first DM to a node. Time spent behind existing FIFO entries does not count
+     * against the radio-response timeout.
      *
      * @return `true` if the radio accepted the packet, `false` on timeout or failure.
      */
@@ -68,7 +69,15 @@ interface CommandSender {
         requestId: Int = generatePacketId(),
         wantResponse: Boolean = false,
         initFn: () -> AdminMessage,
-    ): Boolean
+    ): Boolean = sendAdminAwaitResult(destNum, requestId, wantResponse, initFn).accepted
+
+    /** Detailed form of [sendAdminAwait], including whether an active transport admitted the packet. */
+    suspend fun sendAdminAwaitResult(
+        destNum: Int,
+        requestId: Int = generatePacketId(),
+        wantResponse: Boolean = false,
+        initFn: () -> AdminMessage,
+    ): AwaitedSendResult
 
     /** Sends our current position to the mesh. */
     suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int? = null, wantResponse: Boolean = false)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
+import org.meshtastic.core.model.ConnectionState
+
+/**
+ * Owns canonical connection state and its lifecycle epochs as one lock-free transition.
+ *
+ * The canonical [ConnectionLifecycle] flow is updated with compare-and-set, so concurrent writers cannot lose or
+ * double-count lifecycle edges. One publisher then mirrors its newest value to the legacy state and epoch convenience
+ * flows. Lifecycle-sensitive consumers therefore never have to correlate separate publications.
+ */
+class ConnectionStateHolder(
+    initialState: ConnectionState = ConnectionState.Disconnected,
+    initialEpochs: ConnectionEpochs = ConnectionEpochs(),
+) : ConnectionStateProvider {
+    private val publicationInProgress = atomic(false)
+    private val publishedVersion = atomic(0L)
+
+    private val mutableConnectionLifecycle =
+        MutableStateFlow(ConnectionLifecycle(version = 0, state = initialState, epochs = initialEpochs))
+    private val mutableConnectionState = MutableStateFlow(initialState)
+    private val mutableConnectionEpochs = MutableStateFlow(initialEpochs)
+
+    override val connectionLifecycle: StateFlow<ConnectionLifecycle> = mutableConnectionLifecycle.asStateFlow()
+    override val connectionState: StateFlow<ConnectionState> = mutableConnectionState.asStateFlow()
+    override val connectionEpochs: StateFlow<ConnectionEpochs> = mutableConnectionEpochs.asStateFlow()
+
+    /** Applies [newState] and advances epochs exactly once when the state changes. */
+    fun setConnectionState(newState: ConnectionState) {
+        while (true) {
+            val current = mutableConnectionLifecycle.value
+            if (current.state == newState) return
+
+            val next =
+                ConnectionLifecycle(
+                    version = current.version + 1,
+                    state = newState,
+                    epochs = current.epochs.advance(current.state, newState),
+                )
+            if (mutableConnectionLifecycle.compareAndSet(current, next)) {
+                publishCompatibilityViews()
+                return
+            }
+        }
+    }
+
+    /** Restores a known baseline, primarily for reusable test fakes. */
+    fun reset(state: ConnectionState = ConnectionState.Disconnected, epochs: ConnectionEpochs = ConnectionEpochs()) {
+        while (true) {
+            val current = mutableConnectionLifecycle.value
+            val next = ConnectionLifecycle(version = current.version + 1, state = state, epochs = epochs)
+            if (mutableConnectionLifecycle.compareAndSet(current, next)) {
+                publishCompatibilityViews()
+                return
+            }
+        }
+    }
+
+    private fun publishCompatibilityViews() {
+        while (true) {
+            if (!publicationInProgress.compareAndSet(expect = false, update = true)) return
+            try {
+                do {
+                    val snapshot = mutableConnectionLifecycle.value
+                    mutableConnectionEpochs.value = snapshot.epochs
+                    mutableConnectionState.value = snapshot.state
+                    publishedVersion.value = snapshot.version
+                } while (publishedVersion.value != mutableConnectionLifecycle.value.version)
+            } finally {
+                publicationInProgress.value = false
+            }
+
+            // An updater can publish a new lifecycle after the final loop check but before the publisher flag is
+            // released. AtomicFU's sequentially-consistent lifecycle CAS, failed flag CAS, and flag release order
+            // that update before this post-release comparison. Recheck so its compatibility projection cannot be
+            // stranded; do not weaken the flag or reorder publication without replacing that handoff guarantee.
+            if (publishedVersion.value == mutableConnectionLifecycle.value.version) return
+        }
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
@@ -47,7 +47,13 @@ class ConnectionStateHolder(
     override val connectionState: StateFlow<ConnectionState> = mutableConnectionState.asStateFlow()
     override val connectionEpochs: StateFlow<ConnectionEpochs> = mutableConnectionEpochs.asStateFlow()
 
-    /** Applies [newState] and advances epochs exactly once when the state changes. */
+    /**
+     * Applies [newState] and advances epochs exactly once when the state changes.
+     *
+     * [connectionLifecycle] is authoritative on return. A concurrent publisher may update the compatibility
+     * [connectionState] and [connectionEpochs] mirrors immediately afterward, so they are not read-after-write
+     * consistent for the caller under contention.
+     */
     fun setConnectionState(newState: ConnectionState) {
         while (true) {
             val current = mutableConnectionLifecycle.value
@@ -66,7 +72,10 @@ class ConnectionStateHolder(
         }
     }
 
-    /** Restores a known baseline, primarily for reusable test fakes. */
+    /**
+     * Restores a known baseline, primarily for reusable test fakes. The version remains monotonic even when state and
+     * epochs return to earlier values, so a reader cannot mistake a reset snapshot for an older publication.
+     */
     fun reset(state: ConnectionState = ConnectionState.Disconnected, epochs: ConnectionEpochs = ConnectionEpochs()) {
         while (true) {
             val current = mutableConnectionLifecycle.value
@@ -92,10 +101,9 @@ class ConnectionStateHolder(
                 publicationInProgress.value = false
             }
 
-            // An updater can publish a new lifecycle after the final loop check but before the publisher flag is
-            // released. AtomicFU's sequentially-consistent lifecycle CAS, failed flag CAS, and flag release order
-            // that update before this post-release comparison. Recheck so its compatibility projection cannot be
-            // stranded; do not weaken the flag or reorder publication without replacing that handoff guarantee.
+            // An updater can commit after the final loop check, lose the publisher race, and return before this owner
+            // releases the flag. Sequentially consistent atomics make that lifecycle write visible here. The
+            // post-release recheck ensures its compatibility projection cannot be stranded.
             if (publishedVersion.value == mutableConnectionLifecycle.value.version) return
         }
     }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateProvider.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateProvider.kt
@@ -17,6 +17,8 @@
 package org.meshtastic.core.repository
 
 import kotlinx.coroutines.flow.StateFlow
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
 import org.meshtastic.core.model.ConnectionState
 
 /**
@@ -30,6 +32,14 @@ import org.meshtastic.core.model.ConnectionState
  */
 interface ConnectionStateProvider {
     /**
+     * Atomically correlated canonical state and lifecycle evidence.
+     *
+     * Lifecycle-sensitive code must observe this flow rather than combining independent reads from [connectionState]
+     * and [connectionEpochs].
+     */
+    val connectionLifecycle: StateFlow<ConnectionLifecycle>
+
+    /**
      * Canonical app-level connection state.
      *
      * This is the **single source of truth** for connection status across the entire application.
@@ -37,4 +47,11 @@ interface ConnectionStateProvider {
      * @see ServiceRepository.connectionState
      */
     val connectionState: StateFlow<ConnectionState>
+
+    /**
+     * Convenience view of monotonic departures and completed handshakes. Use [connectionLifecycle] when the counters
+     * must be correlated with a specific state, because independent StateFlow collections can observe different
+     * versions.
+     */
+    val connectionEpochs: StateFlow<ConnectionEpochs>
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRestartTracker.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRestartTracker.kt
@@ -56,7 +56,12 @@ class NodeRestartTracker(private val scope: CoroutineScope) {
     }
 
     /** Closes the window; call when the node is fully back online (config handshake complete). */
-    fun onConnected() {
+    fun onConnected() = clearExpectation()
+
+    /** Closes the window when a restart-triggering operation aborts before recovery completes. */
+    fun cancelExpectedRestart() = clearExpectation()
+
+    private fun clearExpectation() {
         expiryJob?.cancel()
         expiryJob = null
         _restartExpected.value = false

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -56,7 +56,9 @@ interface PacketHandler {
     /** Processes queue status updates from the radio. */
     fun handleQueueStatus(queueStatus: QueueStatus)
 
-    /** Removes and completes a pending response for a request before the caller's lifecycle lease is released. */
+    /**
+     * Completes a dispatched request before the caller's lifecycle lease is released; pre-dispatch replies are stale.
+     */
     suspend fun removeResponse(dataRequestId: Int, complete: Boolean)
 
     /** Stops the packet queue. */

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -28,8 +28,11 @@ interface PacketHandler {
     /**
      * Adds a mesh packet to the queue for sending.
      *
-     * @return `true` when the packet's non-zero ID was reserved and queued, or `false` when the packet was invalid or
-     *   its ID was already queued/in flight.
+     * A completed packet ID may be reused by a later retry. A duplicate is rejected only while that ID is still queued
+     * or in flight, preserving single ownership of its response.
+     *
+     * @return `true` when the packet's non-zero ID was reserved and queued, or `false` when the packet was invalid, its
+     *   ID was already reserved, or the owning service scope has shut down.
      */
     suspend fun sendToRadio(packet: MeshPacket): Boolean
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -25,8 +25,13 @@ interface PacketHandler {
     /** Sends a command/packet directly to the radio. */
     fun sendToRadio(p: ToRadio)
 
-    /** Adds a mesh packet to the queue for sending. */
-    suspend fun sendToRadio(packet: MeshPacket)
+    /**
+     * Adds a mesh packet to the queue for sending.
+     *
+     * @return `true` when the packet's non-zero ID was reserved and queued, or `false` when the packet was invalid or
+     *   its ID was already queued/in flight.
+     */
+    suspend fun sendToRadio(packet: MeshPacket): Boolean
 
     /**
      * Adds a mesh packet to the queue and suspends until the radio acknowledges it via [QueueStatus].
@@ -35,9 +40,15 @@ interface PacketHandler {
      * packet has been accepted by the radio before proceeding. This is critical for operations where ordering matters
      * (e.g., sending a shared contact before the first DM).
      *
+     * Time spent behind packets already in the FIFO is not part of the response timeout. The timeout begins when this
+     * packet reaches the head of the queue and is transmitted.
+     *
      * @return `true` if the radio accepted the packet, `false` on timeout or failure.
      */
-    suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean
+    suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean = sendToRadioAndAwaitResult(packet).accepted
+
+    /** Detailed form of [sendToRadioAndAwait], including whether an active transport admitted the packet. */
+    suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult
 
     /** Processes queue status updates from the radio. */
     fun handleQueueStatus(queueStatus: QueueStatus)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -82,6 +82,8 @@ interface RadioTransportWriter {
     /**
      * Attempts to dispatch [bytes] to the active transport.
      *
+     * Implementations must return promptly: enqueue transport work internally instead of blocking for I/O or delivery.
+     *
      * @return `true` when an active transport accepted the bytes for asynchronous delivery, or `false` when no send
      *   could be scheduled or confirmed.
      */

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -72,6 +72,22 @@ interface RadioSessionAuthority {
         runWithSessionLease(session) { block() }
 }
 
+/** Writes raw protocol frames to the currently admitted transport. */
+interface RadioTransportWriter {
+    /** Sends [bytes] when a transport is available; callers that need admission evidence use [trySendToRadio]. */
+    fun sendToRadio(bytes: ByteArray) {
+        trySendToRadio(bytes)
+    }
+
+    /**
+     * Attempts to dispatch [bytes] to the active transport.
+     *
+     * @return `true` when an active transport accepted the bytes for asynchronous delivery, or `false` when no send
+     *   could be scheduled or confirmed.
+     */
+    fun trySendToRadio(bytes: ByteArray): Boolean
+}
+
 /**
  * Interface for the low-level radio interface that handles raw byte communication.
  *
@@ -89,7 +105,8 @@ interface RadioSessionAuthority {
  */
 interface RadioInterfaceService :
     RadioTransportCallback,
-    RadioSessionAuthority {
+    RadioSessionAuthority,
+    RadioTransportWriter {
     /** The device types supported by this platform's radio interface. */
     val supportedDeviceTypes: List<DeviceType>
 
@@ -144,9 +161,6 @@ interface RadioInterfaceService :
      * collector was attached do not get replayed ahead of the next session's handshake.
      */
     fun resetReceivedBuffer()
-
-    /** Sends a raw byte array to the radio. */
-    fun sendToRadio(bytes: ByteArray)
 
     /** Initiates the connection to the radio. */
     fun connect()

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.testing.FakeRadioConfigRepository
+import org.meshtastic.proto.ChannelSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ChannelCacheReconciliationTest {
+    private val normalizedSettings = listOf(ChannelSettings(name = "Primary"))
+
+    @Test
+    fun `does not reconcile before a channel write is accepted`() = runTest {
+        val backing = FakeRadioConfigRepository()
+        var replacementCalls = 0
+        val repository =
+            object : RadioConfigRepository by backing {
+                override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+                    replacementCalls += 1
+                    backing.replaceAllSettings(settingsList)
+                }
+            }
+
+        repository.withChannelCacheReconciliation(normalizedSettings) {}
+
+        assertEquals(0, replacementCalls)
+    }
+
+    @Test
+    fun `successful explicit reconciliation runs exactly once`() = runTest {
+        val backing = FakeRadioConfigRepository()
+        var replacementCalls = 0
+        val repository =
+            object : RadioConfigRepository by backing {
+                override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+                    replacementCalls += 1
+                    backing.replaceAllSettings(settingsList)
+                }
+            }
+
+        repository.withChannelCacheReconciliation(normalizedSettings) {
+            markChannelWriteIssued()
+            reconcileChannelCache()
+        }
+
+        assertEquals(1, replacementCalls)
+        assertEquals(normalizedSettings, backing.currentChannelSet.settings)
+    }
+
+    @Test
+    fun `retries a failed explicit reconciliation during cleanup`() = runTest {
+        val backing = FakeRadioConfigRepository()
+        val firstFailure = IllegalStateException("first reconciliation failed")
+        var replacementCalls = 0
+        val repository =
+            object : RadioConfigRepository by backing {
+                override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+                    replacementCalls += 1
+                    if (replacementCalls == 1) throw firstFailure
+                    backing.replaceAllSettings(settingsList)
+                }
+            }
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                repository.withChannelCacheReconciliation(normalizedSettings) {
+                    markChannelWriteIssued()
+                    reconcileChannelCache()
+                }
+            }
+
+        assertSame(firstFailure, failure)
+        assertEquals(2, replacementCalls)
+        assertEquals(normalizedSettings, backing.currentChannelSet.settings)
+    }
+
+    @Test
+    fun `does not self-suppress when explicit reconciliation and cleanup throw the same failure`() = runTest {
+        val backing = FakeRadioConfigRepository()
+        val reconciliationFailure = IllegalStateException("reconciliation failed")
+        var replacementCalls = 0
+        val repository =
+            object : RadioConfigRepository by backing {
+                override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+                    replacementCalls += 1
+                    throw reconciliationFailure
+                }
+            }
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                repository.withChannelCacheReconciliation(normalizedSettings) {
+                    markChannelWriteIssued()
+                    reconcileChannelCache()
+                }
+            }
+
+        assertSame(reconciliationFailure, failure)
+        assertEquals(2, replacementCalls)
+        assertTrue(failure.suppressedExceptions.isEmpty())
+    }
+
+    @Test
+    fun `preserves a primary failure and suppresses reconciliation failure`() = runTest {
+        val backing = FakeRadioConfigRepository()
+        val primaryFailure = IllegalArgumentException("install failed")
+        val cleanupFailure = IllegalStateException("reconciliation failed")
+        val repository =
+            object : RadioConfigRepository by backing {
+                override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>): Unit =
+                    throw cleanupFailure
+            }
+
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                repository.withChannelCacheReconciliation(normalizedSettings) {
+                    markChannelWriteIssued()
+                    throw primaryFailure
+                }
+            }
+
+        assertSame(primaryFailure, failure)
+        assertEquals(listOf(cleanupFailure), failure.suppressedExceptions)
+    }
+
+    @Test
+    fun `preserves cancellation identity after reconciliation`() = runTest {
+        val backing = FakeRadioConfigRepository()
+        val cancellation = CancellationException("cancelled")
+
+        val failure =
+            assertFailsWith<CancellationException> {
+                backing.withChannelCacheReconciliation(normalizedSettings) {
+                    markChannelWriteIssued()
+                    throw cancellation
+                }
+            }
+
+        assertSame(cancellation, failure)
+        assertEquals(normalizedSettings, backing.currentChannelSet.settings)
+    }
+}

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ChannelCacheReconciliationTest.kt
@@ -47,6 +47,24 @@ class ChannelCacheReconciliationTest {
     }
 
     @Test
+    fun `normal cleanup reconciles once when only the write was marked`() = runTest {
+        val backing = FakeRadioConfigRepository()
+        var replacementCalls = 0
+        val repository =
+            object : RadioConfigRepository by backing {
+                override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+                    replacementCalls += 1
+                    backing.replaceAllSettings(settingsList)
+                }
+            }
+
+        repository.withChannelCacheReconciliation(normalizedSettings) { markChannelWriteIssued() }
+
+        assertEquals(1, replacementCalls)
+        assertEquals(normalizedSettings, backing.currentChannelSet.settings)
+    }
+
+    @Test
     fun `successful explicit reconciliation runs exactly once`() = runTest {
         val backing = FakeRadioConfigRepository()
         var replacementCalls = 0

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
+import org.meshtastic.core.model.ConnectionState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConnectionStateHolderTest {
+    @Test
+    fun `transitions advance matching epochs exactly once`() {
+        val holder = ConnectionStateHolder()
+
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connecting)
+        holder.setConnectionState(ConnectionState.Disconnected)
+        holder.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            holder.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `lifecycle flow publishes state and epochs as one correlated snapshot`() {
+        val holder = ConnectionStateHolder()
+
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connecting)
+
+        assertEquals(
+            ConnectionLifecycle(
+                version = 2,
+                state = ConnectionState.Connecting,
+                epochs =
+                ConnectionEpochs(
+                    departures = 1,
+                    completedHandshakes = 1,
+                    handshakesAtLastDeparture = 1,
+                    lastDepartureState = ConnectionState.Connecting,
+                ),
+            ),
+            holder.connectionLifecycle.value,
+        )
+    }
+
+    @Test
+    fun `concurrent duplicate transitions advance each lifecycle edge once`() = runTest {
+        val holder = ConnectionStateHolder()
+
+        suspend fun fanOut(state: ConnectionState) = coroutineScope {
+            List(100) { async(Dispatchers.Default) { holder.setConnectionState(state) } }.awaitAll()
+        }
+
+        fanOut(ConnectionState.Connected)
+        fanOut(ConnectionState.Connecting)
+        fanOut(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            holder.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `reset restores an explicit state and epoch baseline`() {
+        val holder = ConnectionStateHolder()
+        holder.setConnectionState(ConnectionState.Connected)
+
+        holder.reset(
+            state = ConnectionState.DeviceSleep,
+            epochs = ConnectionEpochs(departures = 7, completedHandshakes = 11, handshakesAtLastDeparture = 10),
+        )
+
+        assertEquals(ConnectionState.DeviceSleep, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(departures = 7, completedHandshakes = 11, handshakesAtLastDeparture = 10),
+            holder.connectionEpochs.value,
+        )
+    }
+}

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
@@ -39,6 +39,7 @@ class ConnectionStateHolderTest {
         holder.setConnectionState(ConnectionState.Connected)
 
         assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(4L, holder.connectionLifecycle.value.version)
         assertEquals(
             ConnectionEpochs(
                 departures = 1,
@@ -95,6 +96,31 @@ class ConnectionStateHolderTest {
             ),
             holder.connectionEpochs.value,
         )
+    }
+
+    @Test
+    fun `concurrent mixed transitions leave compatibility views on one committed lifecycle`() = runTest {
+        repeat(25) {
+            val holder = ConnectionStateHolder()
+            val states =
+                List(25) {
+                    listOf(
+                        ConnectionState.Connected,
+                        ConnectionState.Connecting,
+                        ConnectionState.DeviceSleep,
+                        ConnectionState.Disconnected,
+                    )
+                }
+                    .flatten()
+
+            coroutineScope {
+                states.map { state -> async(Dispatchers.Default) { holder.setConnectionState(state) } }.awaitAll()
+            }
+
+            val lifecycle = holder.connectionLifecycle.value
+            assertEquals(lifecycle.state, holder.connectionState.value)
+            assertEquals(lifecycle.epochs, holder.connectionEpochs.value)
+        }
     }
 
     @Test

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/NodeRestartTrackerTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/NodeRestartTrackerTest.kt
@@ -46,6 +46,16 @@ class NodeRestartTrackerTest {
     }
 
     @Test
+    fun `cancelExpectedRestart closes an aborted restart window`() = runTest {
+        val tracker = NodeRestartTracker(backgroundScope)
+        tracker.expectRestart()
+
+        tracker.cancelExpectedRestart()
+
+        assertFalse(tracker.restartExpected.value)
+    }
+
+    @Test
     fun `window expires if the node never comes back`() = runTest {
         val tracker = NodeRestartTracker(backgroundScope)
         tracker.expectRestart(window = 10.seconds)

--- a/core/resources/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ar/strings.xml
@@ -142,7 +142,6 @@
     <!-- MQTT -->
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_disconnected">انقطع الاتصال</string>
-    <string name="must_set_region">واجب إدخال المنطقة!</string>
     <!-- MUTE -->
     <string name="mute_1_week">أسبوع 1</string>
     <string name="mute_8_hours">8 ساعات</string>

--- a/core/resources/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-be/strings.xml
@@ -161,7 +161,6 @@
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_connected">Злучаны</string>
     <string name="mqtt_status_disconnected">Адлучана</string>
-    <string name="must_set_region">Трэба наладзіць рэгіён!</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 тыдзень</string>
     <string name="mute_8_hours">8 гадзін</string>

--- a/core/resources/src/commonMain/composeResources/values-bg/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-bg/strings.xml
@@ -726,7 +726,6 @@
     <string name="mqtt_status_reconnecting">Повторно свързване…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Повторно свързване (опит %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Тестване на връзката</string>
-    <string name="must_set_region">Трябва да зададете регион!</string>
     <string name="must_update">Трябва да актуализирате това приложение в магазина за приложения (или GitHub). Приложението е твърде старо, за да говори с този фърмуер на радиото. Моля, прочетете нашите <a href="https://meshtastic.org/docs/software/android/installation">документи</a> по тази тема.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 седмица</string>

--- a/core/resources/src/commonMain/composeResources/values-ca/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ca/strings.xml
@@ -134,7 +134,6 @@
     <string name="module_settings">Configuració de mòdul</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Desconnectat</string>
-    <string name="must_set_region">Has de configurar la regió!</string>
     <string name="must_update">Has d'actualitzar aquesta aplicació a la app store (o Github). És massa antiga per comunicar-se amb aquest firmware de la ràdio. Si us plau llegeix el nostre <a href="https://meshtastic.org/docs/software/android/installation">docs</a> sobre aquesta temàtica.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 setmana</string>

--- a/core/resources/src/commonMain/composeResources/values-cs/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-cs/strings.xml
@@ -815,7 +815,6 @@
     <string name="mqtt_status_connected">Připojeno</string>
     <string name="mqtt_status_disconnected">Odpojeno</string>
     <string name="mqtt_test_connection">Test připojení</string>
-    <string name="must_set_region">Musíte nastavit region!</string>
     <string name="must_update">Musíte aktualizovat aplikaci v obchodu Google Play (nebo z Githubu). Je příliš stará pro komunikaci s touto verzí firmware vysílače. Přečtěte si prosím naše <a href="https://meshtastic.org/docs/software/android/installation">dokumenty</a> na toto téma.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 týden</string>

--- a/core/resources/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-de/strings.xml
@@ -860,7 +860,6 @@
     <string name="mqtt_status_reconnecting">Erneut verbinden…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Erneut verbinden (Versuch %1$d) - %2$s</string>
     <string name="mqtt_test_connection">Verbindung testen</string>
-    <string name="must_set_region">Sie müssen eine Region festlegen!</string>
     <string name="must_update">Sie müssen diese App über den App Store (oder Github) aktualisieren. Sie ist zu alt, um mit dieser Funkgeräte Firmware zu kommunizieren. Bitte lesen Sie unsere  <a href="https://meshtastic.org/docs/software/android/installation">Dokumentation</a> zu diesem Thema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">Eine Woche</string>

--- a/core/resources/src/commonMain/composeResources/values-el/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-el/strings.xml
@@ -157,7 +157,6 @@
     <!-- MQTT -->
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_disconnected">Αποσυνδεδεμένο</string>
-    <string name="must_set_region">Πρέπει να ορίσετε μια περιοχή!</string>
     <string name="must_update">Πρέπει να ενημερώσετε την εφαρμογή μέσω Google Play store (ή Github). Είναι πολύ παλαιά ώστε να συνδεθεί με το radio.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 εβδομάδα</string>

--- a/core/resources/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-es/strings.xml
@@ -518,7 +518,6 @@ Estos datos de ubicación pueden ser utilizados para fines como aparecer en un m
     <string name="mqtt_enabled">Activar el MQTT</string>
     <string name="mqtt_status_connected">Conectado</string>
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">¡Debe establecer una región!</string>
     <string name="must_update">Debe actualizar esta aplicación en la tienda de aplicaciones (o en Github). Es demasiado vieja para comunicarse con este firmware de radio. Por favor, lea nuestra <a href="https://meshtastic.org/docs/software/android/installation">documentación</a> sobre este tema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-et/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-et/strings.xml
@@ -1089,7 +1089,6 @@
     <string name="mqtt_status_reconnecting">Taas ühendan…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Ühendan uuesti (katse %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Test ühendus</string>
-    <string name="must_set_region">Pead valima regiooni!</string>
     <string name="must_update">Pead seda rakendust rakenduste poes (või Github) värskendama. See on liiga vana selle raadio püsivara jaoks. Loe selle kohta lisateavet meie <a href="https://meshtastic.org/docs/software/android/installation"> dokumentatsioonist </a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 nädal</string>

--- a/core/resources/src/commonMain/composeResources/values-fi/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-fi/strings.xml
@@ -1108,7 +1108,6 @@
     <string name="mqtt_status_reconnecting">Yhdistetään uudelleen…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Yhdistetään uudelleen (yritys %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Testaa yhteys</string>
-    <string name="must_set_region">Sinun täytyy määrittää alue!</string>
     <string name="must_update">Sinun täytyy päivittää tämä sovellus sovelluskaupassa (tai Githubissa). Sovelluksen versio on liian vanha toimimaan tämän radion ohjelmiston kanssa. Ole hyvä ja lue lisää aiheesta <a href="https://meshtastic.org/docs/software/android/installation">dokumenteistamme</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 viikko</string>

--- a/core/resources/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-fr/strings.xml
@@ -827,7 +827,6 @@
     <string name="mqtt_status_reconnecting">Reconnexion…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Reconnexion (tentative %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Test de la connexion</string>
-    <string name="must_set_region">Vous devez définir une région !</string>
     <string name="must_update">Vous devez mettre à jour cette application sur l'app store (ou Github). Il est trop vieux pour dialoguer avec le micrologiciel de la radio. Veuillez lire nos  <a href="https://meshtastic.org/docs/software/android/installation"> docs</a> sur ce sujet.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semaine</string>

--- a/core/resources/src/commonMain/composeResources/values-ga/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ga/strings.xml
@@ -153,7 +153,6 @@
     <string name="module_settings">Cumraíocht an mhódule</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Na ceangailte</string>
-    <string name="must_set_region">Caithfidh tú réigiún a shocrú!</string>
     <string name="must_update">Caithfidh tú an feidhmchlár seo a nuashonrú ón siopa feidhmchláir (nó Github). Tá sé ró-aois chun cumarsáid a dhéanamh leis an firmware raidió seo. Le do thoil, léigh ár <a href="https://meshtastic.org/docs/software/android/installation">doiciméid</a> ar an ábhar seo.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 seachtain</string>

--- a/core/resources/src/commonMain/composeResources/values-gl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-gl/strings.xml
@@ -133,7 +133,6 @@
     <string name="module_settings">Configuración de módulo</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">Tes que seleccionar rexión!</string>
     <string name="must_update">Debe actualizar esta aplicación na tenda (ou Github).  É moi vella para falar con este firmware de radio. Por favor lea a nosa <a href="https://meshtastic.org/docs/software/android/installation">documentación</a> neste tema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-he/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-he/strings.xml
@@ -133,7 +133,6 @@
     <string name="module_settings">הגדרות מודולות</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">מנותק</string>
-    <string name="must_set_region">חובה לבחור אזור!</string>
     <string name="must_update">נדרש להתקין עדכון לאפליקציה זו דרך חנות האפליקציות (או Github). גרסת האפליקציה ישנה מדי בכדי לתקשר עם מכשיר זה. בבקשה קרא <a href="https://meshtastic.org/docs/software/android/installation">מסמכי עזרה</a> בנושא זה.</string>
     <!-- MUTE -->
     <string name="name">שם</string>

--- a/core/resources/src/commonMain/composeResources/values-hr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-hr/strings.xml
@@ -138,7 +138,6 @@
     <string name="module_settings">Konfiguracija modula</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Odspojeno</string>
-    <string name="must_set_region">Potrebno je postaviti regiju!</string>
     <string name="must_update">Potrebno je ažurirati ovu aplikaciju putem Play Storea (ili Githuba). Aplikacija je prestara za komunikaciju s ovim firmwerom radija. Pročitajte našu <a href="https://meshtastic.org/docs/software/android/installation">dokumentaciju</a> o ovoj temi.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 tjedan</string>

--- a/core/resources/src/commonMain/composeResources/values-ht/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ht/strings.xml
@@ -149,7 +149,6 @@
     <string name="module_settings">Konfigirasyon modil</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Dekonekte</string>
-    <string name="must_set_region">Ou dwe mete yon rejyon!</string>
     <string name="must_update">Ou dwe mete aplikasyon sa ajou nan magazen Google Jwèt. Li twò ansyen pou li kominike ak radyo sa a.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semèn</string>

--- a/core/resources/src/commonMain/composeResources/values-hu/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-hu/strings.xml
@@ -517,7 +517,6 @@
     <string name="mqtt_enabled">MQTT engedélyezve</string>
     <string name="mqtt_status_connected">Csatlakoztatva</string>
     <string name="mqtt_status_disconnected">Szétkapcsolva</string>
-    <string name="must_set_region">Be kell állítania egy régiót</string>
     <string name="must_update">Frissítenie kell ezt az alkalmazást a Google Play áruházban (vagy a GitHub-ról), mert túl régi, hogy kommunikálni tudjob ezzel a rádió firmware-rel. Kérem olvassa el a tudnivalókat ebből a <a href="https://meshtastic.org/docs/software/android/installation">docs</a>-ből.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 hét</string>

--- a/core/resources/src/commonMain/composeResources/values-is/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-is/strings.xml
@@ -121,7 +121,6 @@
     <string name="module_settings">Stillingar aukaeininga</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Aftengd</string>
-    <string name="must_set_region">Þú verður að velja svæði!</string>
     <string name="must_update">Þú verður að uppfæra þetta smáforrit í app store (eða Github). Það er of gamalt til að geta talað við fastbúnað þessa radíó. Vinsamlegast lestu <a href="https://meshtastic.org/docs/software/android/installation">leiðbeiningar </a> okkar um þetta mál.</string>
     <!-- MUTE -->
     <string name="name">Heiti</string>

--- a/core/resources/src/commonMain/composeResources/values-it/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-it/strings.xml
@@ -1102,7 +1102,6 @@
     <string name="mqtt_status_reconnecting">Riconnessione…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Riconnessione (tentativo %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Prova la connessione</string>
-    <string name="must_set_region">Devi impostare una regione!</string>
     <string name="must_update">È necessario aggiornare questa applicazione nell'app store (o Github). È troppo vecchio per parlare con questo firmware radio. Per favore leggi i nostri <a href="https://meshtastic.org/docs/software/android/installation">documenti</a> su questo argomento.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 settimana</string>

--- a/core/resources/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ja/strings.xml
@@ -1041,7 +1041,6 @@
     <string name="mqtt_status_reconnecting">再接続しています…</string>
     <string name="mqtt_status_reconnecting_with_attempt">再接続しています（試行 %1$d）：%2$s</string>
     <string name="mqtt_test_connection">接続をテスト</string>
-    <string name="must_set_region">リージョンを指定する必要があります。</string>
     <string name="must_update">アプリが古く、デバイスと通信ができません。アプリストアまたはGithubでアプリを更新してください。詳細は<a href="https://meshtastic.org/docs/software/android/installation">こちら</a> に記載されています。</string>
     <!-- MUTE -->
     <string name="mute_1_week">1週間</string>

--- a/core/resources/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ko/strings.xml
@@ -333,7 +333,6 @@
     <string name="mqtt_enabled">MQTT 활성화</string>
     <string name="mqtt_status_connected">연결됨</string>
     <string name="mqtt_status_disconnected">연결 끊김</string>
-    <string name="must_set_region">지역을 설정해 주세요!</string>
     <string name="must_update">구글 플레이 스토어 또는 깃허브를 통해서 앱을 업데이트 해야합니다. 앱이 너무 구버전입니다. 이 주제의  <a href="https://meshtastic.org/docs/software/android/installation">docs</a> 를 읽어주세요</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 주</string>

--- a/core/resources/src/commonMain/composeResources/values-lt/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-lt/strings.xml
@@ -153,7 +153,6 @@
     <string name="module_settings">Modulio konfigūracija</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Atsijungta</string>
-    <string name="must_set_region">Turite nustatyti regioną!</string>
     <string name="must_update">Urite atnaujinti šią programą programėlių parduotuvėje (arba Github). Ji per sena, kad galėtų bendrauti su šiuo radijo įrangos programinės įrangos versija. Prašome perskaityti mūsų <a href="https://meshtastic.org/docs/software/android/installation">dokumentaciją</a> šia tema.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 savaitė</string>

--- a/core/resources/src/commonMain/composeResources/values-nl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-nl/strings.xml
@@ -263,7 +263,6 @@
     <string name="mqtt_enabled">MQTT ingeschakeld</string>
     <string name="mqtt_status_connected">Verbonden</string>
     <string name="mqtt_status_disconnected">Niet verbonden</string>
-    <string name="must_set_region">Je moet een regio instellen!</string>
     <string name="must_update">Applicatie update noodzakelijk in Google Play store (of Github). Deze versie is te oud om te praten met deze radio.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 week</string>

--- a/core/resources/src/commonMain/composeResources/values-no/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-no/strings.xml
@@ -156,7 +156,6 @@
     <string name="module_settings">Modul konfigurasjon</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Frakoblet</string>
-    <string name="must_set_region">Du må angi en region!</string>
     <string name="must_update">Du må oppdatere denne applikasjonen på Google Play store (eller Github). Den er for gammel til å snakke med denne radioen.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 uke</string>

--- a/core/resources/src/commonMain/composeResources/values-pl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-pl/strings.xml
@@ -492,7 +492,6 @@
     <string name="mqtt_enabled">Włącz MQTT</string>
     <string name="mqtt_status_connected">Połączony</string>
     <string name="mqtt_status_disconnected">Rozłączono</string>
-    <string name="must_set_region">Musisz ustawić region!</string>
     <string name="must_update">Należy zaktualizować aplikację za pomocą Sklepu Play lub z GitHub, ponieważ aplikacja jest zbyt stara, by skomunikować się z oprogramowaniem zainstalowanym na tym urządzeniu. <a href="https://meshtastic.org/docs/software/android/installation">Więcej informacji (ang.)</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 tydzień</string>

--- a/core/resources/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -402,7 +402,6 @@
     <string name="mqtt_enabled">MQTT habilitado</string>
     <string name="mqtt_status_connected">Conectado</string>
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">Você deve informar uma região!</string>
     <string name="must_update">Será necessário atualizar este aplicativo no Google Play (ou Github). Versão muito antiga para comunicar com o firmware do rádio.  Favor consultar <a href="https://meshtastic.org/docs/software/android/installation">docs</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-pt/strings.xml
@@ -323,7 +323,6 @@
     <string name="mqtt_enabled">MQTT ativo</string>
     <string name="mqtt_status_connected">Ligado</string>
     <string name="mqtt_status_disconnected">Desconectado</string>
-    <string name="must_set_region">Você deve informar uma região!</string>
     <string name="must_update">Tem de atualizar esta aplicação no Google Play (ou Github). A versão é muito antiga para ser possível falar com este rádio.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 semana</string>

--- a/core/resources/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ro/strings.xml
@@ -682,7 +682,6 @@
     <string name="mqtt_enabled">MQTT activat</string>
     <string name="mqtt_status_connected">Conectat</string>
     <string name="mqtt_status_disconnected">Deconectat</string>
-    <string name="must_set_region">Trebuie să alegeți o regiune!</string>
     <string name="must_update">Trebuie să updatezi această aplicație de pe Google Play  (sau Github). Aplicația este prea veche pentru a comunica cu dispozitivul.</string>
     <!-- MUTE -->
     <string name="mute_1_week">O săptămână</string>

--- a/core/resources/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ru/strings.xml
@@ -1115,7 +1115,6 @@
     <string name="mqtt_status_reconnecting">Восстановление связи…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Восстановление (попытка %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Проверить соединение</string>
-    <string name="must_set_region">Вы должны задать регион!</string>
     <string name="must_update">Вам необходимо обновить данное приложение в магазине приложений (или с Github). Оно слишком старо для взаимодействия с прошивкой радиостанции. Пожалуйста, прочитайте нашу <a href="https://meshtastic.org/docs/software/android/installation">документацию</a> по этой теме.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 неделя</string>

--- a/core/resources/src/commonMain/composeResources/values-sk/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sk/strings.xml
@@ -282,7 +282,6 @@
     <string name="mqtt">MQTT</string>
     <string name="mqtt_status_connected">Pripojený</string>
     <string name="mqtt_status_disconnected">Odpojené</string>
-    <string name="must_set_region">Musíte nastaviť región!</string>
     <string name="must_update">Musíte aktualizovať aplikáciu na Google Play store (alebo z Github). Je príliš stará pre komunikáciu s touto verziou firmvéru vysielača. Viac informácií k tejto téme nájdete na <a href="https://meshtastic.org/docs/software/android/installation">Meshtastic docs</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 týždeň</string>

--- a/core/resources/src/commonMain/composeResources/values-sl/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sl/strings.xml
@@ -158,7 +158,6 @@
     <string name="module_settings">Nastavitev modula</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">Prekinjeno</string>
-    <string name="must_set_region">Nastavitev regije!</string>
     <string name="must_update">To aplikacijo morate posodobiti v trgovini Google Play (ali Github). Žal se ne more povezati s tem radiem.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 teden</string>

--- a/core/resources/src/commonMain/composeResources/values-sq/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sq/strings.xml
@@ -155,7 +155,6 @@
     <string name="module_settings">Konfigurimi i modulit</string>
     <!-- MQTT -->
     <string name="mqtt_status_disconnected">I shkëputur</string>
-    <string name="must_set_region">Duhet të vendosni një rajon!</string>
     <string name="must_update">Duhet të përditësoni këtë aplikacion në dyqanin e aplikacioneve (ose Github). Është shumë i vjetër për të komunikuar me këtë firmware radioje. Ju lutemi lexoni dokumentet tona <a href="https://meshtastic.org/docs/software/android/installation">këtu</a> për këtë temë.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 javë</string>

--- a/core/resources/src/commonMain/composeResources/values-sr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sr/strings.xml
@@ -296,7 +296,6 @@
     <string name="mqtt_config">MQTT подешавања</string>
     <string name="mqtt_status_connected">Блутут повезан</string>
     <string name="mqtt_status_disconnected">Raskačeno</string>
-    <string name="must_set_region">Мораш одабрати регион!</string>
     <string name="must_update">Morate da ažurirate ovu aplikaciju na prodavnici aplikacija (ili Github-u). Previše je stara da bi razgovarala sa ovim radio firmverom. Molimo vas da pročitate naše <a href="https://meshtastic.org/docs/software/android/installation">dokumente</a> o ovoj temi.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 седмица</string>

--- a/core/resources/src/commonMain/composeResources/values-srp/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-srp/strings.xml
@@ -296,7 +296,6 @@
     <string name="mqtt_config">MQTT подешавања</string>
     <string name="mqtt_status_connected">Блутут повезан</string>
     <string name="mqtt_status_disconnected">Раскачено</string>
-    <string name="must_set_region">Мораш одабрати регион!</string>
     <string name="must_update">Морате ажурирати ову апликацију у продавници апликација (или на Гитхабу). Превише је стара да би могла комуницирати са овим радио фирмвером. Молимо вас да прочитате наша &lt;a href='https://meshtastic.org/docs/software/android/installation'&gt;документа&lt;/a&gt; на ову тему.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 седмица</string>

--- a/core/resources/src/commonMain/composeResources/values-sv/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-sv/strings.xml
@@ -780,7 +780,6 @@
     <string name="mqtt_status_reconnecting">Återansluter…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Återansluter (försök %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Testa anslutningen</string>
-    <string name="must_set_region">Du måste ställa in en region!</string>
     <string name="must_update">Du måste uppdatera detta program i app-butiken (eller Github). Det är för gammalt för att prata med denna radioenhet. Läs vår <a href="https://meshtastic.org/docs/software/android/installation">dokumentation</a> i detta ämne.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 vecka</string>

--- a/core/resources/src/commonMain/composeResources/values-tr/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-tr/strings.xml
@@ -348,7 +348,6 @@
     <string name="mqtt_enabled">MQTT etkin</string>
     <string name="mqtt_status_connected">Bağlandı</string>
     <string name="mqtt_status_disconnected">Bağlantı kesildi</string>
-    <string name="must_set_region">Bölge seçmelisin!</string>
     <string name="must_update">Uygulamayı Google Play store (ya da GitHub)'dan güncelleyin. Bu cihaz ile haberleşmek için uygulama çok eski. İlgili <a href="https://meshtastic.org/docs/software/android/installation"> Dokümantasyon</a>.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 hafta</string>

--- a/core/resources/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-uk/strings.xml
@@ -754,7 +754,6 @@
     <string name="mqtt_status_reconnecting">Роз'єднання…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Роз'єднання (спроба %1$d) - %2$s</string>
     <string name="mqtt_test_connection">Перевірка зʼєднання</string>
-    <string name="must_set_region">Ви повинні встановити регіон!</string>
     <string name="must_update">Ви повинні оновити цю програму в App Store (або Github). Він занадто старий, щоб спілкуватися з цією прошивкою радіо. Будь ласка, прочитайте нашу <a href="https://meshtastic.org/docs/software/android/installation">документацію</a> у вказаній темі.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 тиждень</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -1095,7 +1095,6 @@
     <string name="mqtt_status_reconnecting">正在重新连接…</string>
     <string name="mqtt_status_reconnecting_with_attempt">正在重新连接 (尝试 %1$d) — %2$s</string>
     <string name="mqtt_test_connection">连接测试</string>
-    <string name="must_set_region">您必须先选择一个地区</string>
     <string name="must_update">您必须在应用商店或 Github上更新此应用程序。程序太旧了以至于无法与此装置进行通讯。 请阅读有关此主题的 <a href="https://meshtastic.org/docs/software/android/installation">文档</a>。</string>
     <!-- MUTE -->
     <string name="mute_1_week">1周</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -805,7 +805,6 @@
     <string name="mqtt_status_reconnecting">重新連接中…</string>
     <string name="mqtt_status_reconnecting_with_attempt">重新連接中（第 %1$d 次嘗試） — %2$s</string>
     <string name="mqtt_test_connection">測試連線</string>
-    <string name="must_set_region">您必須設定一個區域！</string>
     <string name="must_update">您必須在應用商店(或 Github)更新此應用程式。它太舊無法與此無線電韌體通訊。請閱讀我們關於此主題的<a href="https://meshtastic.org/docs/software/android/installation">文件</a>。</string>
     <!-- MUTE -->
     <string name="mute_1_week">1週</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -819,6 +819,7 @@
     <string name="ignore_remove">Remove '%1$s' from ignore list?</string>
     <!-- IMPORT -->
     <string name="import_configuration">Import configuration</string>
+    <string name="import_configuration_failed">Unable to import the selected configuration</string>
     <string name="import_export_label">Import/Export</string>
     <string name="import_known_shared_contact_text">Warning: This contact is known, importing will overwrite the previous contact information.</string>
     <string name="import_label">Import</string>
@@ -832,6 +833,13 @@
     <string name="insert_link_message">Enter the URL for the selected text</string>
     <string name="insert_link_title">Insert Link</string>
     <string name="insert_link_url_hint">https://</string>
+    <!-- INSTALL -->
+    <string name="install_configuration_bluetooth_repair_hint">Configuration restored. If Bluetooth does not reconnect, forget this device in Android Bluetooth settings and pair it again.</string>
+    <string name="install_configuration_failed">Unable to apply the selected configuration to the device</string>
+    <string name="install_configuration_in_progress_title">Saving device profile</string>
+    <string name="install_configuration_in_progress_warning">Keep this screen open and avoid using other device functions until saving finishes.</string>
+    <string name="install_configuration_preparing">Preparing device profile…</string>
+    <string name="install_configuration_stage">Saving device profile (stage %1$d of %2$d)…</string>
     <string name="installed_firmware_version">Currently Installed</string>
     <string name="internal">Internal</string>
     <string name="interval_always_on">Always On</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1121,7 +1121,6 @@
     <string name="mqtt_status_reconnecting">Reconnecting…</string>
     <string name="mqtt_status_reconnecting_with_attempt">Reconnecting (attempt %1$d) — %2$s</string>
     <string name="mqtt_test_connection">Test connection</string>
-    <string name="must_set_region">You must set a region!</string>
     <string name="must_update">You must update this application on the app store (or Github). It is too old to talk to this radio firmware.  Please read our <a href="https://meshtastic.org/docs/software/android/installation">docs</a> on this topic.</string>
     <!-- MUTE -->
     <string name="mute_1_week">1 week</string>

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
@@ -18,15 +18,22 @@ package org.meshtastic.core.service
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowSeconds
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
+import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.proto.AdminMessage
@@ -36,6 +43,7 @@ import org.meshtastic.proto.HamParameters
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.OTAMode
 import org.meshtastic.proto.User
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [AdminController] implementation: local/remote configuration, channels, owner, device lifecycle, and the
@@ -51,6 +59,7 @@ internal class AdminControllerImpl(
     private val commandSender: CommandSender,
     private val nodeManager: NodeManager,
     private val radioConfigRepository: RadioConfigRepository,
+    private val connectionStateProvider: ConnectionStateProvider,
     private val scope: CoroutineScope,
 ) : AdminController {
 
@@ -219,9 +228,18 @@ internal class AdminControllerImpl(
     // ── Edit Settings (transactional) ───────────────────────────────────────
 
     override suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit) {
-        commandSender.sendAdmin(destNum) { AdminMessage(begin_edit_settings = true) }
-        EditSettingsSession(destNum).block()
-        commandSender.sendAdmin(destNum) { AdminMessage(commit_edit_settings = true) }
+        requireEditBoundaryAccepted(destNum, "begin") { AdminMessage(begin_edit_settings = true) }
+
+        // Firmware has no abort boundary. Preserve any block failure, including cancellation, only long enough to
+        // attempt the commit that closes the accepted session; the original failure is restored below.
+        val blockResult = runCatching { EditSettingsSession(destNum).block() }
+        val commitResult = runCatching { withContext(NonCancellable) { requireCommitBoundaryAccepted(destNum) } }
+
+        blockResult.exceptionOrNull()?.let { blockFailure ->
+            commitResult.exceptionOrNull()?.takeUnless { it === blockFailure }?.let(blockFailure::addSuppressed)
+            throw blockFailure
+        }
+        commitResult.getOrThrow()
     }
 
     override suspend fun editLocalSettings(block: suspend AdminEditScope.() -> Unit) = editSettings(myNodeNum, block)
@@ -235,10 +253,9 @@ internal class AdminControllerImpl(
         override suspend fun setModuleConfig(config: ModuleConfig) =
             setModuleConfig(destNum, config, commandSender.generatePacketId())
 
-        // Unlike the one-shot setRemoteChannel, a transactional channel write does NOT mirror to the local cache per
-        // slot: importChannelSet owns the cache and writes it once after commit (replaceAllSettings), so an import
-        // interrupted before commit leaves the local channel cache untouched. (Firmware still writes each set_channel
-        // into its in-memory channel table on arrival; only disk persist/reload/reboot is deferred to commit.)
+        // Unlike the one-shot setRemoteChannel, transactional writes do not mirror individual slots into the cache.
+        // Profile installation owns one authoritative cache reconciliation after any channel write is issued, including
+        // failure paths, while the next handshake can still overlay the device's actual non-disabled slots.
         override suspend fun setChannel(channel: Channel) =
             commandSender.sendAdmin(destNum) { AdminMessage(set_channel = channel) }
 
@@ -246,7 +263,45 @@ internal class AdminControllerImpl(
             this@AdminControllerImpl.setFixedPosition(destNum, position)
     }
 
+    /**
+     * Applies back-pressure at transaction boundaries. Ordinary writes are already queued FIFO by [CommandSender], so
+     * waiting for the commit's queue acceptance keeps the caller suspended until the sender has processed every
+     * preceding write. This prevents a rebooting transport write from overtaking an uncommitted profile transaction.
+     */
+    private suspend fun requireEditBoundaryAccepted(destNum: Int, boundary: String, message: () -> AdminMessage) {
+        check(commandSender.sendAdminAwait(destNum, initFn = message)) {
+            "Device rejected or timed out while sending edit-settings $boundary"
+        }
+    }
+
+    private suspend fun requireCommitBoundaryAccepted(destNum: Int) {
+        val isLocalDestination = destNum == nodeManager.myNodeNum.value
+        val departureBaseline = connectionStateProvider.connectionLifecycle.value.epochs.departures
+        val result = commandSender.sendAdminAwaitResult(destNum) { AdminMessage(commit_edit_settings = true) }
+        val stoppedAfterDispatch =
+            isLocalDestination && result.dispatched && result.status == AwaitedSendStatus.TRANSPORT_STOPPED
+        val departedLifecycle =
+            if (stoppedAfterDispatch) {
+                withTimeoutOrNull(COMMIT_DEPARTURE_TIMEOUT) {
+                    connectionStateProvider.connectionLifecycle.first { it.epochs.departures > departureBaseline }
+                }
+            } else {
+                null
+            }
+        val committedBeforeLocalDeparture =
+            stoppedAfterDispatch && departedLifecycle?.epochs?.lastDepartureState is ConnectionState.Disconnected
+
+        check(result.accepted || committedBeforeLocalDeparture) {
+            "Device rejected or timed out while sending edit-settings commit " +
+                "(status=${result.status}, dispatched=${result.dispatched})"
+        }
+        if (committedBeforeLocalDeparture) {
+            Logger.i { "Edit-settings commit dispatched before expected local transport departure" }
+        }
+    }
+
     private companion object {
         private const val DEFAULT_DELAY_SECONDS = 5
+        private val COMMIT_DEPARTURE_TIMEOUT = 2.seconds
     }
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
@@ -27,7 +27,6 @@ import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowSeconds
-import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.AdminEditScope
@@ -44,6 +43,9 @@ import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.OTAMode
 import org.meshtastic.proto.User
 import kotlin.time.Duration.Companion.seconds
+
+internal fun editSettingsCommitFailureMessage(status: AwaitedSendStatus, dispatched: Boolean): String =
+    "Device rejected or timed out while sending edit-settings commit (status=$status, dispatched=$dispatched)"
 
 /**
  * [AdminController] implementation: local/remote configuration, channels, owner, device lifecycle, and the
@@ -288,12 +290,13 @@ internal class AdminControllerImpl(
             } else {
                 null
             }
+        // A dispatched local commit is durable once any post-baseline departure is observed. Firmware may move the
+        // connection through Disconnected, Connecting, or DeviceSleep while rebooting.
         val committedBeforeLocalDeparture =
-            stoppedAfterDispatch && departedLifecycle?.epochs?.lastDepartureState is ConnectionState.Disconnected
+            stoppedAfterDispatch && departedLifecycle?.epochs?.lastDepartureState != null
 
         check(result.accepted || committedBeforeLocalDeparture) {
-            "Device rejected or timed out while sending edit-settings commit " +
-                "(status=${result.status}, dispatched=${result.dispatched})"
+            editSettingsCommitFailureMessage(result.status, result.dispatched)
         }
         if (committedBeforeLocalDeparture) {
             Logger.i { "Edit-settings commit dispatched before expected local transport departure" }
@@ -302,6 +305,6 @@ internal class AdminControllerImpl(
 
     private companion object {
         private const val DEFAULT_DELAY_SECONDS = 5
-        private val COMMIT_DEPARTURE_TIMEOUT = 2.seconds
+        private val COMMIT_DEPARTURE_TIMEOUT = 5.seconds
     }
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
@@ -93,7 +93,7 @@ internal class MessagingControllerImpl(
                 rssi = null,
                 hopsAway = 0,
                 packetId = dataPacket.id,
-                status = MessageStatus.QUEUED,
+                status = dataPacket.status ?: MessageStatus.ERROR,
                 to = destId,
                 channel = channel,
             ),

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.common.database.DatabaseManager
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.CommandSender
@@ -95,7 +97,13 @@ class RadioControllerImpl(
     scope: CoroutineScope,
     private val onDeviceAddressChanged: (() -> Unit)? = null,
 ) : RadioController,
-    AdminController by AdminControllerImpl(commandSender, nodeManager, radioConfigRepository, scope),
+    AdminController by AdminControllerImpl(
+        commandSender = commandSender,
+        nodeManager = nodeManager,
+        radioConfigRepository = radioConfigRepository,
+        connectionStateProvider = serviceRepository,
+        scope = scope,
+    ),
     MessagingController by MessagingControllerImpl(
         commandSender,
         nodeManager,
@@ -195,8 +203,14 @@ class RadioControllerImpl(
 
     // ── Connection State ────────────────────────────────────────────────────
 
+    override val connectionLifecycle: StateFlow<ConnectionLifecycle>
+        get() = serviceRepository.connectionLifecycle
+
     override val connectionState: StateFlow<ConnectionState>
         get() = serviceRepository.connectionState
+
+    override val connectionEpochs: StateFlow<ConnectionEpochs>
+        get() = serviceRepository.connectionEpochs
 
     override val clientNotification: StateFlow<ClientNotification?>
         get() = serviceRepository.clientNotification

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/ServiceRepositoryImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/ServiceRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.service.LockdownTokenInfo
 import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.MeshPacket
@@ -42,13 +43,13 @@ import org.meshtastic.proto.MeshPacket
 open class ServiceRepositoryImpl : ServiceRepository {
 
     // Canonical app-level connection state — written exclusively by MeshConnectionManager.
-    private val _connectionState: MutableStateFlow<ConnectionState> = MutableStateFlow(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState>
-        get() = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionLifecycle = connectionStateHolder.connectionLifecycle
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
-    override fun setConnectionState(connectionState: ConnectionState) {
-        _connectionState.value = connectionState
-    }
+    override fun setConnectionState(connectionState: ConnectionState) =
+        connectionStateHolder.setConnectionState(connectionState)
 
     private val _clientNotification = MutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?>

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -984,7 +984,7 @@ class SharedRadioInterfaceService(
         val admitted =
             admitTransportSend()
                 ?: run {
-                    Logger.w { "sendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
+                    Logger.w { "trySendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
                     return false
                 }
         return try {
@@ -992,7 +992,7 @@ class SharedRadioInterfaceService(
                 admitted.transport.handleSendToRadio(bytes)
                 _meshActivity.tryEmit(MeshActivity.Send)
             }
-                .onFailure { Logger.w(it) { "sendToRadio: active transport rejected ${bytes.size} bytes" } }
+                .onFailure { Logger.w(it) { "trySendToRadio: active transport rejected ${bytes.size} bytes" } }
                 .isSuccess
         } finally {
             releaseSessionOperation(admitted.session)

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -77,6 +77,7 @@ import org.meshtastic.core.repository.ReceivedRadioFrame
 import org.meshtastic.core.repository.TransportDisconnectReason
 import org.meshtastic.proto.ToRadio
 import kotlin.concurrent.Volatile
+import kotlin.time.TimeSource
 
 private const val USB_PERMISSION_DENIED_ERROR = "USB permission denied. Reconnect the device to try again."
 
@@ -387,17 +388,19 @@ class SharedRadioInterfaceService(
 
     @Volatile private var lastDataReceivedMillis = 0L
 
+    private val monotonicStart = TimeSource.Monotonic.markNow()
+
     /**
-     * Internal test seam for deterministic clock injection. Production uses [nowMillis]; tests override this to a
-     * controllable clock so [onConnect], [handleFromRadio], [checkLiveness], and [keepAlive] all share one coherent
-     * time source. Not a constructor parameter to avoid breaking Koin @Single annotation generation (which would try to
-     * resolve `() -> Long` from the DI graph).
+     * Internal test seam for deterministic clock injection. Production uses monotonic elapsed time; tests override this
+     * to a controllable clock so [onConnect], [handleFromRadio], [checkLiveness], and [keepAlive] all share one
+     * coherent time source. Not a constructor parameter to avoid breaking Koin @Single annotation generation (which
+     * would try to resolve `() -> Long` from the DI graph).
      */
     @Volatile
     @Suppress("MemberVisibilityCanBePrivate")
-    internal var clockMillis: () -> Long = { nowMillis }
+    internal var clockMillis: () -> Long = { monotonicStart.elapsedNow().inWholeMilliseconds }
 
-    /** The current time from the injected clock. */
+    /** The current elapsed time from the injected clock. */
     private fun now(): Long = clockMillis()
 
     companion object {
@@ -885,13 +888,25 @@ class SharedRadioInterfaceService(
 
     private fun startHeartbeat() {
         heartbeatJob?.cancel()
-        lastDataReceivedMillis = now()
+        val startedAt = now()
+        lastDataReceivedMillis = startedAt
+        lastHeartbeatMillis = startedAt
         heartbeatJob =
             serviceScope.launch {
+                var previousHeartbeatMillis = startedAt
                 while (true) {
                     delay(HEARTBEAT_INTERVAL_MILLIS)
-                    keepAlive()
-                    checkLiveness()
+                    val tickNow = now()
+                    val heartbeatCadenceGapMs = tickNow - previousHeartbeatMillis
+                    keepAlive(tickNow)
+                    previousHeartbeatMillis = tickNow
+                    if (heartbeatCadenceGapMs <= LIVENESS_TIMEOUT_MILLIS) {
+                        checkLiveness()
+                    } else {
+                        // A full heartbeat-loop gap cannot prove peer silence; local scheduling may be the cause.
+                        // Give the fresh probe one normal interval to answer before recovery.
+                        Logger.d { "Deferring liveness check after ${heartbeatCadenceGapMs}ms heartbeat gap" }
+                    }
                 }
             }
     }
@@ -972,7 +987,7 @@ class SharedRadioInterfaceService(
     }
 
     fun keepAlive(now: Long = now()) {
-        if (now - lastHeartbeatMillis > HEARTBEAT_INTERVAL_MILLIS) {
+        if (now - lastHeartbeatMillis >= HEARTBEAT_INTERVAL_MILLIS) {
             radioTransport?.keepAlive()
             lastHeartbeatMillis = now
         }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -55,9 +55,9 @@ import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.ble.BluetoothRepository
 import org.meshtastic.core.common.di.PROCESS_LIFECYCLE
-import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.ignoreExceptionSuspend
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
@@ -207,7 +207,7 @@ class SharedRadioInterfaceService(
     /** Guarded by [sessionCallbackLock]. New work is rejected immediately when teardown closes this gate. */
     private var sessionAdmissionOpen = false
 
-    /** Number of suspend operations admitted for [activeTransportSession], guarded by [sessionCallbackLock]. */
+    /** Number of operations admitted for [activeTransportSession], guarded by [sessionCallbackLock]. */
     private var admittedSessionOperations = 0
 
     /** Completed by the last admitted operation after teardown closes admission. Guarded by [sessionCallbackLock]. */
@@ -253,25 +253,41 @@ class SharedRadioInterfaceService(
             block(lease)
             return true
         } finally {
-            val drainWaiter =
-                synchronized(sessionCallbackLock) {
-                    check(activeTransportSession === admittedSession) {
-                        "Session changed before an admitted operation released its lease"
-                    }
-                    check(admittedSessionOperations > 0) { "Session operation count underflow" }
-                    admittedSessionOperations--
-                    if (admittedSessionOperations == 0) {
-                        sessionDrainWaiter.also { sessionDrainWaiter = null }
-                    } else {
-                        null
-                    }
-                }
-            drainWaiter?.complete(Unit)
+            releaseSessionOperation(admittedSession)
         }
     }
 
     override suspend fun runWhileSessionActive(session: RadioSessionContext, block: suspend () -> Unit): Boolean =
         sessionOperationMutex.withLock { runWithSessionLease(session) { block() } }
+
+    private fun releaseSessionOperation(admittedSession: RadioTransportSession) {
+        val drainWaiter =
+            synchronized(sessionCallbackLock) {
+                check(activeTransportSession === admittedSession) {
+                    "Session changed before an admitted operation released its lease"
+                }
+                check(admittedSessionOperations > 0) { "Session operation count underflow" }
+                admittedSessionOperations--
+                if (admittedSessionOperations == 0) {
+                    sessionDrainWaiter.also { sessionDrainWaiter = null }
+                } else {
+                    null
+                }
+            }
+        drainWaiter?.complete(Unit)
+    }
+
+    private data class AdmittedTransportSend(val session: RadioTransportSession, val transport: RadioTransport)
+
+    /** Admits one synchronous transport handoff under the same gate drained by [revokeTransportSession]. */
+    private fun admitTransportSend(): AdmittedTransportSend? = synchronized(sessionCallbackLock) admission@{
+        if (!sessionAdmissionOpen || isStopping) return@admission null
+        val session = activeTransportSession ?: return@admission null
+        val transport = radioTransport ?: return@admission null
+
+        admittedSessionOperations++
+        AdmittedTransportSend(session = session, transport = transport)
+    }
 
     /** Runs a callback only while [session] still owns admission, atomically with session teardown. */
     private inline fun runIfTransportSessionActive(session: RadioTransportSession, block: () -> Unit): Boolean =
@@ -337,12 +353,13 @@ class SharedRadioInterfaceService(
         get() = _serviceScope
 
     private var _serviceScope = CoroutineScope(dispatchers.io + SupervisorJob())
-    private var radioTransport: RadioTransport? = null
+
+    @Volatile private var radioTransport: RadioTransport? = null
     private var runningTransportId: InterfaceId? = null
     private var isStarted = false
 
     /**
-     * Set while [stopTransportLocked] is draining the polite disconnect frame. [sendToRadio] checks this so any late
+     * Set while [stopTransportLocked] is draining the polite disconnect frame. [trySendToRadio] checks this so any late
      * traffic submitted after we've announced disconnection is dropped rather than racing in front of the firmware-side
      * link teardown.
      */
@@ -781,7 +798,27 @@ class SharedRadioInterfaceService(
                 _connectionState.value = connectionStateBeforeStart
                 throw failure
             }
-        radioTransport = newTransport
+        val published =
+            synchronized(sessionCallbackLock) {
+                if (activeTransportSession !== session || !sessionAdmissionOpen) {
+                    false
+                } else {
+                    radioTransport = newTransport
+                    true
+                }
+            }
+        if (!published) {
+            // Revocation already closed this session's admission and owns the canonical lifecycle rollback. Do not
+            // restore connectionStateBeforeStart here; that would overwrite the newer teardown state.
+            val publicationFailure =
+                IllegalStateException("Transport session was revoked before its transport could be published")
+            try {
+                withContext(NonCancellable) { newTransport.close() }
+            } catch (closeFailure: Exception) {
+                publicationFailure.addSuppressed(closeFailure)
+            }
+            throw publicationFailure
+        }
         runningTransportId = address.firstOrNull()?.let { InterfaceId.forIdChar(it) }
         isStarted = true
         startHeartbeat()
@@ -941,25 +978,24 @@ class SharedRadioInterfaceService(
         }
     }
 
-    override fun sendToRadio(bytes: ByteArray) {
-        if (isStopping) {
-            Logger.d { "sendToRadio: transport stopping, dropping ${bytes.size} bytes" }
-            return
-        }
-        // Snapshot the transport to avoid calling handleSendToRadio on a null reference.
-        // There is still a benign race: stopTransportLocked() may cancel _serviceScope
-        // between the null-check and the launch, causing the coroutine to be silently
-        // dropped. This is acceptable — if the transport is shutting down, dropping the
-        // send is the correct behavior.
-        val currentTransport =
-            radioTransport
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
+        // Admission and teardown share one session gate. Once accepted, teardown drains the synchronous handoff before
+        // revoking the session; transport implementations still own their asynchronous delivery outcome.
+        val admitted =
+            admitTransportSend()
                 ?: run {
-                    Logger.w { "sendToRadio: no active radio transport, dropping ${bytes.size} bytes" }
-                    return
+                    Logger.w { "sendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
+                    return false
                 }
-        _serviceScope.handledLaunch {
-            currentTransport.handleSendToRadio(bytes)
-            _meshActivity.tryEmit(MeshActivity.Send)
+        return try {
+            safeCatching {
+                admitted.transport.handleSendToRadio(bytes)
+                _meshActivity.tryEmit(MeshActivity.Send)
+            }
+                .onFailure { Logger.w(it) { "sendToRadio: active transport rejected ${bytes.size} bytes" } }
+                .isSuccess
+        } finally {
+            releaseSessionOperation(admitted.session)
         }
     }
 

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -31,6 +31,7 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -187,9 +188,6 @@ class RadioControllerImplTest {
             }
         return CommitBoundaryFixture(controller, serviceRepository)
     }
-
-    private fun commitFailureMessage(status: AwaitedSendStatus, dispatched: Boolean): String =
-        "Device rejected or timed out while sending edit-settings commit (status=$status, dispatched=$dispatched)"
 
     @Test
     fun staleAddressIdentityCannotAssociateSelectedTransport() = runTest {
@@ -848,7 +846,7 @@ class RadioControllerImplTest {
         val controller = createController(scope = backgroundScope, myNodeNum = 1234)
         everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
         everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
-            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+            AwaitedSendResult(AwaitedSendStatus.RADIO_REJECTED, dispatched = true)
 
         val failure =
             assertFailsWith<IllegalStateException> {
@@ -860,7 +858,7 @@ class RadioControllerImplTest {
             }
 
         assertEquals(
-            "Device rejected or timed out while sending edit-settings commit (status=REJECTED, dispatched=true)",
+            editSettingsCommitFailureMessage(AwaitedSendStatus.RADIO_REJECTED, dispatched = true),
             failure.message,
         )
         verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
@@ -895,17 +893,14 @@ class RadioControllerImplTest {
         val controller = createController(scope = backgroundScope, myNodeNum = 1234)
         everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
         everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
-            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+            AwaitedSendResult(AwaitedSendStatus.RADIO_REJECTED, dispatched = true)
         val blockFailure = IllegalArgumentException("profile write failed")
 
         val failure = assertFailsWith<IllegalArgumentException> { controller.editLocalSettings { throw blockFailure } }
 
         assertSame(blockFailure, failure)
         assertEquals(
-            listOf(
-                "Device rejected or timed out while sending edit-settings commit " +
-                    "(status=REJECTED, dispatched=true)",
-            ),
+            listOf(editSettingsCommitFailureMessage(AwaitedSendStatus.RADIO_REJECTED, dispatched = true)),
             failure.suppressedExceptions.map(Throwable::message),
         )
         verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
@@ -927,14 +922,17 @@ class RadioControllerImplTest {
 
     @Test
     fun editSettingsWaitsForCanonicalDepartureAfterTransportStops() = runTest {
+        var stateAtCommitReturn: ConnectionState? = null
         val (controller, serviceRepository) =
             createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
                 backgroundScope.launch { serviceRepository.setConnectionState(ConnectionState.Disconnected) }
+                stateAtCommitReturn = serviceRepository.connectionState.value
                 AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
             }
 
         controller.editLocalSettings {}
 
+        assertEquals(ConnectionState.Connected, stateAtCommitReturn)
         verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
         assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
     }
@@ -965,7 +963,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false),
+            failure.message,
+        )
     }
 
     @Test
@@ -977,7 +978,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true),
+            failure.message,
+        )
     }
 
     @Test
@@ -990,20 +994,56 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TIMED_OUT, dispatched = true), failure.message)
+        assertEquals(editSettingsCommitFailureMessage(AwaitedSendStatus.TIMED_OUT, dispatched = true), failure.message)
     }
 
     @Test
-    fun editSettingsRejectsDeviceSleepAsCommitAcceptance() = runTest {
+    fun editSettingsAcceptsDeviceSleepAsPostDispatchDeparture() = runTest {
+        var departuresAtCommit = 0L
+        var departuresAfterSleep = 0L
         val (controller, _) =
             createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                departuresAtCommit = serviceRepository.connectionLifecycle.value.epochs.departures
                 serviceRepository.setConnectionState(ConnectionState.DeviceSleep)
+                departuresAfterSleep = serviceRepository.connectionLifecycle.value.epochs.departures
                 AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
             }
 
-        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+        controller.editLocalSettings {}
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertTrue(
+            departuresAfterSleep > departuresAtCommit,
+            "DeviceSleep must publish a departure before the commit result is evaluated",
+        )
+    }
+
+    @Test
+    fun editSettingsAcceptsConnectingAsPostDispatchDeparture() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { repository ->
+                repository.setConnectionState(ConnectionState.Connecting)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        assertEquals(ConnectionState.Connecting, serviceRepository.connectionState.value)
+    }
+
+    @Test
+    fun editSettingsAcceptsDepartureThatArrivesAfterTwoSeconds() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { repository ->
+                backgroundScope.launch {
+                    delay(3_000)
+                    repository.setConnectionState(ConnectionState.Disconnected)
+                }
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
     }
 
     @Test
@@ -1016,7 +1056,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 5678) {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true),
+            failure.message,
+        )
     }
 
     @Test
@@ -1029,7 +1072,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 0) {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true),
+            failure.message,
+        )
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -41,6 +41,8 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.ConnectionIdentity
 import org.meshtastic.core.repository.MeshDataHandler
@@ -70,6 +72,7 @@ import org.meshtastic.proto.User
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -163,6 +166,30 @@ class RadioControllerImplTest {
             onDeviceAddressChanged = onDeviceAddressChanged,
         )
     }
+
+    private data class CommitBoundaryFixture(
+        val controller: RadioControllerImpl,
+        val serviceRepository: ServiceRepositoryImpl,
+    )
+
+    private fun createCommitBoundaryFixture(
+        scope: CoroutineScope,
+        myNodeNum: Int? = 1234,
+        commitResult: (ServiceRepositoryImpl) -> AwaitedSendResult,
+    ): CommitBoundaryFixture {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller = createController(scope = scope, myNodeNum = myNodeNum, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                commitResult(serviceRepository)
+            }
+        return CommitBoundaryFixture(controller, serviceRepository)
+    }
+
+    private fun commitFailureMessage(status: AwaitedSendStatus, dispatched: Boolean): String =
+        "Device rejected or timed out while sending edit-settings commit (status=$status, dispatched=$dispatched)"
 
     @Test
     fun staleAddressIdentityCannotAssociateSelectedTransport() = runTest {
@@ -739,9 +766,13 @@ class RadioControllerImplTest {
         verifySuspend { commandSender.sendAdmin(any(), any(), any(), any()) }
     }
 
+    private fun acceptedSendResult() = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
     @Test
     fun editLocalSettingsChannelWritesDoNotMirrorToLocalCache() = runTest {
         val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
 
         controller.editLocalSettings {
             setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "A")))
@@ -749,14 +780,279 @@ class RadioControllerImplTest {
         }
         advanceUntilIdle()
 
-        // Exactly 4 admin packets: begin + 2 channel writes + commit. The tight count also catches a duplicated
-        // begin/commit or an accidental double-write per channel.
-        verifySuspend(exactly(4)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+        // Exactly four packets: awaited begin + 2 channel writes + awaited commit. The tight count also catches a
+        // duplicated boundary or an accidental double-write per channel.
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(2)) { commandSender.sendAdmin(any(), any(), any(), any()) }
         // A transactional channel write must NOT eagerly mirror to the local cache the way one-shot
         // setRemoteChannel does for the local node. importChannelSet owns the cache and writes it once after commit
         // (replaceAllSettings), so an interrupted import can't leave partial channels cached. A regression to
         // per-slot mirroring inside the session would make this call count non-zero.
         verifySuspend(exactly(0)) { radioConfigRepository.updateChannelSettings(any()) }
+    }
+
+    @Test
+    fun editSettingsAwaitsBoundariesAroundOrderedWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        val sentMessages = mutableListOf<AdminMessage>()
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+                true
+            }
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+                acceptedSendResult()
+            }
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+            }
+
+        controller.editLocalSettings {
+            setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "Primary")))
+            setChannel(
+                Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "Secondary")),
+            )
+        }
+
+        assertEquals(4, sentMessages.size)
+        assertEquals(true, sentMessages[0].begin_edit_settings)
+        assertEquals(0, sentMessages[1].set_channel?.index)
+        assertEquals(1, sentMessages[2].set_channel?.index)
+        assertEquals(true, sentMessages[3].commit_edit_settings)
+    }
+
+    @Test
+    fun editSettingsRejectsFailedBeginBeforeRunningWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns false
+        var blockRan = false
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { blockRan = true } }
+
+        assertEquals("Device rejected or timed out while sending edit-settings begin", failure.message)
+        assertFalse(blockRan)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(0)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(0)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsReportsFailedCommitAfterOrderedWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
+            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                controller.editLocalSettings {
+                    setChannel(
+                        Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "Primary")),
+                    )
+                }
+            }
+
+        assertEquals(
+            "Device rejected or timed out while sending edit-settings commit (status=REJECTED, dispatched=true)",
+            failure.message,
+        )
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsCommitsAfterWriteFailureAndRethrowsOriginal() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        val writeFailure = IllegalArgumentException("profile write failed")
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } throws writeFailure
+
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                controller.editLocalSettings {
+                    setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "A")))
+                }
+            }
+
+        assertSame(writeFailure, failure)
+        assertTrue(failure.suppressedExceptions.isEmpty())
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsSuppressesCommitFailureOnBlockFailure() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
+            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+        val blockFailure = IllegalArgumentException("profile write failed")
+
+        val failure = assertFailsWith<IllegalArgumentException> { controller.editLocalSettings { throw blockFailure } }
+
+        assertSame(blockFailure, failure)
+        assertEquals(
+            listOf(
+                "Device rejected or timed out while sending edit-settings commit " +
+                    "(status=REJECTED, dispatched=true)",
+            ),
+            failure.suppressedExceptions.map(Throwable::message),
+        )
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsAcceptsDispatchedCommitWhenLocalTransportDeparts() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsWaitsForCanonicalDepartureAfterTransportStops() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                backgroundScope.launch { serviceRepository.setConnectionState(ConnectionState.Disconnected) }
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
+    }
+
+    @Test
+    fun editSettingsAcceptsCapturedDisconnectAfterFastReconnect() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                serviceRepository.setConnectionState(ConnectionState.Connecting)
+                serviceRepository.setConnectionState(ConnectionState.Connected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        assertEquals(ConnectionState.Connected, serviceRepository.connectionState.value)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsRejectsTransportStopBeforeCommitTransmission() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false), failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsTransportStopWithoutObservedDeparture() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) {
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsTimeoutEvenWhenLocalTransportDeparts() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TIMED_OUT, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TIMED_OUT, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsDeviceSleepAsCommitAcceptance() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.DeviceSleep)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsDoesNotTreatLocalDepartureAsRemoteCommitAcceptance() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 5678) {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsDoesNotTreatDestinationZeroAsLocalWhenNodeIdentityIsUnknown() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope, myNodeNum = null) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 0) {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsCommitsWhenCallerIsCancelled() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
+        val blockStarted = CompletableDeferred<Unit>()
+        val keepBlockOpen = CompletableDeferred<Unit>()
+
+        val job = launch {
+            controller.editLocalSettings {
+                blockStarted.complete(Unit)
+                keepBlockOpen.await()
+            }
+        }
+        blockStarted.await()
+        job.cancel(CancellationException("cancel profile restore"))
+        job.join()
+
+        assertTrue(job.isCancelled)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
+import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.TracerouteResponse
 import kotlin.test.Test
@@ -39,6 +40,7 @@ class ServiceRepositoryImplTest {
         val repository = ServiceRepositoryImpl()
 
         assertEquals(ConnectionState.Disconnected, repository.connectionState.value)
+        assertEquals(ConnectionEpochs(), repository.connectionEpochs.value)
         assertNull(repository.clientNotification.value)
         assertNull(repository.errorMessage.value)
         assertNull(repository.connectionProgress.value)
@@ -63,6 +65,33 @@ class ServiceRepositoryImplTest {
 
         assertEquals(ConnectionState.Connecting, emittedState.await())
         assertEquals(ConnectionState.Connecting, repository.connectionState.value)
+    }
+
+    @Test
+    fun connectionEpochsPreserveRapidDepartureAndHandshakeTransitions() = runTest {
+        val repository = ServiceRepositoryImpl()
+        repository.setConnectionState(ConnectionState.Connected)
+        val baseline = repository.connectionEpochs.value
+
+        repository.setConnectionState(ConnectionState.Disconnected)
+        repository.setConnectionState(ConnectionState.Connecting)
+        repository.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, repository.connectionState.value)
+        assertEquals(baseline.departures + 1, repository.connectionEpochs.value.departures)
+        assertEquals(baseline.completedHandshakes + 1, repository.connectionEpochs.value.completedHandshakes)
+    }
+
+    @Test
+    fun duplicateConnectionStatesDoNotAdvanceEpochs() = runTest {
+        val repository = ServiceRepositoryImpl()
+        repository.setConnectionState(ConnectionState.Connected)
+        val afterHandshake = repository.connectionEpochs.value
+
+        repository.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), afterHandshake)
+        assertEquals(afterHandshake, repository.connectionEpochs.value)
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
@@ -80,6 +80,8 @@ class ServiceRepositoryImplTest {
         assertEquals(ConnectionState.Connected, repository.connectionState.value)
         assertEquals(baseline.departures + 1, repository.connectionEpochs.value.departures)
         assertEquals(baseline.completedHandshakes + 1, repository.connectionEpochs.value.completedHandshakes)
+        assertEquals(baseline.completedHandshakes, repository.connectionEpochs.value.handshakesAtLastDeparture)
+        assertEquals(ConnectionState.Disconnected, repository.connectionEpochs.value.lastDepartureState)
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -220,6 +220,33 @@ class SharedRadioInterfaceServiceLivenessTest {
         }
     }
 
+    /** Triggers a liveness restart from inside one synchronous send handoff. */
+    private class ReentrantRestartTransport(private val requestRestart: () -> Unit) : RadioTransport {
+        var handoffCompleted = false
+            private set
+
+        var closeCalled = false
+            private set
+
+        var closeObservedBeforeHandoff = false
+            private set
+
+        private var restartRequested = false
+
+        override fun handleSendToRadio(p: ByteArray) {
+            if (!restartRequested) {
+                restartRequested = true
+                requestRestart()
+            }
+            handoffCompleted = true
+        }
+
+        override suspend fun close() {
+            closeCalled = true
+            closeObservedBeforeHandoff = !handoffCompleted
+        }
+    }
+
     /** Controllable clock — tests advance this manually so all time comparisons are deterministic. */
     private var clock: Long = 0L
 
@@ -656,6 +683,46 @@ class SharedRadioInterfaceServiceLivenessTest {
 
             val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
             assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    @Test
+    fun `transport teardown drains a synchronously admitted send before close`() = runTest(testDispatcher) {
+        val transports = mutableListOf<RadioTransport>()
+        lateinit var service: SharedRadioInterfaceService
+        lateinit var initialTransport: ReentrantRestartTransport
+        val transportProvider: () -> RadioTransport = {
+            if (transports.isEmpty()) {
+                ReentrantRestartTransport {
+                    clock = 65_000L
+                    service.checkLiveness()
+                }
+                    .also {
+                        initialTransport = it
+                        transports += it
+                    }
+            } else {
+                FakeRadioTransport().also { transports += it }
+            }
+        }
+
+        clock = 0L
+        service = createConnectedService("xAA:BB:CC:DD:EE:FF", transportProvider)
+        try {
+            val accepted = service.trySendToRadio(byteArrayOf(1, 2, 3))
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(accepted)
+            assertTrue(initialTransport.handoffCompleted)
+            assertTrue(initialTransport.closeCalled)
+            assertFalse(
+                initialTransport.closeObservedBeforeHandoff,
+                "teardown must wait until the admitted handoff releases its session lease",
+            )
+            assertEquals(2, transports.size, "the liveness restart should publish one replacement transport")
         } finally {
             service.disconnect()
             advanceTimeBy(1_000L)

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -516,7 +516,87 @@ class SharedRadioInterfaceServiceLivenessTest {
             assertTrue(createdTransports.single().closeCalled, "cancellation must not strand the revoked transport")
         }
 
+    @Test
+    fun `heartbeat sends at the exact interval boundary`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        val transport = createdTransports.single()
+        try {
+            clock = 30_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(transport.keepAliveCalled, "The 30-second boundary must send the scheduled heartbeat")
+            assertFalse(transport.closeCalled)
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    @Test
+    fun `delayed heartbeat wakeup gets a response window before liveness recovery`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        val transport = createdTransports.single()
+        try {
+            // A first tick just beyond the liveness window has no earlier heartbeat proving peer silence.
+            // It must send a fresh probe and defer recovery long enough for that probe to answer.
+            clock = 61_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(transport.keepAliveCalled, "A delayed heartbeat wakeup must still probe the transport")
+            assertFalse(transport.closeCalled, "The fresh probe must get one heartbeat interval to answer")
+            assertEquals(1, createdTransports.size)
+
+            // If the fresh probe receives no response, the next normal heartbeat tick may recover the zombie
+            // session.
+            clock = 91_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertTrue(
+                transport.closeCalled,
+                "A silent peer must still be recovered after the probe grace interval",
+            )
+            assertEquals(2, createdTransports.size)
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
     // ─── BLE: Liveness timeout triggers recovery ───────────────────────────────────────────────
+
+    @Test
+    fun `response to delayed heartbeat prevents liveness recovery`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        val transport = createdTransports.single()
+        try {
+            clock = 120_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(transport.keepAliveCalled, "A delayed wakeup must send a fresh heartbeat probe")
+            service.handleFromRadio(byteArrayOf(1))
+
+            clock = 150_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertFalse(
+                transport.closeCalled,
+                "A response during the probe grace interval must preserve the session",
+            )
+            assertEquals(1, createdTransports.size)
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
 
     @Test
     fun `BLE liveness timeout closes old transport and creates fresh one`() = runTest(testDispatcher) {

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -16,7 +16,6 @@
  */
 package org.meshtastic.core.takserver
 
-import co.touchlab.kermit.Severity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,24 +27,21 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
-import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeSortOption
 import org.meshtastic.core.model.Position
-import org.meshtastic.core.model.service.LockdownState
-import org.meshtastic.core.model.service.LockdownTokenInfo
-import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.MeshConfigHandler
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioSessionContext
-import org.meshtastic.core.repository.ServiceRepository
+import org.meshtastic.core.testing.FakeServiceRepository
 import org.meshtastic.proto.AdminMessage
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
-import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Data
 import org.meshtastic.proto.DeviceMetadata
@@ -134,14 +130,12 @@ class TAKMeshIntegrationTest {
             initFn: () -> AdminMessage,
         ) {}
 
-        override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {}
-
-        override suspend fun sendAdminAwait(
+        override suspend fun sendAdminAwaitResult(
             destNum: Int,
             requestId: Int,
             wantResponse: Boolean,
             initFn: () -> AdminMessage,
-        ): Boolean = true
+        ): AwaitedSendResult = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
 
         override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) {}
 
@@ -166,61 +160,6 @@ class TAKMeshIntegrationTest {
         ) {}
 
         override fun sendLockNow() {}
-    }
-
-    private class FakeServiceRepository : ServiceRepository {
-        private val _meshPacketFlow = MutableSharedFlow<MeshPacket>(replay = 1, extraBufferCapacity = 64)
-        override val meshPacketFlow: Flow<MeshPacket> = _meshPacketFlow
-
-        override val connectionState: StateFlow<ConnectionState> = MutableStateFlow(ConnectionState.Disconnected)
-
-        override fun setConnectionState(connectionState: ConnectionState) {}
-
-        override val clientNotification: StateFlow<ClientNotification?> = MutableStateFlow(null)
-
-        override fun setClientNotification(notification: ClientNotification?) {}
-
-        override fun clearClientNotification() {}
-
-        override val errorMessage: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setErrorMessage(text: String, severity: Severity) {}
-
-        override fun clearErrorMessage() {}
-
-        override val connectionProgress: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setConnectionProgress(text: String) {}
-
-        override suspend fun emitMeshPacket(packet: MeshPacket) {
-            _meshPacketFlow.emit(packet)
-        }
-
-        override val tracerouteResponse: StateFlow<TracerouteResponse?> = MutableStateFlow(null)
-
-        override fun setTracerouteResponse(value: TracerouteResponse?) {}
-
-        override fun clearTracerouteResponse() {}
-
-        override val neighborInfoResponse: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setNeighborInfoResponse(value: String?) {}
-
-        override fun clearNeighborInfoResponse() {}
-
-        override val lockdownState: StateFlow<LockdownState> = MutableStateFlow(LockdownState.None)
-
-        override fun setLockdownState(state: LockdownState) {}
-
-        override fun clearLockdownState() {}
-
-        override val lockdownTokenInfo: StateFlow<LockdownTokenInfo?> = MutableStateFlow(null)
-
-        override fun setLockdownTokenInfo(info: LockdownTokenInfo?) {}
-
-        override val sessionAuthorized: StateFlow<Boolean> = MutableStateFlow(false)
-
-        override fun setSessionAuthorized(authorized: Boolean) {}
     }
 
     private class FakeMeshConfigHandler : MeshConfigHandler {

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -27,21 +27,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
-import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeSortOption
-import org.meshtastic.core.model.Position
-import org.meshtastic.core.repository.AwaitedSendResult
-import org.meshtastic.core.repository.AwaitedSendStatus
-import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.MeshConfigHandler
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioSessionContext
+import org.meshtastic.core.testing.FakeCommandSender
 import org.meshtastic.core.testing.FakeServiceRepository
-import org.meshtastic.proto.AdminMessage
 import org.meshtastic.proto.Channel
-import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Data
 import org.meshtastic.proto.DeviceMetadata
@@ -106,60 +100,6 @@ class TAKMeshIntegrationTest {
         suspend fun emitInbound(cotMessage: CoTMessage, clientInfo: TAKClientInfo? = null) {
             _inboundMessages.emit(InboundCoTMessage(cotMessage, clientInfo))
         }
-    }
-
-    private class FakeCommandSender : CommandSender {
-        val sentPackets = mutableListOf<DataPacket>()
-
-        override suspend fun sendData(p: DataPacket) {
-            sentPackets.add(p)
-        }
-
-        override fun getCurrentPacketId(): Long = 0L
-
-        override fun getCachedLocalConfig(): LocalConfig = LocalConfig()
-
-        override fun getCachedChannelSet(): ChannelSet = ChannelSet()
-
-        override fun generatePacketId(): Int = 1
-
-        override suspend fun sendAdmin(
-            destNum: Int,
-            requestId: Int,
-            wantResponse: Boolean,
-            initFn: () -> AdminMessage,
-        ) {}
-
-        override suspend fun sendAdminAwaitResult(
-            destNum: Int,
-            requestId: Int,
-            wantResponse: Boolean,
-            initFn: () -> AdminMessage,
-        ): AwaitedSendResult = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
-
-        override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) {}
-
-        override suspend fun requestPosition(destNum: Int, currentPosition: Position) {}
-
-        override suspend fun setFixedPosition(destNum: Int, pos: Position) {}
-
-        override suspend fun requestUserInfo(destNum: Int) {}
-
-        override suspend fun requestTraceroute(requestId: Int, destNum: Int) {}
-
-        override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) {}
-
-        override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {}
-
-        override fun sendLockdownPassphrase(
-            passphrase: String,
-            boots: Int,
-            hours: Int,
-            maxSessionSeconds: Int,
-            disable: Boolean,
-        ) {}
-
-        override fun sendLockNow() {}
     }
 
     private class FakeMeshConfigHandler : MeshConfigHandler {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeCommandSender.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeCommandSender.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.testing
+
+import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.Position
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
+import org.meshtastic.core.repository.CommandSender
+import org.meshtastic.proto.AdminMessage
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.LocalConfig
+
+/** Shared [CommandSender] fake with packet capture and lockdown-command evidence. */
+@Suppress("TooManyFunctions")
+class FakeCommandSender :
+    BaseFake(),
+    CommandSender {
+    val sentPackets = mutableListOf<DataPacket>()
+    val sentAdminMessages = mutableListOf<AdminMessage>()
+
+    var packetIdSnapshot = 0L
+    var localConfigSnapshot = LocalConfig()
+    var channelSetSnapshot = ChannelSet()
+    var nextPacketId = 1
+    var awaitedSendResult = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
+    var lastPassphrase: String? = null
+    var lastBoots = 0
+    var lastHours = 0
+    var lastMaxSessionSeconds = 0
+    var lastDisable = false
+    var lockNowCalled = false
+
+    init {
+        registerResetAction {
+            sentPackets.clear()
+            sentAdminMessages.clear()
+            packetIdSnapshot = 0L
+            localConfigSnapshot = LocalConfig()
+            channelSetSnapshot = ChannelSet()
+            nextPacketId = 1
+            awaitedSendResult = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+            lastPassphrase = null
+            lastBoots = 0
+            lastHours = 0
+            lastMaxSessionSeconds = 0
+            lastDisable = false
+            lockNowCalled = false
+        }
+    }
+
+    override fun getCurrentPacketId(): Long = packetIdSnapshot
+
+    override fun getCachedLocalConfig(): LocalConfig = localConfigSnapshot
+
+    override fun getCachedChannelSet(): ChannelSet = channelSetSnapshot
+
+    override fun generatePacketId(): Int {
+        val id = nextPacketId.coerceAtLeast(1)
+        nextPacketId = if (id == Int.MAX_VALUE) 1 else id + 1
+        packetIdSnapshot = id.toLong()
+        return id
+    }
+
+    override suspend fun sendData(p: DataPacket) {
+        sentPackets.add(p)
+    }
+
+    override suspend fun sendAdmin(destNum: Int, requestId: Int, wantResponse: Boolean, initFn: () -> AdminMessage) {
+        sentAdminMessages.add(initFn())
+    }
+
+    override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {
+        sentAdminMessages.add(initFn())
+    }
+
+    override suspend fun sendAdminAwaitResult(
+        destNum: Int,
+        requestId: Int,
+        wantResponse: Boolean,
+        initFn: () -> AdminMessage,
+    ): AwaitedSendResult {
+        sentAdminMessages.add(initFn())
+        return awaitedSendResult
+    }
+
+    override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) = Unit
+
+    override suspend fun requestPosition(destNum: Int, currentPosition: Position) = Unit
+
+    override suspend fun setFixedPosition(destNum: Int, pos: Position) = Unit
+
+    override suspend fun requestUserInfo(destNum: Int) = Unit
+
+    override suspend fun requestTraceroute(requestId: Int, destNum: Int) = Unit
+
+    override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) = Unit
+
+    override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) = Unit
+
+    override fun sendLockdownPassphrase(
+        passphrase: String,
+        boots: Int,
+        hours: Int,
+        maxSessionSeconds: Int,
+        disable: Boolean,
+    ) {
+        lastPassphrase = passphrase
+        lastBoots = boots
+        lastHours = hours
+        lastMaxSessionSeconds = maxSessionSeconds
+        lastDisable = disable
+    }
+
+    override fun sendLockNow() {
+        lockNowCalled = true
+    }
+}

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeCommandSender.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeCommandSender.kt
@@ -25,6 +25,8 @@ import org.meshtastic.proto.AdminMessage
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.LocalConfig
 
+data class AdminInvocation(val destNum: Int, val requestId: Int, val wantResponse: Boolean, val message: AdminMessage)
+
 /** Shared [CommandSender] fake with packet capture and lockdown-command evidence. */
 @Suppress("TooManyFunctions")
 class FakeCommandSender :
@@ -32,6 +34,7 @@ class FakeCommandSender :
     CommandSender {
     val sentPackets = mutableListOf<DataPacket>()
     val sentAdminMessages = mutableListOf<AdminMessage>()
+    val adminInvocations = mutableListOf<AdminInvocation>()
 
     var packetIdSnapshot = 0L
     var localConfigSnapshot = LocalConfig()
@@ -50,6 +53,7 @@ class FakeCommandSender :
         registerResetAction {
             sentPackets.clear()
             sentAdminMessages.clear()
+            adminInvocations.clear()
             packetIdSnapshot = 0L
             localConfigSnapshot = LocalConfig()
             channelSetSnapshot = ChannelSet()
@@ -82,7 +86,9 @@ class FakeCommandSender :
     }
 
     override suspend fun sendAdmin(destNum: Int, requestId: Int, wantResponse: Boolean, initFn: () -> AdminMessage) {
-        sentAdminMessages.add(initFn())
+        val message = initFn()
+        adminInvocations.add(AdminInvocation(destNum, requestId, wantResponse, message))
+        sentAdminMessages.add(message)
     }
 
     override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {
@@ -95,8 +101,11 @@ class FakeCommandSender :
         wantResponse: Boolean,
         initFn: () -> AdminMessage,
     ): AwaitedSendResult {
-        sentAdminMessages.add(initFn())
-        return awaitedSendResult
+        val result = awaitedSendResult
+        val message = initFn()
+        adminInvocations.add(AdminInvocation(destNum, requestId, wantResponse, message))
+        if (result.dispatched) sentAdminMessages.add(message)
+        return result
     }
 
     override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) = Unit

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioConfigRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioConfigRepository.kt
@@ -93,10 +93,14 @@ class FakeRadioConfigRepository :
     var lastSetModuleConfig: ModuleConfig? = null
         private set
 
+    /** Optional failure thrown by [replaceAllSettings], for exercising reconciliation error paths. */
+    var replaceAllSettingsFailure: Exception? = null
+
     init {
         registerResetAction {
             lastSetLocalConfig = null
             lastSetModuleConfig = null
+            replaceAllSettingsFailure = null
         }
     }
 
@@ -105,6 +109,7 @@ class FakeRadioConfigRepository :
     }
 
     override suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+        replaceAllSettingsFailure?.let { throw it }
         channelSetBacking.value = channelSetBacking.value.copy(settings = settingsList)
     }
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -16,11 +16,14 @@
  */
 package org.meshtastic.core.testing
 
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ClientNotification
@@ -38,8 +41,10 @@ class FakeRadioController :
     RadioController {
 
     /** Canonical app-level connection state, mirroring [ServiceRepository][connectionState] semantics. */
-    private val _connectionState = mutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState> = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionLifecycle = connectionStateHolder.connectionLifecycle
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
     private val _clientNotification = mutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?> = _clientNotification
@@ -48,13 +53,53 @@ class FakeRadioController :
     val favoritedNodes = mutableListOf<Int>()
     val sentSharedContacts = mutableListOf<Int>()
 
-    /** Every [setLocalConfig] call, in order — lets tests assert e.g. that a scan restored the home LoRa preset. */
-    val localConfigs = mutableListOf<Config>()
-    val lastLocalConfig: Config?
-        get() = localConfigs.lastOrNull()
+    /** One local or admin configuration write. Local writes have no destination. */
+    data class ConfigWrite(val destination: Int?, val config: Config)
 
-    /** Every [setLocalChannel] call, in order. */
+    /** One module configuration write, preserving its destination and payload as a single observation. */
+    data class ModuleConfigWrite(val destination: Int, val config: ModuleConfig)
+
+    /** Every local or admin configuration write, preserving destination and call order together. */
+    val configWrites = mutableListOf<ConfigWrite>()
+
+    /** Local configuration payloads in call order. Prefer [configWrites] when destination identity matters. */
+    val localConfigs: List<Config>
+        get() = configWrites.filter { it.destination == null }.map(ConfigWrite::config)
+
+    val lastLocalConfig: Config?
+        get() = configWrites.lastOrNull { it.destination == null }?.config
+
+    /** Every local or admin channel write, in call order. */
     val localChannels = mutableListOf<Channel>()
+
+    /** Every [setFixedPosition] call, in order. */
+    val fixedPositions = mutableListOf<Position>()
+
+    /** Every module configuration write, preserving destination and call order together. */
+    val moduleConfigWrites = mutableListOf<ModuleConfigWrite>()
+
+    /** Module configuration payloads in call order. Prefer [moduleConfigWrites] when destination identity matters. */
+    val moduleConfigs: List<ModuleConfig>
+        get() = moduleConfigWrites.map(ModuleConfigWrite::config)
+
+    /** Destination node for every module configuration write, in order. */
+    val moduleConfigDestinations: List<Int>
+        get() = moduleConfigWrites.map(ModuleConfigWrite::destination)
+
+    /** Destination node for every edit transaction, in order. Local edits use the fake's sentinel value of zero. */
+    val editSettingsDestinations = mutableListOf<Int>()
+
+    /** High-level admin operation order, including edit transaction boundaries. */
+    val adminOperations = mutableListOf<String>()
+
+    /** Test hook invoked after an edit transaction commits. */
+    var onEditSettingsCommitted: suspend () -> Unit = {}
+
+    /** Test hook invoked after a standalone module-config write. */
+    var onStandaloneModuleConfig: suspend (ModuleConfig) -> Unit = {}
+
+    /** Test hook invoked after a standalone general-config write. */
+    var onStandaloneConfig: suspend (Config) -> Unit = {}
 
     var throwOnSend: Boolean = false
 
@@ -81,11 +126,19 @@ class FakeRadioController :
 
     init {
         registerResetAction {
+            connectionStateHolder.reset()
             sentPackets.clear()
             favoritedNodes.clear()
             sentSharedContacts.clear()
-            localConfigs.clear()
+            configWrites.clear()
             localChannels.clear()
+            fixedPositions.clear()
+            moduleConfigWrites.clear()
+            editSettingsDestinations.clear()
+            adminOperations.clear()
+            onEditSettingsCommitted = {}
+            onStandaloneModuleConfig = {}
+            onStandaloneConfig = {}
             throwOnSend = false
             throwOnSetLocalConfig = false
             failChannelWriteAfter = null
@@ -129,7 +182,7 @@ class FakeRadioController :
 
     override suspend fun setLocalConfig(config: Config) {
         if (throwOnSetLocalConfig) error("Fake local config write failure")
-        localConfigs.add(config)
+        configWrites.add(ConfigWrite(destination = null, config = config))
     }
 
     override suspend fun setLocalChannel(channel: Channel) {
@@ -138,22 +191,41 @@ class FakeRadioController :
 
     override suspend fun setOwner(destNum: Int, user: User, packetId: Int) {
         lastSetOwnerUser = user
+        adminOperations.add("owner")
     }
 
     override suspend fun setHamMode(destNum: Int, hamParameters: HamParameters, packetId: Int) {}
 
     override suspend fun setConfig(destNum: Int, config: Config, packetId: Int) {
-        localConfigs.add(config)
+        recordConfigWrite(destNum, config, invokeStandaloneHook = true)
     }
 
-    override suspend fun setModuleConfig(destNum: Int, config: ModuleConfig, packetId: Int) {}
+    override suspend fun setModuleConfig(destNum: Int, config: ModuleConfig, packetId: Int) {
+        recordModuleConfigWrite(destNum, config, invokeStandaloneHook = true)
+    }
+
+    private suspend fun recordConfigWrite(destNum: Int, config: Config, invokeStandaloneHook: Boolean) {
+        configWrites.add(ConfigWrite(destination = destNum, config = config))
+        adminOperations.add("config:update")
+        if (invokeStandaloneHook) onStandaloneConfig(config)
+    }
+
+    private suspend fun recordModuleConfigWrite(destNum: Int, config: ModuleConfig, invokeStandaloneHook: Boolean) {
+        moduleConfigWrites.add(ModuleConfigWrite(destination = destNum, config = config))
+        adminOperations.add("module:update")
+        if (invokeStandaloneHook) onStandaloneModuleConfig(config)
+    }
 
     override suspend fun setRemoteChannel(destNum: Int, channel: Channel, packetId: Int) {
         failChannelWriteAfter?.let { if (localChannels.size >= it) error("Fake channel write failure") }
         localChannels.add(channel)
+        adminOperations.add("channel:${channel.index}")
     }
 
-    override suspend fun setFixedPosition(destNum: Int, position: Position) {}
+    override suspend fun setFixedPosition(destNum: Int, position: Position) {
+        fixedPositions.add(position)
+        adminOperations.add("fixed-position")
+    }
 
     override suspend fun setRingtone(destNum: Int, ringtone: String) {}
 
@@ -202,15 +274,18 @@ class FakeRadioController :
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {}
 
     override suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit) {
+        editSettingsDestinations.add(destNum)
         editSettingsCalled = true
+        adminOperations.add("begin")
         val scope =
             object : AdminEditScope {
                 override suspend fun setOwner(user: User) = setOwner(destNum, user, generatePacketId())
 
-                override suspend fun setConfig(config: Config) = setConfig(destNum, config, generatePacketId())
+                override suspend fun setConfig(config: Config) =
+                    recordConfigWrite(destNum, config, invokeStandaloneHook = false)
 
                 override suspend fun setModuleConfig(config: ModuleConfig) =
-                    setModuleConfig(destNum, config, generatePacketId())
+                    recordModuleConfigWrite(destNum, config, invokeStandaloneHook = false)
 
                 override suspend fun setChannel(channel: Channel) =
                     setRemoteChannel(destNum, channel, generatePacketId())
@@ -218,7 +293,19 @@ class FakeRadioController :
                 override suspend fun setFixedPosition(position: Position) =
                     this@FakeRadioController.setFixedPosition(destNum, position)
             }
-        scope.block()
+        val blockResult = runCatching { scope.block() }
+        val commitResult = runCatching {
+            withContext(NonCancellable) {
+                adminOperations.add("commit")
+                onEditSettingsCommitted()
+            }
+        }
+
+        blockResult.exceptionOrNull()?.let { blockFailure ->
+            commitResult.exceptionOrNull()?.takeUnless { it === blockFailure }?.let(blockFailure::addSuppressed)
+            throw blockFailure
+        }
+        commitResult.getOrThrow()
     }
 
     override suspend fun editLocalSettings(block: suspend AdminEditScope.() -> Unit) = editSettings(0, block)
@@ -243,9 +330,7 @@ class FakeRadioController :
 
     // --- Helper methods for testing ---
 
-    fun setConnectionState(state: ConnectionState) {
-        _connectionState.value = state
-    }
+    fun setConnectionState(state: ConnectionState) = connectionStateHolder.setConnectionState(state)
 
     fun setClientNotification(notification: ClientNotification?) {
         _clientNotification.value = notification

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -66,6 +66,10 @@ class FakeRadioController :
     val localConfigs: List<Config>
         get() = configWrites.filter { it.destination == null }.map(ConfigWrite::config)
 
+    /** Admin configuration payloads in call order, including edit-local-settings transactions. */
+    val adminConfigs: List<Config>
+        get() = configWrites.filter { it.destination != null }.map(ConfigWrite::config)
+
     val lastLocalConfig: Config?
         get() = configWrites.lastOrNull { it.destination == null }?.config
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -91,16 +91,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
         session: RadioSessionContext,
         block: suspend (RadioSessionLease) -> Unit,
     ): Boolean {
-        val admittedSession =
-            synchronized(sessionAdmissionLock) {
-                val active = _activeSession.value
-                if (!sessionAdmissionOpen || active != session) {
-                    null
-                } else {
-                    admittedSessionOperations++
-                    active
-                }
-            } ?: return false
+        val admittedSession = admitSessionOperation(session) ?: return false
 
         val lease =
             object : RadioSessionLease {
@@ -114,20 +105,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
             block(lease)
             return true
         } finally {
-            val waiter =
-                synchronized(sessionAdmissionLock) {
-                    check(_activeSession.value == admittedSession) {
-                        "Fake session changed before an admitted operation released its lease"
-                    }
-                    check(admittedSessionOperations > 0) { "Session operation count underflow" }
-                    admittedSessionOperations--
-                    if (admittedSessionOperations == 0) {
-                        sessionDrainWaiter.also { sessionDrainWaiter = null }
-                    } else {
-                        null
-                    }
-                }
-            waiter?.complete(Unit)
+            releaseSessionOperation(admittedSession)
         }
     }
 
@@ -152,8 +130,14 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
 
     override fun isMockTransport(): Boolean = true
 
-    override fun sendToRadio(bytes: ByteArray) {
-        sentToRadio.add(bytes)
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
+        val admittedSession = admitSessionOperation() ?: return false
+        return try {
+            synchronized(sessionAdmissionLock) { sentToRadio.add(bytes) }
+            true
+        } finally {
+            releaseSessionOperation(admittedSession)
+        }
     }
 
     override fun connect() {
@@ -179,6 +163,35 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
     override fun setDeviceAddress(deviceAddr: String?): Boolean {
         _currentDeviceAddressFlow.value = deviceAddr
         return true
+    }
+
+    private fun admitSessionOperation(expectedSession: RadioSessionContext? = null): RadioSessionContext? =
+        synchronized(sessionAdmissionLock) {
+            val active = _activeSession.value
+            val matchesExpectedSession = expectedSession == null || active == expectedSession
+            if (!sessionAdmissionOpen || active == null || !matchesExpectedSession) {
+                null
+            } else {
+                admittedSessionOperations++
+                active
+            }
+        }
+
+    private fun releaseSessionOperation(admittedSession: RadioSessionContext) {
+        val waiter =
+            synchronized(sessionAdmissionLock) {
+                check(_activeSession.value == admittedSession) {
+                    "Fake session changed before an admitted operation released its lease"
+                }
+                check(admittedSessionOperations > 0) { "Session operation count underflow" }
+                admittedSessionOperations--
+                if (admittedSessionOperations == 0) {
+                    sessionDrainWaiter.also { sessionDrainWaiter = null }
+                } else {
+                    null
+                }
+            }
+        waiter?.complete(Unit)
     }
 
     private fun admitSelectedSession() {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeServiceRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeServiceRepository.kt
@@ -26,6 +26,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.service.LockdownTokenInfo
 import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.MeshPacket
@@ -33,12 +34,13 @@ import org.meshtastic.proto.MeshPacket
 @Suppress("TooManyFunctions")
 class FakeServiceRepository : ServiceRepository {
     /** Canonical app-level connection state — the single source of truth for UI/feature tests. */
-    private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState> = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionLifecycle = connectionStateHolder.connectionLifecycle
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
-    override fun setConnectionState(connectionState: ConnectionState) {
-        _connectionState.value = connectionState
-    }
+    override fun setConnectionState(connectionState: ConnectionState) =
+        connectionStateHolder.setConnectionState(connectionState)
 
     private val _clientNotification = MutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?> = _clientNotification

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
@@ -63,6 +63,25 @@ class FakeRadioInterfaceServiceSessionTest {
     }
 
     @Test
+    fun `trySendToRadio records bytes only while a session is admitted`() = runTest {
+        val service = FakeRadioInterfaceService(serviceScope = backgroundScope)
+        val bytes = byteArrayOf(1, 2, 3)
+
+        assertFalse(service.trySendToRadio(bytes))
+        assertTrue(service.sentToRadio.isEmpty())
+
+        service.setDeviceAddress("ble:test")
+        service.connect()
+        assertTrue(service.trySendToRadio(bytes))
+        assertEquals(1, service.sentToRadio.size)
+        assertTrue(bytes.contentEquals(service.sentToRadio.single()))
+
+        service.disconnect()
+        assertFalse(service.trySendToRadio(bytes))
+        assertEquals(1, service.sentToRadio.size)
+    }
+
+    @Test
     fun `disconnect closes admission and waits for admitted fake session work`() = runTest {
         val service = FakeRadioInterfaceService(serviceScope = backgroundScope)
         service.setDeviceAddress("ble:test")

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -17,18 +17,28 @@
 package org.meshtastic.core.testing
 
 import app.cash.turbine.test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.QuickChatAction
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.Position
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.meshtastic.core.model.Position as ModelPosition
 
 class RepositoryFakesTest {
 
@@ -130,6 +140,130 @@ class RepositoryFakesTest {
         assertEquals("active", manager.lastAssociatedAddress)
         assertEquals(3, manager.lastAssociatedNode)
         assertEquals("fresh", manager.lastAssociatedDeviceId)
+    }
+
+    @Test
+    fun `service repository fake preserves connection epoch semantics`() {
+        val repository = FakeServiceRepository()
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), repository.connectionEpochs.value)
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), repository.connectionEpochs.value)
+
+        repository.setConnectionState(ConnectionState.Connecting)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 1,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            repository.connectionEpochs.value,
+        )
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            repository.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `FakeRadioController preserves configuration and fixed-position evidence until reset`() = runTest {
+        val controller = FakeRadioController()
+        val local = Config(device = Config.DeviceConfig())
+        val admin = Config(lora = Config.LoRaConfig(hop_limit = 5))
+        val module = ModuleConfig(serial = ModuleConfig.SerialConfig(enabled = true))
+        val position = ModelPosition(latitude = 1.0, longitude = 2.0, altitude = 3)
+
+        controller.setLocalConfig(local)
+        controller.setConfig(destNum = 7, config = admin, packetId = 8)
+        controller.setModuleConfig(destNum = 7, config = module, packetId = 9)
+        controller.setFixedPosition(destNum = 7, position = position)
+        controller.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(
+            listOf(
+                FakeRadioController.ConfigWrite(destination = null, config = local),
+                FakeRadioController.ConfigWrite(destination = 7, config = admin),
+            ),
+            controller.configWrites,
+        )
+        assertEquals(listOf(local), controller.localConfigs)
+        assertEquals(local, controller.lastLocalConfig)
+        assertEquals(
+            listOf(FakeRadioController.ModuleConfigWrite(destination = 7, config = module)),
+            controller.moduleConfigWrites,
+        )
+        assertEquals(listOf(module), controller.moduleConfigs)
+        assertEquals(listOf(7), controller.moduleConfigDestinations)
+        assertEquals(listOf(position), controller.fixedPositions)
+        assertEquals(ConnectionState.Connected, controller.connectionState.value)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), controller.connectionEpochs.value)
+
+        controller.reset()
+
+        assertTrue(controller.configWrites.isEmpty())
+        assertTrue(controller.localConfigs.isEmpty())
+        assertTrue(controller.moduleConfigWrites.isEmpty())
+        assertTrue(controller.moduleConfigs.isEmpty())
+        assertTrue(controller.moduleConfigDestinations.isEmpty())
+        assertTrue(controller.fixedPositions.isEmpty())
+        assertEquals(ConnectionState.Disconnected, controller.connectionState.value)
+        assertEquals(ConnectionEpochs(), controller.connectionEpochs.value)
+    }
+
+    @Test
+    fun `FakeRadioController scopes standalone hooks per write`() = runTest {
+        val controller = FakeRadioController()
+        val transactionStarted = CompletableDeferred<Unit>()
+        val finishTransaction = CompletableDeferred<Unit>()
+        val standaloneHooks = mutableListOf<String>()
+        controller.onStandaloneConfig = { standaloneHooks += "config" }
+        controller.onStandaloneModuleConfig = { standaloneHooks += "module" }
+
+        val transaction = async {
+            controller.editSettings(destNum = 7) {
+                transactionStarted.complete(Unit)
+                finishTransaction.await()
+                setConfig(Config(device = Config.DeviceConfig()))
+                setModuleConfig(ModuleConfig(serial = ModuleConfig.SerialConfig(enabled = true)))
+            }
+        }
+        transactionStarted.await()
+
+        controller.setConfig(destNum = 8, config = Config(power = Config.PowerConfig()), packetId = 1)
+        controller.setModuleConfig(
+            destNum = 8,
+            config = ModuleConfig(mqtt = ModuleConfig.MQTTConfig(enabled = true)),
+            packetId = 2,
+        )
+        finishTransaction.complete(Unit)
+        transaction.await()
+
+        assertEquals(listOf("config", "module"), standaloneHooks)
+    }
+
+    @Test
+    fun `FakeRadioController commits after block failure and preserves failure precedence`() = runTest {
+        val controller = FakeRadioController()
+        val blockFailure = IllegalStateException("write failed")
+        val commitFailure = IllegalArgumentException("commit failed")
+        controller.onEditSettingsCommitted = { throw commitFailure }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { throw blockFailure } }
+
+        assertSame(blockFailure, failure)
+        val suppressedCommitFailure = assertIs<IllegalArgumentException>(failure.suppressedExceptions.single())
+        assertEquals(commitFailure.message, suppressedCommitFailure.message)
+        assertEquals(listOf("begin", "commit"), controller.adminOperations)
     }
 
     @Test

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -25,6 +25,7 @@ import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.QuickChatAction
 import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSettings
@@ -34,6 +35,7 @@ import org.meshtastic.proto.Position
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -173,6 +175,33 @@ class RepositoryFakesTest {
             ),
             repository.connectionEpochs.value,
         )
+    }
+
+    @Test
+    fun `FakeCommandSender captures shared evidence and resets it`() = runTest {
+        val sender = FakeCommandSender()
+
+        sender.sendData(DataPacket(to = null, channel = 0, text = "test"))
+        sender.sendLockdownPassphrase("secret", boots = 2, hours = 3, maxSessionSeconds = 4, disable = true)
+        sender.sendLockNow()
+
+        assertEquals(1, sender.sentPackets.size)
+        assertEquals("secret", sender.lastPassphrase)
+        assertEquals(2, sender.lastBoots)
+        assertEquals(3, sender.lastHours)
+        assertEquals(4, sender.lastMaxSessionSeconds)
+        assertTrue(sender.lastDisable)
+        assertTrue(sender.lockNowCalled)
+
+        sender.reset()
+
+        assertTrue(sender.sentPackets.isEmpty())
+        assertNull(sender.lastPassphrase)
+        assertEquals(0, sender.lastBoots)
+        assertEquals(0, sender.lastHours)
+        assertEquals(0, sender.lastMaxSessionSeconds)
+        assertFalse(sender.lastDisable)
+        assertFalse(sender.lockNowCalled)
     }
 
     @Test

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -27,6 +27,9 @@ import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.DeviceHardware
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
+import org.meshtastic.proto.AdminMessage
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config
@@ -202,6 +205,24 @@ class RepositoryFakesTest {
         assertEquals(0, sender.lastMaxSessionSeconds)
         assertFalse(sender.lastDisable)
         assertFalse(sender.lockNowCalled)
+    }
+
+    @Test
+    fun `FakeCommandSender preserves admin metadata and records only dispatched awaited sends`() = runTest {
+        val sender = FakeCommandSender()
+        val message = AdminMessage(commit_edit_settings = true)
+        sender.awaitedSendResult = AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false)
+
+        sender.sendAdminAwaitResult(destNum = 7, requestId = 8, wantResponse = true) { message }
+
+        assertEquals(listOf(AdminInvocation(7, 8, true, message)), sender.adminInvocations)
+        assertTrue(sender.sentAdminMessages.isEmpty())
+
+        sender.awaitedSendResult = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+        sender.sendAdminAwaitResult(destNum = 9, requestId = 10, wantResponse = false) { message }
+
+        assertEquals(AdminInvocation(9, 10, false, message), sender.adminInvocations.last())
+        assertEquals(listOf(message), sender.sentAdminMessages)
     }
 
     @Test

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -197,6 +197,7 @@ class RepositoryFakesTest {
             controller.configWrites,
         )
         assertEquals(listOf(local), controller.localConfigs)
+        assertEquals(listOf(admin), controller.adminConfigs)
         assertEquals(local, controller.lastLocalConfig)
         assertEquals(
             listOf(FakeRadioController.ModuleConfigWrite(destination = 7, config = module)),
@@ -212,6 +213,7 @@ class RepositoryFakesTest {
 
         assertTrue(controller.configWrites.isEmpty())
         assertTrue(controller.localConfigs.isEmpty())
+        assertTrue(controller.adminConfigs.isEmpty())
         assertTrue(controller.moduleConfigWrites.isEmpty())
         assertTrue(controller.moduleConfigs.isEmpty())
         assertTrue(controller.moduleConfigDestinations.isEmpty())

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -18,15 +18,17 @@ package org.meshtastic.core.ui.util
 
 import androidx.compose.runtime.Composable
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
-import okio.ByteString
+import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.DateFormatter
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.model.util.getUniqueChannelAdditions
+import org.meshtastic.core.model.util.planChannelReplacement
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
+import org.meshtastic.core.repository.withChannelCacheReconciliation
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.unknown_age
 import org.meshtastic.proto.Channel
@@ -36,12 +38,10 @@ import org.meshtastic.proto.Config
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.Position
 import kotlin.time.Duration.Companion.days
-import org.meshtastic.core.model.Channel as ModelChannel
+import kotlin.time.Duration.Companion.seconds
 
 private const val SECONDS_TO_MILLIS = 1000L
-
-// Firmware channel files expose eight slots: one primary plus up to seven secondary channels.
-private const val CHANNEL_REPLACEMENT_SLOT_COUNT = 8
+private val CHANNEL_IMPORT_SNAPSHOT_TIMEOUT = 10.seconds
 
 @Composable
 fun Position.formatPositionTime(): String {
@@ -94,124 +94,28 @@ fun getChannelList(new: List<ChannelSettings>, old: List<ChannelSettings>): List
 }
 
 /**
- * Builds an authoritative [Channel] list for a full REPLACE import. Every position in [new] is emitted (PRIMARY at
- * index 0, SECONDARY for 1..new.lastIndex) and any trailing positions beyond [new]'s range are emitted as DISABLED so
- * the radio stops using them.
- *
- * Unlike [getChannelList], this does NOT skip positions where `currentSettings[i] == new[i]`: the imported set is
- * authoritative, the local cache must not gate the writes, and silent diff-skips during REPLACE were the source of
- * stale channels.
- *
- * [currentSettings] is consulted only for its size (to determine trailing DISABLED writes); its values are never
- * compared against [new]. Callers should read it from `radioConfigRepository.channelSetFlow.first().settings`, not from
- * a `stateInWhileSubscribed` StateFlow's `.value` — the StateFlow placeholder window can return an empty list and
- * suppress trailing DISABLED writes.
- *
- * Edge case: if [new] is empty, every emitted slot (including index 0) is DISABLED rather than wrongly promoting an
- * empty [ChannelSettings] to PRIMARY.
- *
- * @param new The imported [ChannelSettings] list. Every index becomes a write to the radio.
- * @param currentSettings The current [ChannelSettings] list. Only its size is used; trailing indices past [new] become
- *   DISABLED writes so leftover slots are cleared.
- * @param minimumSlotCount The minimum slot count to emit. Full replacement callers can use this to disable firmware
- *   slots even when the local cache is stale or shorter than the radio's actual channel list.
- * @param maximumSlotCount The maximum slot count to emit. Full replacement callers use this to avoid unsupported
- *   firmware channel indices even if an imported or cached list is longer than expected.
- * @return A [Channel] list covering every slot the radio needs written to materialize [new] and clear leftover slots.
- */
-fun getChannelReplacementList(
-    new: List<ChannelSettings>,
-    currentSettings: List<ChannelSettings>,
-    minimumSlotCount: Int = 0,
-    maximumSlotCount: Int = Int.MAX_VALUE,
-): List<Channel> = buildList {
-    require(minimumSlotCount <= maximumSlotCount) { "minimumSlotCount must be <= maximumSlotCount" }
-    val minimumLastIndex = minimumSlotCount.coerceAtLeast(0) - 1
-    val maximumLastIndex = maximumSlotCount.coerceAtLeast(0) - 1
-    val endIndex = maxOf(currentSettings.lastIndex, new.lastIndex, minimumLastIndex).coerceAtMost(maximumLastIndex)
-    if (endIndex < 0) return@buildList
-    for (i in 0..endIndex) {
-        add(
-            Channel(
-                role =
-                when (i) {
-                    // Empty-new is a degenerate import: every slot (including 0) must be DISABLED.
-                    0 -> if (new.isEmpty()) Channel.Role.DISABLED else Channel.Role.PRIMARY
-
-                    in 1..new.lastIndex -> Channel.Role.SECONDARY
-
-                    else -> Channel.Role.DISABLED
-                },
-                index = i,
-                settings = new.getOrNull(i) ?: ChannelSettings(),
-            ),
-        )
-    }
-}
-
-/**
- * Normalizes an imported REPLACE-mode [ChannelSettings] list so firmware only materializes real, distinct channels.
- *
- * Imported replacement sets can carry blank placeholder secondaries (trailing empty [ChannelSettings] padding) and
- * semantic duplicates (two slots resolving to the same effective channel under the active LoRa preset). Both produce
- * invalid LongFast-looking slots on the radio that cause route failures (`QueueStatus res=6` / `routeErr=6`).
- * - Slot 0 (primary) is always preserved as-is, even if blank (a blank primary is a deliberate disable signal).
- * - A blank placeholder primary does not participate in duplicate tracking.
- * - Blank placeholder secondaries (no name AND no PSK) are dropped.
- * - Semantic duplicates (same effective name + effective PSK as an earlier kept slot) are dropped.
- * - Remaining valid secondaries compact into sequential slots 1..n.
- *
- * @param settings Raw imported settings list.
- * @param loraConfig Active LoRa config used to resolve effective channel identity. Null falls back to defaults.
- * @return Compacted, deduplicated list safe to write to the radio.
- */
-fun normalizeReplacementSettings(
-    settings: List<ChannelSettings>,
-    loraConfig: Config.LoRaConfig?,
-): List<ChannelSettings> {
-    if (settings.size <= 1) return settings
-    val effectiveLora = loraConfig ?: Config.LoRaConfig()
-    val primary = settings.first()
-    val seen = mutableSetOf<ChannelIdentity>()
-    if (!primary.isPlaceholder()) {
-        seen.add(primary.channelIdentity(effectiveLora))
-    }
-    val compact = mutableListOf(primary)
-    for (index in 1..settings.lastIndex) {
-        val candidate = settings[index]
-        val identity = if (candidate.isPlaceholder()) null else candidate.channelIdentity(effectiveLora)
-        if (identity != null && seen.add(identity)) {
-            compact.add(candidate)
-        }
-    }
-    return compact
-}
-
-/** True when a [ChannelSettings] carries no name and no PSK — a placeholder, not an intended channel. */
-private fun ChannelSettings.isPlaceholder(): Boolean = name.isNullOrBlank() && psk.size == 0
-
-/**
  * Imports a [ChannelSet] as an authoritative REPLACE: writes every channel and — when present and actually different —
  * the imported LoRa config, all inside one [RadioController.editLocalSettings] transaction, then replaces the local
  * channel cache.
  *
- * Reads the current LoRa config and channel set from [radioConfigRepository]'s flows (avoiding the StateFlow
- * placeholder window) and builds the authoritative replacement list via [getChannelReplacementList]. The edit-settings
- * transaction defers disk persistence, radio reload/reconfiguration, and reboot until the closing commit, so channels +
- * LoRa land in a single reboot with no per-slot reconfigure to pace against. (Firmware still writes each `set_channel`
- * into its in-memory channel table as it arrives — the transaction is not a full staging of channel state — but the
- * expensive persist/reload path runs once at commit.) Writing LoRa inside the same session mirrors
- * `InstallProfileUseCase` and is why the old pre/post settle delays are gone: the begin/commit boundary is the settle.
+ * Reads the current channel and LoRa state from [radioConfigRepository] and builds the authoritative replacement via
+ * [planChannelReplacement]. The edit-settings transaction defers disk persistence, radio reload/reconfiguration, and
+ * reboot until the closing commit, so channels + LoRa land in a single reboot with no per-slot reconfigure to pace
+ * against. (Firmware still writes each `set_channel` into its in-memory channel table as it arrives — the transaction
+ * is not a full staging of channel state — but the expensive persist/reload path runs once at commit.) Writing LoRa
+ * inside the same session mirrors `InstallProfileUseCase` and is why the old pre/post settle delays are gone: the
+ * begin/commit boundary is the settle.
  *
  * The local channel cache is commit-shaped: transactional channel writes deliberately do not mirror per slot (see
- * `AdminControllerImpl.EditSettingsSession.setChannel`), and this function replaces the cached channel list once, after
- * the session succeeds — so an import interrupted before that point leaves the local channel cache untouched. (The
- * imported LoRa config is the one exception: it still writes through the cache-mirroring `setConfig`, so its local
- * cache update is not itself deferred to commit — a single trailing write that self-heals on the device's next config
- * re-send. Making `setConfig` transaction-aware is future work.)
+ * `AdminControllerImpl.EditSettingsSession.setChannel`). After the first channel command is accepted, this function
+ * reconciles the authoritative normalized list exactly once on either normal or exceptional exit; a failure before the
+ * first accepted channel write leaves the cache untouched. (The imported LoRa config is the one exception: it still
+ * writes through the cache-mirroring `setConfig`, so its local cache update is not itself deferred to commit — a single
+ * trailing write that self-heals on the device's next config re-send. Making `setConfig` transaction-aware is future
+ * work.)
  *
- * Imported settings are normalized via [normalizeReplacementSettings] before any write or bounds check, so blank
- * placeholder secondaries and semantic duplicates never reach the radio or the local cache.
+ * Imported settings are normalized by [planChannelReplacement] before any write or bounds check, so blank placeholder
+ * secondaries and semantic duplicates never reach the radio or the local cache.
  *
  * @param channelSet The imported [ChannelSet] to apply as a replacement. Its `lora_config`, if present and different
  *   from the device's current LoRa config, is written inside the same transaction.
@@ -223,41 +127,51 @@ suspend fun importChannelSet(
     radioController: RadioController,
     radioConfigRepository: RadioConfigRepository,
 ) {
-    // Resolve the LoRa preset used for semantic identity: prefer the imported config, fall back to the device's current
-    // local config so duplicate detection stays correct when the import omits lora_config (e.g. a non-default preset).
-    val currentLoraConfig = radioConfigRepository.localConfigFlow.first().lora
-    val identityLoraConfig = channelSet.lora_config ?: currentLoraConfig
-    val normalizedSettings = normalizeReplacementSettings(channelSet.settings, identityLoraConfig)
-    require(normalizedSettings.size <= CHANNEL_REPLACEMENT_SLOT_COUNT) {
-        "Imported channel set exceeds supported channel slot count"
-    }
-    val currentSettings = radioConfigRepository.channelSetFlow.first().settings
-    val replacements =
-        getChannelReplacementList(
-            new = normalizedSettings,
-            currentSettings = currentSettings,
-            minimumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
-            maximumSlotCount = CHANNEL_REPLACEMENT_SLOT_COUNT,
-        )
-    // Only write LoRa when the import carries one that actually differs from the device — avoids a redundant
-    // reconfigure.
-    val importedLoraConfig = channelSet.lora_config?.takeIf { it != currentLoraConfig }
-    Logger.i {
-        "Applying imported channel replacement writes=${replacements.size} " +
-            "importedSettings=${channelSet.settings.size} normalizedSettings=${normalizedSettings.size} " +
-            "writesLora=${importedLoraConfig != null}"
-    }
-    radioController.editLocalSettings {
-        for (channel in replacements) {
-            Logger.i {
-                "Writing imported channel index=${channel.index} role=${channel.role} " +
-                    "hasName=${channel.settings?.name?.isNotBlank() == true}"
-            }
-            setChannel(channel)
+    val admissionLifecycle = radioController.connectionLifecycle.value
+    val (currentChannelSet, currentConfig) =
+        checkNotNull(
+            withTimeoutOrNull(CHANNEL_IMPORT_SNAPSHOT_TIMEOUT) {
+                combine(radioConfigRepository.channelSetFlow, radioConfigRepository.localConfigFlow) {
+                        channels,
+                        config,
+                    ->
+                    channels to config
+                }
+                    .first()
+            },
+        ) {
+            "Timed out waiting for the connected device configuration before importing channels"
         }
-        importedLoraConfig?.let { setConfig(Config(lora = it)) }
+    check(radioController.connectionLifecycle.value == admissionLifecycle) {
+        "The connected radio lifecycle changed while preparing channel import"
     }
-    withContext(NonCancellable) { radioConfigRepository.replaceAllSettings(normalizedSettings) }
+    val plan =
+        planChannelReplacement(
+            channelSet = channelSet,
+            currentSettings = currentChannelSet.settings,
+            currentLoraConfig = currentConfig.lora,
+        )
+    Logger.i {
+        "Applying imported channel replacement writes=${plan.writes.size} " +
+            "importedSettings=${channelSet.settings.size} normalizedSettings=${plan.normalizedSettings.size} " +
+            "writesLora=${plan.loraConfig != null}"
+    }
+    if (!plan.hasInstallableWrites) return
+
+    radioConfigRepository.withChannelCacheReconciliation(plan.normalizedSettings) {
+        radioController.editLocalSettings {
+            for (channel in plan.writes) {
+                Logger.i {
+                    "Writing imported channel index=${channel.index} role=${channel.role} " +
+                        "hasName=${channel.settings?.name?.isNotBlank() == true}"
+                }
+                setChannel(channel)
+                markChannelWriteIssued()
+            }
+            plan.loraConfig?.let { setConfig(Config(lora = it)) }
+        }
+        reconcileChannelCache()
+    }
 }
 
 /**
@@ -267,7 +181,7 @@ suspend fun importChannelSet(
  * incoming channel are omitted from the preview. Unique incoming channels are appended in scanned order and selected by
  * default while firmware channel capacity remains; unique channels beyond [maxChannels] stay visible but unchecked.
  *
- * Semantic identity is resolved via the [Channel] domain model so preset/default channels match correctly across modem
+ * Semantic identity is resolved by [getUniqueChannelAdditions] so preset/default channels match correctly across modem
  * presets: empty names resolve to the preset display name, and 1-byte PSK markers expand to the full default key.
  *
  * @param existing The current [ChannelSettings] list on the radio. Always shown, always selected.
@@ -282,36 +196,17 @@ fun getChannelPreviewForAdd(
     loraConfig: Config.LoRaConfig,
     maxChannels: Int,
 ): ChannelAddPreview {
-    val seen = existing.map { it.channelIdentity(loraConfig) }.toMutableSet()
     val previewSettings = existing.toMutableList()
     val previewSelections = MutableList(existing.size) { true }
     var remaining = (maxChannels - existing.size).coerceAtLeast(0)
-    for (channel in incoming) {
-        val shouldShow = !channel.isPlaceholder()
-        val identity = if (shouldShow) channel.channelIdentity(loraConfig) else null
-        // Omit blank placeholders and semantic duplicates entirely — they are not shown to the user.
-        if (identity != null && seen.add(identity)) {
-            previewSettings += channel
-            val shouldSelect = remaining > 0
-            previewSelections += shouldSelect
-            if (shouldSelect) remaining--
-        }
+    for (channel in getUniqueChannelAdditions(existing, incoming, loraConfig)) {
+        previewSettings += channel
+        val shouldSelect = remaining > 0
+        previewSelections += shouldSelect
+        if (shouldSelect) remaining--
     }
     return ChannelAddPreview(settings = previewSettings, selections = previewSelections)
 }
 
 /** Filtered ADD-mode preview: the visible channel list paired with its default selections (always size-matched). */
 data class ChannelAddPreview(val settings: List<ChannelSettings>, val selections: List<Boolean>)
-
-/** Semantic channel identity based on effective name and effective PSK. */
-private data class ChannelIdentity(val name: String, val psk: ByteString) {
-    // Redact the effective PSK from auto-generated diagnostics so a cryptographic key never leaks
-    // via toString() in exception messages, debug logs, or stack traces.
-    override fun toString(): String = "ChannelIdentity(name=$name, psk=<redacted>)"
-}
-
-/** Resolves the [ChannelIdentity] of this [ChannelSettings] under the given [Config.LoRaConfig]. */
-private fun ChannelSettings.channelIdentity(loraConfig: Config.LoRaConfig): ChannelIdentity {
-    val channel = ModelChannel(settings = this, loraConfig = loraConfig)
-    return ChannelIdentity(name = channel.name, psk = channel.psk)
-}

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
@@ -41,6 +41,7 @@ import org.meshtastic.core.model.FirmwareUpdateNoticePolicy
 import org.meshtastic.core.model.FirmwareUpdateTransport
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.util.TimeConstants
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
@@ -61,9 +62,8 @@ import org.meshtastic.proto.Config
 import org.meshtastic.proto.LocalConfig
 
 /**
- * Derived, UI-friendly summary of the device connection state. Combines [ServiceRepository.connectionState] with
- * "region unset" and the [ServiceRepository.RECONNECTING_PROGRESS_TEXT] handshake-recovery signal to surface cases
- * (MUST_SET_REGION, RECONNECTING) that otherwise need separate boolean flags in the UI layer.
+ * Derived, UI-friendly summary of the device connection lifecycle. Region configuration is exposed separately through
+ * [ConnectionsViewModel.regionRequired] so the connected card and required-action warning can remain visible together.
  */
 enum class ConnectionStatus {
     /** No device has been selected or we are otherwise disconnected. */
@@ -90,9 +90,6 @@ enum class ConnectionStatus {
 
     /** Connected but the device is in deep sleep. */
     CONNECTED_SLEEPING,
-
-    /** Connected and active, but LoRa region is UNSET — user action required. */
-    MUST_SET_REGION,
 }
 
 @KoinViewModel
@@ -117,6 +114,14 @@ class ConnectionsViewModel(
     val lockdownState = serviceRepository.lockdownState
     val sessionAuthorized = serviceRepository.sessionAuthorized
 
+    /** True when this session may change radio configuration. Legacy/non-lockdown radios report no lockdown state. */
+    val regionConfigurationAllowed: StateFlow<Boolean> =
+        combine(lockdownState, sessionAuthorized) { state, authorized ->
+            authorized || state is LockdownState.None || state is LockdownState.Disabled
+        }
+            .distinctUntilChanged()
+            .stateInWhileSubscribed(initialValue = false)
+
     val myNodeInfo: StateFlow<MyNodeInfo?> = nodeRepository.myNodeInfo
 
     val ourNodeInfo: StateFlow<Node?> = nodeRepository.ourNodeInfo
@@ -136,17 +141,24 @@ class ConnectionsViewModel(
             }
             .stateInWhileSubscribed(initialValue = nodeRepository.ourNodeInfo.value)
 
-    /** Whether the LoRa region is UNSET and needs to be configured. */
-    val regionUnset: StateFlow<Boolean> =
-        radioConfigRepository.localConfigFlow
-            .map { it.lora?.region == Config.LoRaConfig.RegionCode.UNSET }
+    /** True while a connected node still requires a LoRa region after any expected restart completes. */
+    val regionRequired: StateFlow<Boolean> =
+        combine(connectionState, radioConfigRepository.localConfigFlow, nodeRestartTracker.restartExpected) {
+                state,
+                localConfig,
+                restartExpected,
+            ->
+            state is ConnectionState.Connected &&
+                !restartExpected &&
+                localConfig.lora?.region == Config.LoRaConfig.RegionCode.UNSET
+        }
             .distinctUntilChanged()
             .stateInWhileSubscribed(initialValue = false)
 
     /**
-     * Single source of truth for the UI's "connection status" pill/banner. Derived from [connectionState],
-     * [ServiceRepository.connectionProgress], and [regionUnset]; kept here rather than in the composable so the mapping
-     * is observable and testable.
+     * Single source of truth for the UI's connection status. Derived from [connectionState],
+     * [ServiceRepository.connectionProgress], and expected-restart state. The mapping remains here so it is observable
+     * and testable.
      *
      * The [ConnectionStatus.RECONNECTING] case is signalled by the WiFi/TCP handshake watchdog writing
      * [ServiceRepository.RECONNECTING_PROGRESS_TEXT] to [ServiceRepository.connectionProgress] immediately before its
@@ -154,15 +166,14 @@ class ConnectionsViewModel(
      * [ServiceRepository.RECONNECTING_PROGRESS_TEXT] for the cross-track contract.
      */
     val connectionStatus: StateFlow<ConnectionStatus> =
-        combine(
-            connectionState,
-            regionUnset,
-            serviceRepository.connectionProgress,
-            nodeRestartTracker.restartExpected,
-        ) { state, unset, progress, restartExpected ->
+        combine(connectionState, serviceRepository.connectionProgress, nodeRestartTracker.restartExpected) {
+                state,
+                progress,
+                restartExpected,
+            ->
             when (state) {
                 is ConnectionState.Connected ->
-                    if (unset) ConnectionStatus.MUST_SET_REGION else ConnectionStatus.CONNECTED
+                    if (restartExpected) ConnectionStatus.RESTARTING else ConnectionStatus.CONNECTED
 
                 // While an expected node restart is in flight, the drop and the reconnect attempts are the restart
                 // —

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
@@ -339,7 +339,7 @@ class ProtoExtensionsTest {
         )
 
         // LoRa write is the last op in the edit session, with no settle delays around it.
-        assertEquals(listOf(Config(lora = imported)), radioController.localConfigs)
+        assertEquals(listOf(Config(lora = imported)), radioController.adminConfigs)
     }
 
     @Test
@@ -366,8 +366,8 @@ class ProtoExtensionsTest {
             radioConfigRepository = unchangedRepo,
         )
 
-        assertTrue(absent.localConfigs.isEmpty())
-        assertTrue(unchanged.localConfigs.isEmpty())
+        assertTrue(absent.adminConfigs.isEmpty())
+        assertTrue(unchanged.adminConfigs.isEmpty())
     }
 
     // --- getChannelPreviewForAdd tests ---

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
@@ -16,8 +16,16 @@
  */
 package org.meshtastic.core.ui.util
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.util.CHANNEL_REPLACEMENT_SLOT_COUNT
+import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioController
 import org.meshtastic.proto.Channel
@@ -32,135 +40,91 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.meshtastic.core.model.Channel as ModelChannel
 
-/**
- * Coverage for [getChannelReplacementList]. The REPLACE helper must emit an authoritative slot list for QR imports:
- * every imported index becomes a write (PRIMARY at 0, SECONDARY thereafter), and any trailing slots present in the
- * cached set are emitted as DISABLED so the radio stops using them. Critically, positions where the cache already
- * matches the import are NOT skipped — the diff-skip was the source of stale channels.
- */
+/** Coverage for the channel import and preview surfaces owned by core:ui. */
 class ProtoExtensionsTest {
     @Test
-    fun index_zero_emits_primary_with_new_settings_even_when_unchanged_from_old() {
-        val same = ChannelSettings(name = "Main", psk = byteArrayOf(1, 2, 3).toByteString())
+    fun import_times_out_before_writing_when_the_device_config_snapshot_stalls() = runTest {
+        val radioController = FakeRadioController()
+        val backingRepository = FakeRadioConfigRepository()
+        val stalledRepository =
+            object : RadioConfigRepository by backingRepository {
+                override val localConfigFlow = MutableSharedFlow<LocalConfig>()
+            }
 
-        val result = getChannelReplacementList(new = listOf(same), currentSettings = listOf(same))
-
-        assertEquals(1, result.size)
-        assertEquals(Channel.Role.PRIMARY, result.single().role)
-        assertEquals(0, result.single().index)
-        assertEquals(same, result.single().settings)
-    }
-
-    @Test
-    fun secondary_indices_emit_secondary_with_new_settings_even_when_unchanged_from_old() {
-        val primary = ChannelSettings(name = "Main")
-        val secondary = ChannelSettings(name = "Chat")
-
-        val result =
-            getChannelReplacementList(new = listOf(primary, secondary), currentSettings = listOf(primary, secondary))
-
-        assertEquals(2, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(primary, result[0].settings)
-        assertEquals(Channel.Role.SECONDARY, result[1].role)
-        assertEquals(1, result[1].index)
-        assertEquals(secondary, result[1].settings)
-    }
-
-    @Test
-    fun old_trailing_indices_beyond_new_are_emitted_as_disabled_with_empty_settings() {
-        val primary = ChannelSettings(name = "Main")
-
-        val result =
-            getChannelReplacementList(
-                new = listOf(primary),
-                currentSettings = listOf(primary, ChannelSettings(name = "Old")),
-            )
-
-        // index 0 PRIMARY (new), index 1 DISABLED (trailing old slot)
-        assertEquals(2, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(primary, result[0].settings)
-        assertEquals(Channel.Role.DISABLED, result[1].role)
-        assertEquals(1, result[1].index)
-        assertEquals(ChannelSettings(), result[1].settings)
-    }
-
-    @Test
-    fun empty_new_and_empty_old_produces_empty_list() {
-        val result = getChannelReplacementList(new = emptyList(), currentSettings = emptyList())
-
-        assertTrue(result.isEmpty())
-    }
-
-    @Test
-    fun empty_new_with_non_empty_current_emits_disabled_for_every_current_index() {
-        val currentSettings =
-            listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"), ChannelSettings(name = "C"))
-
-        val result = getChannelReplacementList(new = emptyList(), currentSettings = currentSettings)
-
-        assertEquals(3, result.size)
-        result.forEachIndexed { i, channel ->
-            assertEquals(Channel.Role.DISABLED, channel.role, "index $i should be DISABLED")
-            assertEquals(i, channel.index)
-            assertEquals(ChannelSettings(), channel.settings, "index $i should carry empty settings")
+        val result = async {
+            runCatching {
+                importChannelSet(
+                    channelSet = ChannelSet(settings = listOf(ChannelSettings(name = "Imported"))),
+                    radioController = radioController,
+                    radioConfigRepository = stalledRepository,
+                )
+            }
         }
+        advanceTimeBy(10_001)
+
+        val failure = result.await().exceptionOrNull()
+        assertTrue(failure is IllegalStateException)
+        assertTrue(failure.message.orEmpty().contains("Timed out waiting"))
+        assertFalse(radioController.editSettingsCalled)
+        assertTrue(radioController.localChannels.isEmpty())
     }
 
     @Test
-    fun single_entry_new_with_multi_entry_current_emits_primary_then_disabled_trailing() {
-        val newPrimary = ChannelSettings(name = "Imported")
-        val currentSettings =
-            listOf(
-                ChannelSettings(name = "CurrentPrimary"),
-                ChannelSettings(name = "CurrentSecondary"),
-                ChannelSettings(name = "CurrentTertiary"),
-            )
+    fun import_rejects_a_snapshot_after_connection_lifecycle_rollover() = runTest {
+        val radioController = FakeRadioController().apply { setConnectionState(ConnectionState.Connected) }
+        val backingRepository = FakeRadioConfigRepository()
+        val snapshotStarted = CompletableDeferred<Unit>()
+        val releaseSnapshot = CompletableDeferred<Unit>()
+        val delayedRepository =
+            object : RadioConfigRepository by backingRepository {
+                override val localConfigFlow = flow {
+                    snapshotStarted.complete(Unit)
+                    releaseSnapshot.await()
+                    emit(LocalConfig())
+                }
+            }
 
-        val result = getChannelReplacementList(new = listOf(newPrimary), currentSettings = currentSettings)
-
-        assertEquals(3, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(0, result[0].index)
-        assertEquals(newPrimary, result[0].settings)
-        assertEquals(Channel.Role.DISABLED, result[1].role)
-        assertEquals(Channel.Role.DISABLED, result[2].role)
-        assertEquals(ChannelSettings(), result[1].settings)
-        assertEquals(ChannelSettings(), result[2].settings)
-    }
-
-    @Test
-    fun new_larger_than_old_emits_primary_plus_secondaries_for_every_new_index() {
-        val primary = ChannelSettings(name = "Main")
-        val secondaryA = ChannelSettings(name = "Chat")
-        val secondaryB = ChannelSettings(name = "Data")
-
-        val result =
-            getChannelReplacementList(new = listOf(primary, secondaryA, secondaryB), currentSettings = listOf(primary))
-
-        assertEquals(3, result.size)
-        assertEquals(Channel.Role.PRIMARY, result[0].role)
-        assertEquals(0, result[0].index)
-        assertEquals(primary, result[0].settings)
-        assertEquals(Channel.Role.SECONDARY, result[1].role)
-        assertEquals(1, result[1].index)
-        assertEquals(secondaryA, result[1].settings)
-        assertEquals(Channel.Role.SECONDARY, result[2].role)
-        assertEquals(2, result[2].index)
-        assertEquals(secondaryB, result[2].settings)
-    }
-
-    @Test
-    fun replacement_list_rejects_minimum_slot_count_above_maximum_slot_count() {
-        assertFailsWith<IllegalArgumentException> {
-            getChannelReplacementList(
-                new = listOf(ChannelSettings(name = "Main")),
-                currentSettings = emptyList(),
-                minimumSlotCount = 2,
-                maximumSlotCount = 1,
-            )
+        val result = async {
+            runCatching {
+                importChannelSet(
+                    channelSet = ChannelSet(settings = listOf(ChannelSettings(name = "Imported"))),
+                    radioController = radioController,
+                    radioConfigRepository = delayedRepository,
+                )
+            }
         }
+        snapshotStarted.await()
+        radioController.setConnectionState(ConnectionState.Disconnected)
+        radioController.setConnectionState(ConnectionState.Connected)
+        releaseSnapshot.complete(Unit)
+
+        val failure = result.await().exceptionOrNull()
+        assertTrue(failure is IllegalStateException)
+        assertTrue(failure.message.orEmpty().contains("lifecycle changed"))
+        assertFalse(radioController.editSettingsCalled)
+        assertTrue(radioController.localChannels.isEmpty())
+    }
+
+    @Test
+    fun import_skips_transaction_when_channels_and_lora_are_unchanged() = runTest {
+        val radioController = FakeRadioController()
+        val radioConfigRepository = FakeRadioConfigRepository()
+        val settings =
+            (0 until CHANNEL_REPLACEMENT_SLOT_COUNT).map { index -> ChannelSettings(name = "Channel $index") }
+        val lora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.US)
+        radioConfigRepository.setChannelSet(ChannelSet(settings = settings))
+        radioConfigRepository.setLocalConfigDirect(LocalConfig(lora = lora))
+
+        importChannelSet(
+            channelSet = ChannelSet(settings = settings, lora_config = lora),
+            radioController = radioController,
+            radioConfigRepository = radioConfigRepository,
+        )
+
+        assertFalse(radioController.editSettingsCalled)
+        assertTrue(radioController.localChannels.isEmpty())
+        assertTrue(radioController.configWrites.isEmpty())
+        assertEquals(settings, radioConfigRepository.currentChannelSet.settings)
     }
 
     @Test
@@ -182,7 +146,7 @@ class ProtoExtensionsTest {
             radioConfigRepository = radioConfigRepository,
         )
 
-        assertEquals((0..7).toList(), radioController.localChannels.map { it.index })
+        assertEquals((0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(), radioController.localChannels.map { it.index })
         assertEquals(
             listOf(
                 Channel.Role.PRIMARY,
@@ -200,7 +164,7 @@ class ProtoExtensionsTest {
     }
 
     @Test
-    fun import_leaves_cache_untouched_when_a_channel_write_fails_mid_session() = runTest {
+    fun import_reconciles_cache_when_a_channel_write_fails_after_prior_writes() = runTest {
         val radioController = FakeRadioController().apply { failChannelWriteAfter = 2 }
         val radioConfigRepository = FakeRadioConfigRepository()
         val oldSettings =
@@ -212,8 +176,27 @@ class ProtoExtensionsTest {
         val importedSettings = listOf(ChannelSettings(name = "Imported"), ChannelSettings(name = "Private"))
         radioConfigRepository.setChannelSet(ChannelSet(settings = oldSettings))
 
-        // A write failing inside the editLocalSettings session propagates out before the post-session cache
-        // replace, so the local cache stays exactly as it was — nothing partially applied.
+        // Two channel writes are accepted before the third fails. The imported set is authoritative, so cleanup
+        // reconciles the cache even though the edit transaction itself reports failure.
+        assertFailsWith<IllegalStateException> {
+            importChannelSet(
+                channelSet = ChannelSet(settings = importedSettings),
+                radioController = radioController,
+                radioConfigRepository = radioConfigRepository,
+            )
+        }
+
+        assertEquals(importedSettings, radioConfigRepository.currentChannelSet.settings)
+    }
+
+    @Test
+    fun import_leaves_cache_untouched_when_the_first_channel_write_is_rejected() = runTest {
+        val radioController = FakeRadioController().apply { failChannelWriteAfter = 0 }
+        val radioConfigRepository = FakeRadioConfigRepository()
+        val oldSettings = listOf(ChannelSettings(name = "Old Primary"))
+        val importedSettings = listOf(ChannelSettings(name = "Imported"))
+        radioConfigRepository.setChannelSet(ChannelSet(settings = oldSettings))
+
         assertFailsWith<IllegalStateException> {
             importChannelSet(
                 channelSet = ChannelSet(settings = importedSettings),
@@ -259,7 +242,7 @@ class ProtoExtensionsTest {
             radioConfigRepository = radioConfigRepository,
         )
 
-        assertEquals((0..7).toList(), radioController.localChannels.map { it.index })
+        assertEquals((0 until CHANNEL_REPLACEMENT_SLOT_COUNT).toList(), radioController.localChannels.map { it.index })
         assertEquals(importedSettings, radioConfigRepository.currentChannelSet.settings)
     }
 
@@ -417,6 +400,23 @@ class ProtoExtensionsTest {
             getChannelPreviewForAdd(listOf(channel), listOf(channel), ModelChannel.default.loraConfig, maxChannels = 8)
 
         assertEquals(listOf(channel), preview.settings)
+    }
+
+    @Test
+    fun preview_blank_existing_slot_does_not_suppress_meaningful_incoming_channel() {
+        val blank = ChannelSettings()
+        val incoming = ChannelSettings(name = "LongFast")
+
+        val preview =
+            getChannelPreviewForAdd(
+                existing = listOf(blank),
+                incoming = listOf(incoming),
+                loraConfig = ModelChannel.default.loraConfig,
+                maxChannels = 8,
+            )
+
+        assertEquals(listOf(blank, incoming), preview.settings)
+        assertTrue(preview.selections[1])
     }
 
     @Test
@@ -585,128 +585,5 @@ class ProtoExtensionsTest {
 
         assertTrue(preview.settings.isEmpty())
         assertTrue(preview.selections.isEmpty())
-    }
-
-    // --- normalizeReplacementSettings tests ---
-
-    @Test
-    fun normalize_empty_list_passes_through() {
-        assertEquals(emptyList(), normalizeReplacementSettings(emptyList(), ModelChannel.default.loraConfig))
-    }
-
-    @Test
-    fun normalize_single_element_passes_through() {
-        val primary = ChannelSettings(name = "Solo", psk = byteArrayOf(1).toByteString())
-
-        assertEquals(listOf(primary), normalizeReplacementSettings(listOf(primary), ModelChannel.default.loraConfig))
-    }
-
-    @Test
-    fun normalize_drops_blank_placeholder_secondary() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1, 2).toByteString())
-        val real = ChannelSettings(name = "Chat", psk = byteArrayOf(3).toByteString())
-
-        val result =
-            normalizeReplacementSettings(listOf(primary, ChannelSettings(), real), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary, real), result)
-    }
-
-    @Test
-    fun normalize_preserves_blank_primary() {
-        val blankPrimary = ChannelSettings()
-        val real = ChannelSettings(name = "Chat", psk = byteArrayOf(3).toByteString())
-
-        // Slot 0 is always preserved, even when blank (deliberate disable signal).
-        val result = normalizeReplacementSettings(listOf(blankPrimary, real), ModelChannel.default.loraConfig)
-
-        assertEquals(2, result.size)
-        assertEquals(blankPrimary, result[0])
-        assertEquals(real, result[1])
-    }
-
-    @Test
-    fun normalize_blank_primary_does_not_seed_duplicate_tracking() {
-        val blankPrimary = ChannelSettings()
-        val publicSecondary = ChannelSettings(psk = byteArrayOf(1).toByteString())
-
-        val result =
-            normalizeReplacementSettings(listOf(blankPrimary, publicSecondary), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(blankPrimary, publicSecondary), result)
-    }
-
-    @Test
-    fun normalize_drops_semantic_duplicate_secondary() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-        val dup = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-
-        val result = normalizeReplacementSettings(listOf(primary, dup), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary), result)
-    }
-
-    @Test
-    fun normalize_keeps_same_name_different_psk() {
-        val primary = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
-        val other = ChannelSettings(name = "A", psk = byteArrayOf(2).toByteString())
-
-        val result = normalizeReplacementSettings(listOf(primary, other), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary, other), result)
-    }
-
-    @Test
-    fun normalize_keeps_same_psk_different_name() {
-        val psk = byteArrayOf(1, 2).toByteString()
-        val primary = ChannelSettings(name = "A", psk = psk)
-        val other = ChannelSettings(name = "B", psk = psk)
-
-        val result = normalizeReplacementSettings(listOf(primary, other), ModelChannel.default.loraConfig)
-
-        assertEquals(listOf(primary, other), result)
-    }
-
-    @Test
-    fun normalize_compacts_valid_secondaries_into_sequential_slots() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-        val b = ChannelSettings(name = "B", psk = byteArrayOf(2).toByteString())
-        val c = ChannelSettings(name = "C", psk = byteArrayOf(3).toByteString())
-
-        // blank + duplicate mixed in; valid B and C must compact to slots 1 and 2 with no gap
-        val result =
-            normalizeReplacementSettings(
-                listOf(
-                    primary,
-                    ChannelSettings(),
-                    b,
-                    ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString()),
-                    c,
-                ),
-                ModelChannel.default.loraConfig,
-            )
-
-        assertEquals(listOf(primary, b, c), result)
-    }
-
-    @Test
-    fun normalize_null_lora_falls_back_to_defaults_without_crashing() {
-        val primary = ChannelSettings(name = "Main", psk = byteArrayOf(1).toByteString())
-
-        val result = normalizeReplacementSettings(listOf(primary, ChannelSettings()), loraConfig = null)
-
-        assertEquals(listOf(primary), result)
-    }
-
-    @Test
-    fun normalize_all_blank_input_preserves_only_primary() {
-        // Primary is always preserved (even blank); both blank placeholder secondaries are dropped.
-        val result =
-            normalizeReplacementSettings(
-                listOf(ChannelSettings(), ChannelSettings(), ChannelSettings()),
-                ModelChannel.default.loraConfig,
-            )
-
-        assertEquals(1, result.size)
     }
 }

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.FirmwareUpdateDestination
+import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
@@ -47,6 +48,7 @@ import org.meshtastic.core.testing.FakeRadioPrefs
 import org.meshtastic.core.testing.FakeServiceRepository
 import org.meshtastic.core.testing.FakeUiPrefs
 import org.meshtastic.core.testing.TestDataFactory
+import org.meshtastic.proto.Config
 import org.meshtastic.proto.HardwareModel
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.User
@@ -62,6 +64,7 @@ class ConnectionsViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var viewModel: ConnectionsViewModel
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
+    private val localConfigFlow = MutableStateFlow(LocalConfig())
     private val serviceRepository = FakeServiceRepository()
     private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
     private val nodeRepository = FakeNodeRepository()
@@ -89,7 +92,9 @@ class ConnectionsViewModelTest {
         dispatchedNotifications.clear()
         notificationsCanBeScheduled = true
 
-        every { radioConfigRepository.localConfigFlow } returns MutableStateFlow(LocalConfig())
+        localConfigFlow.value = LocalConfig()
+        nodeRestartTracker.onConnected()
+        every { radioConfigRepository.localConfigFlow } returns localConfigFlow
         uiPrefs.hasShownNotPairedWarning.value = false
         uiPrefs.firmwareUpdateNotificationKeys.value = emptySet()
 
@@ -123,6 +128,71 @@ class ConnectionsViewModelTest {
 
         assertEquals(true, viewModel.hasShownNotPairedWarning.value)
         assertEquals(true, uiPrefs.hasShownNotPairedWarning.value)
+    }
+
+    @Test
+    fun `region configuration is available when firmware reports no lockdown state`() = runTest {
+        viewModel.regionConfigurationAllowed.test {
+            assertEquals(false, awaitItem())
+            assertEquals(true, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `locked session keeps region configuration disabled until authorized`() = runTest {
+        serviceRepository.setLockdownState(LockdownState.Locked())
+
+        viewModel.regionConfigurationAllowed.test {
+            assertEquals(false, awaitItem())
+
+            serviceRepository.setSessionAuthorized(true)
+            assertEquals(true, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `region configuration becomes available when lockdown is disabled`() = runTest {
+        viewModel.regionConfigurationAllowed.test {
+            assertEquals(false, awaitItem())
+
+            serviceRepository.setLockdownState(LockdownState.Disabled)
+            assertEquals(true, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `expected restart suppresses region warning without replacing connected status`() = runTest {
+        localConfigFlow.value = LocalConfig(lora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.UNSET))
+        nodeRestartTracker.expectRestart()
+
+        viewModel.connectionStatus.test {
+            val connectionStatusItems = this
+            viewModel.regionRequired.test {
+                assertEquals(ConnectionStatus.NOT_CONNECTED, connectionStatusItems.awaitItem())
+                assertEquals(false, awaitItem())
+
+                serviceRepository.setConnectionState(ConnectionState.Connected)
+                assertEquals(ConnectionStatus.RESTARTING, connectionStatusItems.awaitItem())
+                expectNoEvents()
+
+                nodeRestartTracker.onConnected()
+                assertEquals(ConnectionStatus.CONNECTED, connectionStatusItems.awaitItem())
+                assertEquals(true, awaitItem())
+
+                localConfigFlow.value = LocalConfig(lora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.US))
+                assertEquals(false, awaitItem())
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -89,8 +89,9 @@ class NoopRadioInterfaceService : RadioInterfaceService {
     override val meshActivity: Flow<MeshActivity> = MutableSharedFlow<MeshActivity>()
     override val connectionError: Flow<String> = MutableSharedFlow<String>()
 
-    override fun sendToRadio(bytes: ByteArray) {
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
         logWarn("NoopRadioInterfaceService.sendToRadio(${bytes.size} bytes)")
+        return false
     }
 
     override fun resetReceivedBuffer() {

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -90,7 +90,7 @@ class NoopRadioInterfaceService : RadioInterfaceService {
     override val connectionError: Flow<String> = MutableSharedFlow<String>()
 
     override fun trySendToRadio(bytes: ByteArray): Boolean {
-        logWarn("NoopRadioInterfaceService.sendToRadio(${bytes.size} bytes)")
+        logWarn("NoopRadioInterfaceService.trySendToRadio(${bytes.size} bytes)")
         return false
     }
 

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -146,8 +146,8 @@ fun ConnectionsScreen(
     val connectionState by connectionsViewModel.connectionState.collectAsStateWithLifecycle()
     val ourNode by connectionsViewModel.ourNodeForDisplay.collectAsStateWithLifecycle()
     val firmwareUpdateNotice by connectionsViewModel.firmwareUpdateNotice.collectAsStateWithLifecycle()
-    val regionUnset by connectionsViewModel.regionUnset.collectAsStateWithLifecycle()
-    val sessionAuthorized by connectionsViewModel.sessionAuthorized.collectAsStateWithLifecycle()
+    val regionRequired by connectionsViewModel.regionRequired.collectAsStateWithLifecycle()
+    val regionConfigurationAllowed by connectionsViewModel.regionConfigurationAllowed.collectAsStateWithLifecycle()
 
     val selectedDevice by scanModel.selectedNotNullFlow.collectAsStateWithLifecycle()
     val persistedDeviceName by scanModel.persistedDeviceName.collectAsStateWithLifecycle()
@@ -398,17 +398,15 @@ fun ConnectionsScreen(
                         val isPhysicalDevice =
                             selectedDevice != InterfaceId.MOCK.id.toString() &&
                                 selectedDevice != InterfaceId.REPLAY.id.toString()
-                        if (
-                            uiState == ConnectionUiState.CONNECTED_WITH_NODE &&
-                            regionUnset &&
-                            sessionAuthorized &&
-                            isPhysicalDevice
-                        ) {
+                        val showRegionWarning =
+                            connectionState is ConnectionState.Connected && regionRequired && isPhysicalDevice
+                        if (showRegionWarning) {
                             Spacer(modifier = Modifier.height(8.dp))
                             Card(modifier = Modifier.fillMaxWidth()) {
                                 ListItem(
                                     leadingIcon = MeshtasticIcons.Language,
                                     text = stringResource(Res.string.set_your_region),
+                                    enabled = regionConfigurationAllowed,
                                     onClick = {
                                         isWaiting = true
                                         radioConfigViewModel.setResponseStateLoading(ConfigRoute.LORA)

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
@@ -38,7 +38,6 @@ import org.meshtastic.core.resources.connected
 import org.meshtastic.core.resources.connected_sleeping
 import org.meshtastic.core.resources.connecting
 import org.meshtastic.core.resources.disconnect
-import org.meshtastic.core.resources.must_set_region
 import org.meshtastic.core.resources.node_restarting
 import org.meshtastic.core.resources.not_connected
 import org.meshtastic.core.resources.reconnecting
@@ -61,7 +60,6 @@ fun ConnectingDeviceInfo(
     val statusLabel =
         when (connectionStatus) {
             ConnectionStatus.CONNECTED -> stringResource(Res.string.connected)
-            ConnectionStatus.MUST_SET_REGION -> stringResource(Res.string.must_set_region)
             ConnectionStatus.CONNECTING -> connectionProgress ?: stringResource(Res.string.connecting)
             ConnectionStatus.RECONNECTING -> stringResource(Res.string.reconnecting)
             ConnectionStatus.RESTARTING -> stringResource(Res.string.node_restarting)
@@ -75,7 +73,6 @@ fun ConnectingDeviceInfo(
         when (connectionStatus) {
             ConnectionStatus.CONNECTED,
             ConnectionStatus.CONNECTED_SLEEPING,
-            ConnectionStatus.MUST_SET_REGION,
             -> stringResource(Res.string.disconnect)
 
             ConnectionStatus.CONNECTING,

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
@@ -59,6 +59,7 @@ import org.meshtastic.core.resources.app_functions_settings
 import org.meshtastic.core.resources.app_functions_settings_summary
 import org.meshtastic.core.resources.app_settings
 import org.meshtastic.core.resources.bottom_nav_settings
+import org.meshtastic.core.resources.cancel
 import org.meshtastic.core.resources.device_links
 import org.meshtastic.core.resources.export_configuration
 import org.meshtastic.core.resources.filter_settings
@@ -130,6 +131,8 @@ fun SettingsScreen(
     if (profileInstallState !is ProfileInstallState.Idle) {
         MeshtasticDialog(
             titleRes = Res.string.install_configuration_in_progress_title,
+            dismissTextRes = Res.string.cancel,
+            onDismiss = viewModel::cancelProfileInstall,
             dismissable = false,
             text = {
                 Column(
@@ -202,10 +205,11 @@ fun SettingsScreen(
                 showEditDeviceProfileDialog = false
                 if (deviceProfile != null) {
                     val selectedProfile = it
+                    val installIsLocal = state.isLocal
                     viewModel.installProfile(selectedProfile) { result ->
                         result
                             .onSuccess {
-                                if (selectedProfile.shouldSuggestBluetoothRepair(isLocal = state.isLocal)) {
+                                if (selectedProfile.shouldSuggestBluetoothRepair(isLocal = installIsLocal)) {
                                     snackbarManager.showSnackbar(bluetoothRepairHint)
                                 }
                             }

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
@@ -22,16 +22,22 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -58,6 +64,13 @@ import org.meshtastic.core.resources.export_configuration
 import org.meshtastic.core.resources.filter_settings
 import org.meshtastic.core.resources.help_and_documentation
 import org.meshtastic.core.resources.import_configuration
+import org.meshtastic.core.resources.import_configuration_failed
+import org.meshtastic.core.resources.install_configuration_bluetooth_repair_hint
+import org.meshtastic.core.resources.install_configuration_failed
+import org.meshtastic.core.resources.install_configuration_in_progress_title
+import org.meshtastic.core.resources.install_configuration_in_progress_warning
+import org.meshtastic.core.resources.install_configuration_preparing
+import org.meshtastic.core.resources.install_configuration_stage
 import org.meshtastic.core.resources.node_layout_section_title
 import org.meshtastic.core.resources.preferences_language
 import org.meshtastic.core.resources.remotely_administrating
@@ -72,6 +85,7 @@ import org.meshtastic.core.ui.icon.List
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.SettingsRemote
 import org.meshtastic.core.ui.icon.Wifi
+import org.meshtastic.core.ui.util.SnackbarManager
 import org.meshtastic.feature.settings.component.AppInfoSection
 import org.meshtastic.feature.settings.component.AppearanceSettingsContent
 import org.meshtastic.feature.settings.component.ExpressiveSection
@@ -80,9 +94,11 @@ import org.meshtastic.feature.settings.component.PrivacySettingsContent
 import org.meshtastic.feature.settings.component.ThemePickerDialog
 import org.meshtastic.feature.settings.navigation.ConfigRoute
 import org.meshtastic.feature.settings.navigation.ModuleRoute
+import org.meshtastic.feature.settings.radio.ProfileInstallState
 import org.meshtastic.feature.settings.radio.RadioConfigItemList
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.radio.component.EditDeviceProfileDialog
+import org.meshtastic.feature.settings.radio.shouldSuggestBluetoothRepair
 import org.meshtastic.feature.settings.util.LanguageUtils
 import org.meshtastic.feature.settings.util.LanguageUtils.languageMap
 import org.meshtastic.proto.DeviceProfile
@@ -98,6 +114,10 @@ fun SettingsScreen(
     onBack: (() -> Unit)? = null,
 ) {
     val appFunctionsAvailable: Boolean = koinInject(qualifier = named(GOOGLE_SERVICES_AVAILABLE))
+    val snackbarManager: SnackbarManager = koinInject()
+    val importFailureMessage = stringResource(Res.string.import_configuration_failed)
+    val installFailureMessage = stringResource(Res.string.install_configuration_failed)
+    val bluetoothRepairHint = stringResource(Res.string.install_configuration_bluetooth_repair_hint)
     val hiddenFeaturesUnlocked by settingsViewModel.hiddenFeaturesUnlocked.collectAsStateWithLifecycle()
     val localConfig by settingsViewModel.localConfig.collectAsStateWithLifecycle()
     val ourNode by settingsViewModel.ourNodeInfo.collectAsStateWithLifecycle()
@@ -105,16 +125,56 @@ fun SettingsScreen(
     val isOtaCapable by settingsViewModel.isOtaCapable.collectAsStateWithLifecycle()
     val destNode by viewModel.destNode.collectAsStateWithLifecycle()
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
+    val profileInstallState by viewModel.profileInstallState.collectAsStateWithLifecycle()
+
+    if (profileInstallState !is ProfileInstallState.Idle) {
+        MeshtasticDialog(
+            titleRes = Res.string.install_configuration_in_progress_title,
+            dismissable = false,
+            text = {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    CircularProgressIndicator()
+                    val status =
+                        when (val installState = profileInstallState) {
+                            is ProfileInstallState.Installing ->
+                                stringResource(
+                                    Res.string.install_configuration_stage,
+                                    installState.currentStage,
+                                    installState.totalStages,
+                                )
+
+                            else -> stringResource(Res.string.install_configuration_preparing)
+                        }
+                    Text(text = status)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(text = stringResource(Res.string.install_configuration_in_progress_warning))
+                }
+            },
+        )
+    }
 
     var deviceProfile by remember { mutableStateOf<DeviceProfile?>(null) }
     var showEditDeviceProfileDialog by remember { mutableStateOf(false) }
 
     val importConfigLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            if (it.resultCode == Activity.RESULT_OK) {
-                showEditDeviceProfileDialog = true
-                it.data?.data?.let { uri ->
-                    viewModel.importProfile(uri.toKmpUri()) { profile -> deviceProfile = profile }
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val uri = result.data?.data
+                if (uri == null) {
+                    snackbarManager.showSnackbar(importFailureMessage)
+                } else {
+                    viewModel.importProfile(uri.toKmpUri()) { importResult ->
+                        importResult
+                            .onSuccess { profile ->
+                                deviceProfile = profile
+                                showEditDeviceProfileDialog = true
+                            }
+                            .onFailure { snackbarManager.showSnackbar(importFailureMessage) }
+                    }
                 }
             }
         }
@@ -127,6 +187,9 @@ fun SettingsScreen(
         }
 
     if (showEditDeviceProfileDialog) {
+        // Snapshot exports for the lifetime of this dialog so unrelated device-profile refreshes do not reset the
+        // user's switches. Imported profiles remain keyed by their explicit value and intentionally reset selection.
+        val dialogProfile = remember(deviceProfile) { deviceProfile ?: viewModel.currentDeviceProfile }
         EditDeviceProfileDialog(
             title =
             if (deviceProfile != null) {
@@ -134,11 +197,20 @@ fun SettingsScreen(
             } else {
                 stringResource(Res.string.export_configuration)
             },
-            deviceProfile = deviceProfile ?: viewModel.currentDeviceProfile,
+            deviceProfile = dialogProfile,
             onConfirm = {
                 showEditDeviceProfileDialog = false
                 if (deviceProfile != null) {
-                    viewModel.installProfile(it)
+                    val selectedProfile = it
+                    viewModel.installProfile(selectedProfile) { result ->
+                        result
+                            .onSuccess {
+                                if (selectedProfile.shouldSuggestBluetoothRepair(isLocal = state.isLocal)) {
+                                    snackbarManager.showSnackbar(bluetoothRepairHint)
+                                }
+                            }
+                            .onFailure { snackbarManager.showSnackbar(installFailureMessage) }
+                    }
                 } else {
                     deviceProfile = it
                     val nodeName = (it.short_name ?: "").ifBlank { "node" }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContext.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContext.kt
@@ -20,10 +20,7 @@ import org.meshtastic.core.model.Capabilities
 import org.meshtastic.proto.LoRaRegionPresetMap
 
 /** Firmware capabilities and the region-preset map only when that firmware supports the map contract. */
-internal data class LoRaRegionPresetContext(
-    val capabilities: Capabilities,
-    val regionPresetMap: LoRaRegionPresetMap?,
-)
+internal data class LoRaRegionPresetContext(val capabilities: Capabilities, val regionPresetMap: LoRaRegionPresetMap?)
 
 internal fun RadioConfigState.loRaRegionPresetContext(): LoRaRegionPresetContext {
     val capabilities = Capabilities(metadata?.firmware_version)

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContext.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContext.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio
+
+import org.meshtastic.core.model.Capabilities
+import org.meshtastic.proto.LoRaRegionPresetMap
+
+/** Firmware capabilities and the region-preset map only when that firmware supports the map contract. */
+internal data class LoRaRegionPresetContext(
+    val capabilities: Capabilities,
+    val regionPresetMap: LoRaRegionPresetMap?,
+)
+
+internal fun RadioConfigState.loRaRegionPresetContext(): LoRaRegionPresetContext {
+    val capabilities = Capabilities(metadata?.firmware_version)
+    return LoRaRegionPresetContext(
+        capabilities = capabilities,
+        regionPresetMap = loraRegionPresetMap.takeIf { capabilities.supportsLoraRegionPresetMap },
+    )
+}

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHints.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHints.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio
+
+import org.meshtastic.proto.DeviceProfile
+
+/** Whether a successful local restore may require Android to establish a new Bluetooth bond. */
+internal fun DeviceProfile.shouldSuggestBluetoothRepair(isLocal: Boolean): Boolean =
+    isLocal && config?.bluetooth?.enabled == true

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -135,6 +135,15 @@ data class RadioConfigState(
     val nodeDbResetPreserveFavorites: Boolean = false,
 )
 
+/** UI state for a local device-profile installation. */
+sealed interface ProfileInstallState {
+    data object Idle : ProfileInstallState
+
+    data object Preparing : ProfileInstallState
+
+    data class Installing(val currentStage: Int, val totalStages: Int) : ProfileInstallState
+}
+
 @KoinViewModel
 @Suppress("LongParameterList", "LargeClass")
 open class RadioConfigViewModel(
@@ -186,6 +195,9 @@ open class RadioConfigViewModel(
             lockdownCoordinator.submitPassphrase(passphrase, boots, hours, maxSessionSeconds, disable)
         }
     }
+
+    private val _profileInstallState = MutableStateFlow<ProfileInstallState>(ProfileInstallState.Idle)
+    val profileInstallState: StateFlow<ProfileInstallState> = _profileInstallState.asStateFlow()
 
     val analyticsAllowedFlow = analyticsPrefs.analyticsAllowed
 
@@ -544,33 +556,10 @@ open class RadioConfigViewModel(
         }
     }
 
-    @Suppress("CyclomaticComplexMethod")
     fun setModuleConfig(config: ModuleConfig) {
         val destNum = destNum ?: destNode.value?.num ?: return
         safeLaunch(tag = "setModuleConfig") {
-            _radioConfigState.update { state ->
-                state.copy(
-                    moduleConfig =
-                    state.moduleConfig.copy(
-                        mqtt = config.mqtt ?: state.moduleConfig.mqtt,
-                        serial = config.serial ?: state.moduleConfig.serial,
-                        external_notification =
-                        config.external_notification ?: state.moduleConfig.external_notification,
-                        store_forward = config.store_forward ?: state.moduleConfig.store_forward,
-                        range_test = config.range_test ?: state.moduleConfig.range_test,
-                        telemetry = config.telemetry ?: state.moduleConfig.telemetry,
-                        canned_message = config.canned_message ?: state.moduleConfig.canned_message,
-                        audio = config.audio ?: state.moduleConfig.audio,
-                        remote_hardware = config.remote_hardware ?: state.moduleConfig.remote_hardware,
-                        neighbor_info = config.neighbor_info ?: state.moduleConfig.neighbor_info,
-                        ambient_lighting = config.ambient_lighting ?: state.moduleConfig.ambient_lighting,
-                        detection_sensor = config.detection_sensor ?: state.moduleConfig.detection_sensor,
-                        paxcounter = config.paxcounter ?: state.moduleConfig.paxcounter,
-                        statusmessage = config.statusmessage ?: state.moduleConfig.statusmessage,
-                        tak = config.tak ?: state.moduleConfig.tak,
-                    ),
-                )
-            }
+            _radioConfigState.update { state -> state.copy(moduleConfig = state.moduleConfig.updatedWith(config)) }
             expectRestartIfLocal(config.saveRebootBehavior())
             radioConfigUseCase.setModuleConfig(destNum, config, onRequestId = ::registerRequestId)
         }
@@ -643,13 +632,19 @@ open class RadioConfigViewModel(
         safeLaunch(tag = "removeFixedPosition") { radioConfigUseCase.removeFixedPosition(destNum) }
     }
 
-    fun importProfile(uri: CommonUri, onResult: (DeviceProfile) -> Unit) {
-        safeLaunch(tag = "importProfile") {
-            var profile: DeviceProfile? = null
-            fileService.read(uri) { source ->
-                importProfileUseCase(source).onSuccess { profile = it }.onFailure { throw it }
+    fun importProfile(uri: CommonUri, onResult: (Result<DeviceProfile>) -> Unit) {
+        viewModelScope.launch {
+            val result = safeCatching {
+                var profile: DeviceProfile? = null
+                val wasRead = fileService.read(uri) { source -> profile = importProfileUseCase(source).getOrThrow() }
+                check(wasRead) { "Unable to read the selected configuration profile" }
+                checkNotNull(profile) { "The selected configuration profile was empty" }
             }
-            profile?.let { onResult(it) }
+            // Do not attach the exception: parser messages can quote profile bytes containing credentials.
+            result.onFailure { error ->
+                Logger.w { "[importProfile] Failed to import profile; cause=${error.safeLogType()}" }
+            }
+            onResult(result)
         }
     }
 
@@ -720,9 +715,41 @@ open class RadioConfigViewModel(
         }
     }
 
-    fun installProfile(protobuf: DeviceProfile) {
-        val destNum = destNum ?: destNode.value?.num ?: return
-        safeLaunch(tag = "installProfile") { installProfileUseCase(destNum, protobuf, destNode.value?.user) }
+    fun installProfile(protobuf: DeviceProfile, onResult: (Result<Unit>) -> Unit = {}) {
+        val destNum = destNum ?: destNode.value?.num
+        val currentUser = destNode.value?.user
+        val isLocal = radioConfigState.value.isLocal
+        if (destNum == null) {
+            onResult(Result.failure(IllegalStateException("No destination is available for profile installation")))
+            return
+        }
+        if (!_profileInstallState.compareAndSet(ProfileInstallState.Idle, ProfileInstallState.Preparing)) {
+            onResult(Result.failure(IllegalStateException("A device profile installation is already in progress")))
+            return
+        }
+        viewModelScope.launch {
+            try {
+                val result = safeCatching {
+                    installProfileUseCase(
+                        destNum = destNum,
+                        profile = protobuf,
+                        currentUser = currentUser,
+                        isLocal = isLocal,
+                    ) { progress ->
+                        _profileInstallState.value =
+                            ProfileInstallState.Installing(progress.currentStage, progress.totalStages)
+                    }
+                    Unit
+                }
+                // Keep device/profile identifiers and exception messages out of logs while retaining the failure type.
+                result.onFailure { error ->
+                    Logger.w { "[installProfile] Failed to install profile; cause=${error.safeLogType()}" }
+                }
+                onResult(result)
+            } finally {
+                _profileInstallState.value = ProfileInstallState.Idle
+            }
+        }
     }
 
     fun clearPacketResponse() {
@@ -1097,29 +1124,8 @@ open class RadioConfigViewModel(
             }
 
             is RadioResponseResult.ModuleConfigResponse -> {
-                val response = result.config
                 _radioConfigState.update { state ->
-                    state.copy(
-                        moduleConfig =
-                        state.moduleConfig.copy(
-                            mqtt = response.mqtt ?: state.moduleConfig.mqtt,
-                            serial = response.serial ?: state.moduleConfig.serial,
-                            external_notification =
-                            response.external_notification ?: state.moduleConfig.external_notification,
-                            store_forward = response.store_forward ?: state.moduleConfig.store_forward,
-                            range_test = response.range_test ?: state.moduleConfig.range_test,
-                            telemetry = response.telemetry ?: state.moduleConfig.telemetry,
-                            canned_message = response.canned_message ?: state.moduleConfig.canned_message,
-                            audio = response.audio ?: state.moduleConfig.audio,
-                            remote_hardware = response.remote_hardware ?: state.moduleConfig.remote_hardware,
-                            neighbor_info = response.neighbor_info ?: state.moduleConfig.neighbor_info,
-                            ambient_lighting = response.ambient_lighting ?: state.moduleConfig.ambient_lighting,
-                            detection_sensor = response.detection_sensor ?: state.moduleConfig.detection_sensor,
-                            paxcounter = response.paxcounter ?: state.moduleConfig.paxcounter,
-                            statusmessage = response.statusmessage ?: state.moduleConfig.statusmessage,
-                            tak = response.tak ?: state.moduleConfig.tak,
-                        ),
-                    )
+                    state.copy(moduleConfig = state.moduleConfig.updatedWith(result.config))
                 }
                 incrementCompleted()
             }
@@ -1250,3 +1256,28 @@ internal fun Config.saveRebootBehavior(): RebootBehavior = when {
 /** Firmware `AdminModule::handleSetModuleConfig` reboots for every module section except status message. */
 internal fun ModuleConfig.saveRebootBehavior(): RebootBehavior =
     if (statusmessage != null) RebootBehavior.NEVER else RebootBehavior.ALWAYS
+
+/** Applies the single populated ModuleConfig one-of arm to the locally cached aggregate. */
+@Suppress("CyclomaticComplexMethod")
+private fun LocalModuleConfig.updatedWith(config: ModuleConfig): LocalModuleConfig = copy(
+    mqtt = config.mqtt ?: mqtt,
+    serial = config.serial ?: serial,
+    external_notification = config.external_notification ?: external_notification,
+    store_forward = config.store_forward ?: store_forward,
+    range_test = config.range_test ?: range_test,
+    telemetry = config.telemetry ?: telemetry,
+    canned_message = config.canned_message ?: canned_message,
+    audio = config.audio ?: audio,
+    remote_hardware = config.remote_hardware ?: remote_hardware,
+    neighbor_info = config.neighbor_info ?: neighbor_info,
+    ambient_lighting = config.ambient_lighting ?: ambient_lighting,
+    detection_sensor = config.detection_sensor ?: detection_sensor,
+    paxcounter = config.paxcounter ?: paxcounter,
+    statusmessage = config.statusmessage ?: statusmessage,
+    traffic_management = config.traffic_management ?: traffic_management,
+    tak = config.tak ?: tak,
+    mesh_beacon = config.mesh_beacon ?: mesh_beacon,
+)
+
+/** Returns diagnostic type information without logging a potentially sensitive exception message. */
+private fun Throwable.safeLogType(): String = this::class.simpleName ?: "Throwable"

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -52,6 +53,7 @@ import org.meshtastic.core.domain.usecase.settings.InstallProfileUseCase
 import org.meshtastic.core.domain.usecase.settings.ProcessRadioResponseUseCase
 import org.meshtastic.core.domain.usecase.settings.RadioConfigUseCase
 import org.meshtastic.core.domain.usecase.settings.RadioResponseResult
+import org.meshtastic.core.domain.usecase.settings.updatedWithModuleConfig
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.MqttConnectionState
 import org.meshtastic.core.model.MqttProbeStatus
@@ -197,6 +199,7 @@ open class RadioConfigViewModel(
     }
 
     private val _profileInstallState = MutableStateFlow<ProfileInstallState>(ProfileInstallState.Idle)
+    private var profileInstallJob: Job? = null
     val profileInstallState: StateFlow<ProfileInstallState> = _profileInstallState.asStateFlow()
 
     val analyticsAllowedFlow = analyticsPrefs.analyticsAllowed
@@ -559,7 +562,9 @@ open class RadioConfigViewModel(
     fun setModuleConfig(config: ModuleConfig) {
         val destNum = destNum ?: destNode.value?.num ?: return
         safeLaunch(tag = "setModuleConfig") {
-            _radioConfigState.update { state -> state.copy(moduleConfig = state.moduleConfig.updatedWith(config)) }
+            _radioConfigState.update { state ->
+                state.copy(moduleConfig = state.moduleConfig.updatedWithModuleConfig(config))
+            }
             expectRestartIfLocal(config.saveRebootBehavior())
             radioConfigUseCase.setModuleConfig(destNum, config, onRequestId = ::registerRequestId)
         }
@@ -727,29 +732,43 @@ open class RadioConfigViewModel(
             onResult(Result.failure(IllegalStateException("A device profile installation is already in progress")))
             return
         }
-        viewModelScope.launch {
-            try {
-                val result = safeCatching {
-                    installProfileUseCase(
-                        destNum = destNum,
-                        profile = protobuf,
-                        currentUser = currentUser,
-                        isLocal = isLocal,
-                    ) { progress ->
-                        _profileInstallState.value =
-                            ProfileInstallState.Installing(progress.currentStage, progress.totalStages)
+        lateinit var installJob: Job
+        installJob =
+            viewModelScope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    val result = safeCatching {
+                        installProfileUseCase(
+                            destNum = destNum,
+                            profile = protobuf,
+                            currentUser = currentUser,
+                            isLocal = isLocal,
+                        ) { progress ->
+                            _profileInstallState.value =
+                                ProfileInstallState.Installing(progress.currentStage, progress.totalStages)
+                        }
+                        Unit
                     }
-                    Unit
+                    // Keep device/profile identifiers and exception messages out of logs while retaining the
+                    // failure type.
+                    result.onFailure { error ->
+                        Logger.w { "[installProfile] Failed to install profile; cause=${error.safeLogType()}" }
+                    }
+                    onResult(result)
+                } finally {
+                    if (profileInstallJob === installJob) profileInstallJob = null
+                    _profileInstallState.value = ProfileInstallState.Idle
                 }
-                // Keep device/profile identifiers and exception messages out of logs while retaining the failure type.
-                result.onFailure { error ->
-                    Logger.w { "[installProfile] Failed to install profile; cause=${error.safeLogType()}" }
-                }
-                onResult(result)
-            } finally {
-                _profileInstallState.value = ProfileInstallState.Idle
             }
+        profileInstallJob = installJob
+        if (!installJob.start()) {
+            if (profileInstallJob === installJob) profileInstallJob = null
+            _profileInstallState.value = ProfileInstallState.Idle
+            onResult(Result.failure(IllegalStateException("Profile installation could not start")))
         }
+    }
+
+    fun cancelProfileInstall() {
+        profileInstallJob?.cancel()
     }
 
     fun clearPacketResponse() {
@@ -1125,7 +1144,7 @@ open class RadioConfigViewModel(
 
             is RadioResponseResult.ModuleConfigResponse -> {
                 _radioConfigState.update { state ->
-                    state.copy(moduleConfig = state.moduleConfig.updatedWith(result.config))
+                    state.copy(moduleConfig = state.moduleConfig.updatedWithModuleConfig(result.config))
                 }
                 incrementCompleted()
             }
@@ -1256,28 +1275,6 @@ internal fun Config.saveRebootBehavior(): RebootBehavior = when {
 /** Firmware `AdminModule::handleSetModuleConfig` reboots for every module section except status message. */
 internal fun ModuleConfig.saveRebootBehavior(): RebootBehavior =
     if (statusmessage != null) RebootBehavior.NEVER else RebootBehavior.ALWAYS
-
-/** Applies the single populated ModuleConfig one-of arm to the locally cached aggregate. */
-@Suppress("CyclomaticComplexMethod")
-private fun LocalModuleConfig.updatedWith(config: ModuleConfig): LocalModuleConfig = copy(
-    mqtt = config.mqtt ?: mqtt,
-    serial = config.serial ?: serial,
-    external_notification = config.external_notification ?: external_notification,
-    store_forward = config.store_forward ?: store_forward,
-    range_test = config.range_test ?: range_test,
-    telemetry = config.telemetry ?: telemetry,
-    canned_message = config.canned_message ?: canned_message,
-    audio = config.audio ?: audio,
-    remote_hardware = config.remote_hardware ?: remote_hardware,
-    neighbor_info = config.neighbor_info ?: neighbor_info,
-    ambient_lighting = config.ambient_lighting ?: ambient_lighting,
-    detection_sensor = config.detection_sensor ?: detection_sensor,
-    paxcounter = config.paxcounter ?: paxcounter,
-    statusmessage = config.statusmessage ?: statusmessage,
-    traffic_management = config.traffic_management ?: traffic_management,
-    tak = config.tak ?: tak,
-    mesh_beacon = config.mesh_beacon ?: mesh_beacon,
-)
 
 /** Returns diagnostic type information without logging a potentially sensitive exception message. */
 private fun Throwable.safeLogType(): String = this::class.simpleName ?: "Throwable"

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
@@ -63,7 +63,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.core.model.Channel
 import org.meshtastic.core.model.ConnectionState
-import org.meshtastic.core.model.defaultPresetFor
+import org.meshtastic.core.model.presetForFreshRegion
 import org.meshtastic.core.navigation.Route
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.add
@@ -95,6 +95,7 @@ import org.meshtastic.feature.settings.navigation.ConfigRoute
 import org.meshtastic.feature.settings.navigation.getNavRouteFrom
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.radio.RebootBehavior
+import org.meshtastic.feature.settings.radio.loRaRegionPresetContext
 import org.meshtastic.feature.settings.radio.component.PacketResponseStateDialog
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
@@ -200,9 +201,9 @@ fun ChannelScreen(
             messageRes = Res.string.are_you_sure_change_default,
             onConfirm = {
                 Logger.d { "Switching back to default channel" }
-                // The default channel takes the region's preferred preset (e.g. US -> LongTurbo) so its derived name,
-                // hash, and frequency match what a freshly-set-up node in that region would use.
-                val preset = defaultPresetFor(viewModel.region) ?: Channel.default.loraConfig.modem_preset
+                val presetContext = radioConfigState.loRaRegionPresetContext()
+                val preset =
+                    presetContext.regionPresetMap.presetForFreshRegion(viewModel.region, presetContext.capabilities)
                 val lora =
                     Channel.default.loraConfig.copy(
                         region = viewModel.region,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
@@ -95,8 +95,8 @@ import org.meshtastic.feature.settings.navigation.ConfigRoute
 import org.meshtastic.feature.settings.navigation.getNavRouteFrom
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.radio.RebootBehavior
-import org.meshtastic.feature.settings.radio.loRaRegionPresetContext
 import org.meshtastic.feature.settings.radio.component.PacketResponseStateDialog
+import org.meshtastic.feature.settings.radio.loRaRegionPresetContext
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialog.kt
@@ -31,7 +31,6 @@ import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.cancel
 import org.meshtastic.core.resources.channel_url
 import org.meshtastic.core.resources.fixed_position
-import org.meshtastic.core.resources.licensed_amateur_radio
 import org.meshtastic.core.resources.long_name
 import org.meshtastic.core.resources.module_settings
 import org.meshtastic.core.resources.radio_configuration
@@ -50,7 +49,6 @@ private enum class ProfileField(val labelRes: StringResource) {
     MODULE_CONFIG(Res.string.module_settings),
     FIXED_POSITION(Res.string.fixed_position),
     UNMESSAGABLE(Res.string.unmessageable),
-    LICENSED(Res.string.licensed_amateur_radio),
     ;
 
     fun isPresent(profile: DeviceProfile): Boolean = when (this) {
@@ -61,7 +59,6 @@ private enum class ProfileField(val labelRes: StringResource) {
         MODULE_CONFIG -> profile.module_config != null
         FIXED_POSITION -> profile.fixed_position != null
         UNMESSAGABLE -> profile.is_unmessagable != null
-        LICENSED -> profile.is_licensed != null
     }
 }
 
@@ -107,7 +104,8 @@ fun EditDeviceProfileDialog(
                     },
                     is_unmessagable =
                     if (state[ProfileField.UNMESSAGABLE] == true) deviceProfile.is_unmessagable else null,
-                    is_licensed = if (state[ProfileField.LICENSED] == true) deviceProfile.is_licensed else null,
+                    // Licensing is established through onboarding and is intentionally never restored from profiles.
+                    is_licensed = null,
                 )
             onConfirm(result)
         },

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialog.kt
@@ -42,18 +42,27 @@ import org.meshtastic.core.ui.component.MeshtasticDialog
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.proto.DeviceProfile
 
-private const val UNMESSAGABLE_TAG = 9
-private const val LICENSED_TAG = 10
+private enum class ProfileField(val labelRes: StringResource) {
+    LONG_NAME(Res.string.long_name),
+    SHORT_NAME(Res.string.short_name),
+    CHANNEL_URL(Res.string.channel_url),
+    CONFIG(Res.string.radio_configuration),
+    MODULE_CONFIG(Res.string.module_settings),
+    FIXED_POSITION(Res.string.fixed_position),
+    UNMESSAGABLE(Res.string.unmessageable),
+    LICENSED(Res.string.licensed_amateur_radio),
+    ;
 
-private enum class ProfileField(val tag: Int, val labelRes: StringResource) {
-    LONG_NAME(1, Res.string.long_name),
-    SHORT_NAME(2, Res.string.short_name),
-    CHANNEL_URL(3, Res.string.channel_url),
-    CONFIG(4, Res.string.radio_configuration),
-    MODULE_CONFIG(5, Res.string.module_settings),
-    FIXED_POSITION(6, Res.string.fixed_position),
-    UNMESSAGABLE(UNMESSAGABLE_TAG, Res.string.unmessageable),
-    LICENSED(LICENSED_TAG, Res.string.licensed_amateur_radio),
+    fun isPresent(profile: DeviceProfile): Boolean = when (this) {
+        LONG_NAME -> profile.long_name != null
+        SHORT_NAME -> profile.short_name != null
+        CHANNEL_URL -> profile.channel_url != null
+        CONFIG -> profile.config != null
+        MODULE_CONFIG -> profile.module_config != null
+        FIXED_POSITION -> profile.fixed_position != null
+        UNMESSAGABLE -> profile.is_unmessagable != null
+        LICENSED -> profile.is_licensed != null
+    }
 }
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -65,24 +74,12 @@ fun EditDeviceProfileDialog(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val state = remember {
-        mutableStateMapOf<ProfileField, Boolean>().apply {
-            putAll(
-                ProfileField.entries.associateWith { field ->
-                    when (field) {
-                        ProfileField.LONG_NAME -> deviceProfile.long_name != null
-                        ProfileField.SHORT_NAME -> deviceProfile.short_name != null
-                        ProfileField.CHANNEL_URL -> deviceProfile.channel_url != null
-                        ProfileField.CONFIG -> deviceProfile.config != null
-                        ProfileField.MODULE_CONFIG -> deviceProfile.module_config != null
-                        ProfileField.FIXED_POSITION -> deviceProfile.fixed_position != null
-                        ProfileField.UNMESSAGABLE -> deviceProfile.is_unmessagable != null
-                        ProfileField.LICENSED -> deviceProfile.is_licensed != null
-                    }
-                },
-            )
+    val state =
+        remember(deviceProfile) {
+            mutableStateMapOf<ProfileField, Boolean>().apply {
+                putAll(ProfileField.entries.associateWith { field -> field.isPresent(deviceProfile) })
+            }
         }
-    }
 
     MeshtasticDialog(
         title = title,
@@ -119,21 +116,10 @@ fun EditDeviceProfileDialog(
             Column(modifier = Modifier.fillMaxWidth()) {
                 HorizontalDivider()
                 ProfileField.entries.forEach { field ->
-                    val isAvailable =
-                        when (field) {
-                            ProfileField.LONG_NAME -> deviceProfile.long_name != null
-                            ProfileField.SHORT_NAME -> deviceProfile.short_name != null
-                            ProfileField.CHANNEL_URL -> deviceProfile.channel_url != null
-                            ProfileField.CONFIG -> deviceProfile.config != null
-                            ProfileField.MODULE_CONFIG -> deviceProfile.module_config != null
-                            ProfileField.FIXED_POSITION -> deviceProfile.fixed_position != null
-                            ProfileField.UNMESSAGABLE -> deviceProfile.is_unmessagable != null
-                            ProfileField.LICENSED -> deviceProfile.is_licensed != null
-                        }
                     SwitchPreference(
                         title = stringResource(field.labelRes),
                         checked = state[field] == true,
-                        enabled = isAvailable,
+                        enabled = field.isPresent(deviceProfile),
                         onCheckedChange = { state[field] = it },
                         padding = PaddingValues(0.dp),
                     )

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -33,8 +33,8 @@ import org.meshtastic.core.model.ChannelOption
 import org.meshtastic.core.model.RegionInfo
 import org.meshtastic.core.model.RegionPresetConstraint
 import org.meshtastic.core.model.constraintFor
-import org.meshtastic.core.model.defaultPresetFor
 import org.meshtastic.core.model.numChannels
+import org.meshtastic.core.model.presetForFreshRegion
 import org.meshtastic.core.model.repairPresetFor
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.advanced
@@ -68,6 +68,7 @@ import org.meshtastic.core.ui.component.SignedIntegerEditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.loRaRegionPresetContext
 import org.meshtastic.feature.settings.util.hopLimits
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
@@ -146,9 +147,12 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 // instance, so the locally-cached map (from our own handshake) is reused for remote admin too. Gated
                 // on the *target* node's firmware capability (metadata is per-target): pre-2.8 nodes don't get the
                 // map or the new TINY presets, which also keeps older remotes unconstrained.
-                val capabilities =
-                    remember(state.metadata?.firmware_version) { Capabilities(state.metadata?.firmware_version) }
-                val regionPresetMap = if (capabilities.supportsLoraRegionPresetMap) state.loraRegionPresetMap else null
+                val presetContext =
+                    remember(state.metadata?.firmware_version, state.loraRegionPresetMap) {
+                        state.loRaRegionPresetContext()
+                    }
+                val capabilities = presetContext.capabilities
+                val regionPresetMap = presetContext.regionPresetMap
                 val presetConstraint =
                     remember(regionPresetMap, formState.value.region) {
                         regionPresetMap.constraintFor(formState.value.region)
@@ -165,14 +169,11 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                         // When the region changes, snap the preset to the region's default if the current one is
                         // no longer legal there (R7); a no-op when the region is unconstrained.
                         val repaired = regionPresetMap.repairPresetFor(region, formState.value.modem_preset)
-                        // At fresh setup (region was UNSET) adopt the region's advertised default rather than keeping
-                        // a merely-legal preset: the firmware map's default when present, else the app's built-in
-                        // default (e.g. US -> LongTurbo on pre-2.8 firmware that sends no map).
+                        // At fresh setup, use the firmware-advertised default when available. Firmware 2.8 falls back
+                        // to its built-in regional default (US Long Turbo); older firmware retains Long Fast.
                         val preset =
                             if (freshSetup) {
-                                regionPresetMap.constraintFor(region)?.defaultPreset
-                                    ?: defaultPresetFor(region)
-                                    ?: repaired
+                                regionPresetMap.presetForFreshRegion(region, capabilities)
                             } else {
                                 repaired
                             }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContextTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContextTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio
+
+import org.meshtastic.proto.DeviceMetadata
+import org.meshtastic.proto.LoRaPresetGroup
+import org.meshtastic.proto.LoRaRegionPresetMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LoRaRegionPresetContextTest {
+    private val regionPresetMap = LoRaRegionPresetMap(groups = listOf(LoRaPresetGroup()))
+
+    @Test
+    fun `pre 2_8 firmware ignores an available region preset map`() {
+        val state =
+            RadioConfigState(
+                metadata = DeviceMetadata(firmware_version = "2.7.12"),
+                loraRegionPresetMap = regionPresetMap,
+            )
+
+        val context = state.loRaRegionPresetContext()
+
+        assertFalse(context.capabilities.supportsLoraRegionPresetMap)
+        assertNull(context.regionPresetMap)
+    }
+
+    @Test
+    fun `2_8 firmware exposes the region preset map`() {
+        val state =
+            RadioConfigState(
+                metadata = DeviceMetadata(firmware_version = "2.8.0"),
+                loraRegionPresetMap = regionPresetMap,
+            )
+
+        val context = state.loRaRegionPresetContext()
+
+        assertTrue(context.capabilities.supportsLoraRegionPresetMap)
+        assertEquals(regionPresetMap, context.regionPresetMap)
+    }
+}

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContextTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/LoRaRegionPresetContextTest.kt
@@ -55,4 +55,20 @@ class LoRaRegionPresetContextTest {
         assertTrue(context.capabilities.supportsLoraRegionPresetMap)
         assertEquals(regionPresetMap, context.regionPresetMap)
     }
+
+    @Test
+    fun `missing metadata hides an available region preset map`() {
+        val context = RadioConfigState(loraRegionPresetMap = regionPresetMap).loRaRegionPresetContext()
+
+        assertFalse(context.capabilities.supportsLoraRegionPresetMap)
+        assertNull(context.regionPresetMap)
+    }
+
+    @Test
+    fun `2_8 firmware remains supported when the map is absent`() {
+        val context = RadioConfigState(metadata = DeviceMetadata(firmware_version = "2.8.0")).loRaRegionPresetContext()
+
+        assertTrue(context.capabilities.supportsLoraRegionPresetMap)
+        assertNull(context.regionPresetMap)
+    }
 }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHintsTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRestoreHintsTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio
+
+import org.meshtastic.proto.Config.BluetoothConfig
+import org.meshtastic.proto.DeviceProfile
+import org.meshtastic.proto.LocalConfig
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProfileRestoreHintsTest {
+    @Test
+    fun `local enabled Bluetooth restore suggests repair troubleshooting`() {
+        val profile = DeviceProfile(config = LocalConfig(bluetooth = BluetoothConfig(enabled = true)))
+
+        assertTrue(profile.shouldSuggestBluetoothRepair(isLocal = true))
+    }
+
+    @Test
+    fun `absent or disabled Bluetooth restore does not suggest repair troubleshooting`() {
+        assertFalse(DeviceProfile().shouldSuggestBluetoothRepair(isLocal = true))
+        assertFalse(
+            DeviceProfile(config = LocalConfig(bluetooth = BluetoothConfig(enabled = false)))
+                .shouldSuggestBluetoothRepair(isLocal = true),
+        )
+    }
+
+    @Test
+    fun `remote Bluetooth restore does not suggest local pairing repair`() {
+        val profile = DeviceProfile(config = LocalConfig(bluetooth = BluetoothConfig(enabled = true)))
+
+        assertFalse(profile.shouldSuggestBluetoothRepair(isLocal = false))
+    }
+}

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
@@ -221,15 +221,15 @@ class ProfileRoundTripTest {
     private suspend fun TestScope.assertRoundTrip(profile: DeviceProfile) {
         val exportUri = CommonUri.parse("content://test/profile.bin")
         val reExportUri = CommonUri.parse("content://test/profile-reexport.bin")
-        var importedProfile: DeviceProfile? = null
+        var importResult: Result<DeviceProfile>? = null
 
         viewModel.exportProfile(exportUri, profile)
         runCurrent()
 
-        viewModel.importProfile(exportUri) { importedProfile = it }
+        viewModel.importProfile(exportUri) { importResult = it }
         runCurrent()
 
-        val actualImportedProfile = assertNotNull(importedProfile)
+        val actualImportedProfile = assertNotNull(importResult).getOrThrow()
         assertEquals(profile, actualImportedProfile)
         assertContentEquals(profile.encode(), fileService.readBytes(exportUri))
         assertContentEquals(profile.encode(), actualImportedProfile.encode())

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -20,6 +20,7 @@ import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -27,6 +28,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -42,12 +44,14 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import okio.ByteString.Companion.encodeUtf8
+import org.meshtastic.core.common.util.CommonUri
 import org.meshtastic.core.domain.usecase.settings.AdminActionsUseCase
 import org.meshtastic.core.domain.usecase.settings.ExportProfileUseCase
 import org.meshtastic.core.domain.usecase.settings.ImportProfileUseCase
 import org.meshtastic.core.domain.usecase.settings.ImportSecurityConfigUseCase
 import org.meshtastic.core.domain.usecase.settings.InstallProfileUseCase
 import org.meshtastic.core.domain.usecase.settings.ProcessRadioResponseUseCase
+import org.meshtastic.core.domain.usecase.settings.ProfileInstallProgress
 import org.meshtastic.core.domain.usecase.settings.RadioConfigUseCase
 import org.meshtastic.core.domain.usecase.settings.RadioResponseResult
 import org.meshtastic.core.model.ConnectionState
@@ -85,6 +89,8 @@ import org.meshtastic.proto.LoRaRegionPresetMap
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.ModuleConfig.MeshBeaconConfig
+import org.meshtastic.proto.ModuleConfig.TrafficManagementConfig
 import org.meshtastic.proto.User
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -125,6 +131,7 @@ class RadioConfigViewModelTest {
     private val snackbarManager: SnackbarManager = mock(MockMode.autofill)
     private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
 
+    private lateinit var serviceConnectionState: MutableStateFlow<ConnectionState>
     private lateinit var viewModel: RadioConfigViewModel
 
     @BeforeTest
@@ -143,8 +150,8 @@ class RadioConfigViewModelTest {
         every { homoglyphEncodingPrefs.homoglyphEncodingEnabled } returns MutableStateFlow(false)
 
         every { serviceRepository.meshPacketFlow } returns MutableSharedFlow()
-        every { serviceRepository.connectionState } returns
-            MutableStateFlow(org.meshtastic.core.model.ConnectionState.Connected)
+        serviceConnectionState = MutableStateFlow(ConnectionState.Connected)
+        every { serviceRepository.connectionState } returns serviceConnectionState
 
         every { mqttManager.mqttConnectionState } returns
             MutableStateFlow(org.meshtastic.core.model.MqttConnectionState.Inactive)
@@ -185,6 +192,35 @@ class RadioConfigViewModelTest {
         mqttManager = mqttManager,
         lockdownCoordinator = FakeLockdownCoordinator(),
     )
+
+    @Test
+    fun `importProfile reports unreadable file instead of silently dropping result`() = runTest {
+        everySuspend { fileService.read(any(), any()) } returns false
+        var result: Result<DeviceProfile>? = null
+
+        viewModel.importProfile(CommonUri.parse("content://test/missing.cfg")) { result = it }
+        advanceUntilIdle()
+
+        assertFalse(assertNotNull(result).isSuccess)
+    }
+
+    @Test
+    fun `importProfile reports decoder failure exactly once`() = runTest {
+        everySuspend { fileService.read(any(), any()) } calls
+            { args ->
+                val block = args.arg<suspend (okio.BufferedSource) -> Unit>(1)
+                block(okio.Buffer().writeUtf8("not a profile"))
+                true
+            }
+        everySuspend { importProfileUseCase(any()) } returns Result.failure(IllegalArgumentException("bad profile"))
+        val results = mutableListOf<Result<DeviceProfile>>()
+
+        viewModel.importProfile(CommonUri.parse("content://test/bad.cfg"), results::add)
+        advanceUntilIdle()
+
+        assertEquals(1, results.size)
+        assertFalse(results.single().isSuccess)
+    }
 
     @Test
     fun `setConfig calls useCase`() = runTest {
@@ -985,14 +1021,14 @@ class RadioConfigViewModelTest {
         nodeRepository.setNodes(listOf(node))
         viewModel = createViewModel()
 
-        val config =
-            org.meshtastic.proto.ModuleConfig(mqtt = org.meshtastic.proto.ModuleConfig.MQTTConfig(enabled = true))
+        val trafficManagement = TrafficManagementConfig(position_min_interval_secs = 30)
+        val config = org.meshtastic.proto.ModuleConfig(traffic_management = trafficManagement)
         everySuspend { radioConfigUseCase.setModuleConfig(any(), any(), any()) } returns 42
 
         viewModel.setModuleConfig(config)
 
         verifySuspend { radioConfigUseCase.setModuleConfig(123, config, any()) }
-        assertEquals(true, viewModel.radioConfigState.value.moduleConfig.mqtt?.enabled)
+        assertEquals(trafficManagement, viewModel.radioConfigState.value.moduleConfig.traffic_management)
     }
 
     @Test
@@ -1029,11 +1065,106 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val profile = DeviceProfile()
-        everySuspend { installProfileUseCase(any(), any(), any()) } returns Unit
+        everySuspend { installProfileUseCase(any(), any(), any(), any(), any()) } returns Unit
+
+        var result: Result<Unit>? = null
+        viewModel.installProfile(profile) { result = it }
+        advanceUntilIdle()
+
+        verifySuspend { installProfileUseCase(123, profile, any(), true, any()) }
+        assertTrue(assertNotNull(result).isSuccess)
+    }
+
+    @Test
+    fun `installProfile binds owner context at invocation time`() = runTest {
+        val originalNode = Node(num = 123, user = User(id = "!123", long_name = "Original"))
+        val replacementNode = Node(num = 123, user = User(id = "!123", long_name = "Replacement"))
+        nodeRepository.setNodes(listOf(originalNode))
+        viewModel = createViewModel()
+        runCurrent()
+        val profile = DeviceProfile(long_name = "Updated")
+        everySuspend { installProfileUseCase(any(), any(), any(), any(), any()) } returns Unit
 
         viewModel.installProfile(profile)
+        nodeRepository.setNodes(listOf(replacementNode))
+        advanceUntilIdle()
 
-        verifySuspend { installProfileUseCase(123, profile, any()) }
+        verifySuspend { installProfileUseCase(123, profile, originalNode.user, true, any()) }
+    }
+
+    @Test
+    fun `installProfile exposes preparing and staged progress until completion`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        val allowProgress = CompletableDeferred<Unit>()
+        val releaseInstall = CompletableDeferred<Unit>()
+        everySuspend { installProfileUseCase(any(), any(), any(), any(), any()) } calls
+            { args ->
+                allowProgress.await()
+                args.arg<(ProfileInstallProgress) -> Unit>(4)(ProfileInstallProgress(2, 4))
+                releaseInstall.await()
+            }
+
+        viewModel.installProfile(DeviceProfile())
+        assertEquals(ProfileInstallState.Preparing, viewModel.profileInstallState.value)
+        allowProgress.complete(Unit)
+        runCurrent()
+        assertEquals(ProfileInstallState.Installing(2, 4), viewModel.profileInstallState.value)
+
+        releaseInstall.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(ProfileInstallState.Idle, viewModel.profileInstallState.value)
+    }
+
+    @Test
+    fun `installProfile rejects a second install while the first is active`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        val releaseInstall = CompletableDeferred<Unit>()
+        everySuspend { installProfileUseCase(any(), any(), any(), any(), any()) } calls { releaseInstall.await() }
+
+        viewModel.installProfile(DeviceProfile())
+        runCurrent()
+        var secondResult: Result<Unit>? = null
+        viewModel.installProfile(DeviceProfile()) { secondResult = it }
+
+        assertFalse(assertNotNull(secondResult).isSuccess)
+        verifySuspend(exactly(1)) { installProfileUseCase(any(), any(), any(), any(), any()) }
+        releaseInstall.complete(Unit)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `installProfile reports missing destination`() = runTest {
+        viewModel = createViewModel()
+        var result: Result<Unit>? = null
+
+        viewModel.installProfile(DeviceProfile()) { result = it }
+
+        assertFalse(assertNotNull(result).isSuccess)
+        verifySuspend(exactly(0)) { installProfileUseCase(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `installProfile reports staged restore failure`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val profile = DeviceProfile()
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
+        nodeRepository.setNodes(listOf(node))
+        serviceConnectionState.value = ConnectionState.Connected
+        viewModel = createViewModel()
+        runCurrent()
+        everySuspend { installProfileUseCase(123, profile, node.user, true, any()) } throws
+            IllegalStateException("restore interrupted")
+        var result: Result<Unit>? = null
+
+        viewModel.installProfile(profile) { result = it }
+        advanceUntilIdle()
+
+        verifySuspend { installProfileUseCase(123, profile, node.user, true, any()) }
+        assertFalse(assertNotNull(result).isSuccess)
     }
 
     @Test
@@ -1053,14 +1184,31 @@ class RadioConfigViewModelTest {
         assertEquals(5, viewModel.radioConfigState.value.radioConfig.lora?.hop_limit)
 
         // ModuleConfigResponse
-        val moduleResponse =
+        val telemetryResponse =
             org.meshtastic.proto.ModuleConfig(
                 telemetry = org.meshtastic.proto.ModuleConfig.TelemetryConfig(device_update_interval = 300),
             )
         every { processRadioResponseUseCase(any(), 123, any()) } returns
-            RadioResponseResult.ModuleConfigResponse(moduleResponse)
+            RadioResponseResult.ModuleConfigResponse(telemetryResponse)
         packetFlow.emit(MeshPacket())
         assertEquals(300, viewModel.radioConfigState.value.moduleConfig.telemetry?.device_update_interval)
+
+        val meshBeacon = MeshBeaconConfig(broadcast_message = "response beacon")
+        val meshBeaconResponse = org.meshtastic.proto.ModuleConfig(mesh_beacon = meshBeacon)
+        every { processRadioResponseUseCase(any(), 123, any()) } returns
+            RadioResponseResult.ModuleConfigResponse(meshBeaconResponse)
+        packetFlow.emit(MeshPacket())
+        assertEquals(300, viewModel.radioConfigState.value.moduleConfig.telemetry?.device_update_interval)
+        assertEquals(meshBeacon, viewModel.radioConfigState.value.moduleConfig.mesh_beacon)
+
+        val trafficManagement = TrafficManagementConfig(position_min_interval_secs = 30)
+        val trafficManagementResponse = org.meshtastic.proto.ModuleConfig(traffic_management = trafficManagement)
+        every { processRadioResponseUseCase(any(), 123, any()) } returns
+            RadioResponseResult.ModuleConfigResponse(trafficManagementResponse)
+        packetFlow.emit(MeshPacket())
+        assertEquals(300, viewModel.radioConfigState.value.moduleConfig.telemetry?.device_update_interval)
+        assertEquals(meshBeacon, viewModel.radioConfigState.value.moduleConfig.mesh_beacon)
+        assertEquals(trafficManagement, viewModel.radioConfigState.value.moduleConfig.traffic_management)
 
         // Owner
         val user = User(long_name = "New Name")

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -1115,6 +1116,29 @@ class RadioConfigViewModelTest {
         releaseInstall.complete(Unit)
         advanceUntilIdle()
         assertEquals(ProfileInstallState.Idle, viewModel.profileInstallState.value)
+    }
+
+    @Test
+    fun `cancelProfileInstall cancels the active restore and returns to idle`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        val installStarted = CompletableDeferred<Unit>()
+        var resultCallbackInvoked = false
+        everySuspend { installProfileUseCase(any(), any(), any(), any(), any()) } calls
+            {
+                installStarted.complete(Unit)
+                awaitCancellation()
+            }
+
+        viewModel.installProfile(DeviceProfile()) { resultCallbackInvoked = true }
+        installStarted.await()
+        viewModel.cancelProfileInstall()
+        advanceUntilIdle()
+
+        assertEquals(ProfileInstallState.Idle, viewModel.profileInstallState.value)
+        assertFalse(resultCallbackInvoked, "cancellation is not an installation result")
+        verifySuspend(exactly(1)) { installProfileUseCase(any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialogTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialogTest.kt
@@ -16,6 +16,9 @@
  */
 package org.meshtastic.feature.settings.radio.component
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
@@ -81,6 +84,29 @@ class EditDeviceProfileDialogTest {
 
         // Verify onDismiss is called
         assertTrue(onDismissClicked)
+    }
+
+    @Test
+    fun `selection resets when imported profile replaces initial profile`() = runComposeUiTest {
+        val initial = DeviceProfile(long_name = "Current node")
+        val imported = DeviceProfile(short_name = "IMPT")
+        var displayedProfile by mutableStateOf(initial)
+        var confirmedProfile: DeviceProfile? = null
+
+        setContent {
+            EditDeviceProfileDialog(
+                title = title,
+                deviceProfile = displayedProfile,
+                onConfirm = { confirmedProfile = it },
+                onDismiss = {},
+            )
+        }
+
+        runOnIdle { displayedProfile = imported }
+        waitForIdle()
+        onNodeWithText(getString(Res.string.save)).performClick()
+
+        assertEquals(imported, confirmedProfile)
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialogTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/EditDeviceProfileDialogTest.kt
@@ -27,11 +27,14 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.cancel
 import org.meshtastic.core.resources.getString
+import org.meshtastic.core.resources.licensed_amateur_radio
 import org.meshtastic.core.resources.save
 import org.meshtastic.proto.DeviceProfile
 import org.meshtastic.proto.Position
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
@@ -107,6 +110,27 @@ class EditDeviceProfileDialogTest {
         onNodeWithText(getString(Res.string.save)).performClick()
 
         assertEquals(imported, confirmedProfile)
+    }
+
+    @Test
+    fun `licensed mode is not offered or restored`() = runComposeUiTest {
+        val licensedProfile = deviceProfile.copy(is_licensed = true)
+        var confirmedProfile: DeviceProfile? = null
+
+        setContent {
+            EditDeviceProfileDialog(
+                title = title,
+                deviceProfile = licensedProfile,
+                onConfirm = { confirmedProfile = it },
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithText(getString(Res.string.licensed_amateur_radio)).assertDoesNotExist()
+        onNodeWithText(getString(Res.string.save)).performClick()
+
+        val confirmed = assertNotNull(confirmedProfile)
+        assertNull(confirmed.is_licensed)
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change set improves device profile import and restore with staged installation, stronger BLE and connection lifecycle handling, shared channel replacement and cache reconciliation, firmware-aware LoRa presets, and database flow recovery. It also adds UI progress and error handling and expands test coverage.

## Key changes

### Features
- Added staged, restart-aware profile installation with progress reporting, transport-specific writes, channel restoration, and module configuration support.
- Added profile import and installation states, progress dialogs, error messages, and Bluetooth repair guidance.
- Added shared channel replacement planning, normalization, slot cleanup, duplicate filtering, and cache reconciliation.
- Added correlated connection lifecycle and epoch tracking through `ConnectionLifecycle`, `ConnectionEpochs`, and `ConnectionStateHolder`.
- Added firmware-aware LoRa region preset selection, including firmware 2.8 defaults.
- Added detailed awaited-send results through `AwaitedSendResult` and `AwaitedSendStatus`.
- Added database flow observation with recovery from Room pool-acquisition timeouts.
- Replaced raw BLE addresses in logs and user-facing errors with anonymized addresses.

### Fixes
- Hardened BLE connection handling against overlapping attempts, stale ownership, disconnect races, cancellation, and teardown failures.
- Added a five-second timeout for Android MTU negotiation.
- Improved packet queue admission, packet ID handling, cleanup, timeout, cancellation, and transport failure reporting.
- Improved admin transaction handling for queue rejection, cancellation, commit failures, and local transport shutdown.
- Updated channel-cache reconciliation to run after accepted writes while preserving primary failures and cancellation.
- Stabilized node notification decisions across database readiness and CAS retries.
- Improved map lifecycle handling when the lifecycle instance or tile source changes.
- Updated RSSI polling to follow lifecycle state and use a longer interval.
- Preserved packet status when storing local reactions instead of always marking them as queued.

### Refactors
- Added `trySendToRadio(...)` and the `RadioTransportWriter` abstraction for synchronous transport admission.
- Updated packet and admin sender APIs to expose admission results with compatibility wrappers.
- Centralized profile-install planning, field filtering, and write helpers in the domain layer.
- Centralized database switching through `observeCurrentDb`.
- Added shared test fakes and broader tests for BLE races, queue behavior, lifecycle epochs, profile installation, channel reconciliation, database recovery, and UI behavior.

## Breaking changes and migration notes

- `PacketHandler.sendToRadio(...)` now returns `Boolean`. Use `sendToRadioAndAwaitResult(...)` for detailed awaited results.
- `CommandSender` adds `sendAdminAwaitResult(...)`. `sendAdminAwait(...)` remains as a compatibility wrapper.
- Transport implementations should provide `trySendToRadio(bytes): Boolean`.
- `InstallProfileUseCase` requires new dependencies and an updated invocation signature with `isLocal` and progress callbacks.
- `defaultPresetFor(...)` now requires `Capabilities`. Use `presetForFreshRegion(...)` for fresh-region selection.
- Profile import callbacks now return `Result<DeviceProfile>`. Installation callbacks return `Result<Unit>`.
- Consumers that need correlated lifecycle information can use `connectionLifecycle` and `connectionEpochs`.
- `ConnectionStatus.MUST_SET_REGION` and `ConnectionsViewModel.regionUnset` were removed. Use `regionRequired` and `regionConfigurationAllowed`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->