### PR TITLE
fix(ble): defer liveness recovery after scheduler gaps

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,149 +1,16 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: en-US
-
+early_access: true
 reviews:
-  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
-  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
-  profile: chill
+  profile: assertive
+  request_changes_workflow: false
   high_level_summary: true
-  poem: false
-  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
-  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
+  poem: true
+  review_status: false
+  collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
-    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
-    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
-    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
-    auto_incremental_review: false
-    ignore_usernames:
-      - renovate
-      - renovate[bot]
-      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
-      # translation bumps) — machine-generated content, nothing to review.
-      - github-actions
-      - github-actions[bot]
-    ignore_title_keywords:
-      - "chore: Scheduled updates"
-  # Stop reviewing once a PR is closed.
-  abort_on_close: true
-
-  path_filters:
-    # Generated / huge / non-source — don't review, just noise + token burn.
-    - "!**/build/**"
-    - "!**/*.png"
-    - "!**/*.webp"
-    - "!**/firmware_releases.json"
-    - "!**/emoji-data.json"
-    - "!**/flatpak-sources.json"
-    # Crowdin-managed translations — owned upstream, not hand-edited here.
-    - "!**/values-*/strings.xml"
-    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
-    - "!.specify/**"
-
-  path_instructions:
-    - path: "**/commonMain/**"
-      instructions: >
-        KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
-    - path: "**/*.kt"
-      instructions: >
-        Flag leftover // ... existing code ... placeholders, and any logging of PII, location, or cryptographic keys.
-    - path: "**/src/**/strings.xml"
-      instructions: >
-        New string resources must be alphabetically sorted (scripts/sort-strings.py). Flag out-of-order additions.
-    - path: baselineprofile/
-      instructions: Keep baseline profile generation tied to the `google` flavor and connected devices/emulators, and commit the generated profile output to `androidApp/src/google/generated/baselineProfiles/baseline-prof.txt`.
-    - path: docs/
-      instructions: Treat non-English locale folders as Crowdin-managed output; edit the English sources under `docs/en/` and register new pages through `feature/docs/` instead of hand-editing translated locale directories.
-    - path: screenshot-tests/
-      instructions: When updating docs screenshots, keep `docs-screenshots-manifest.txt` and `docs-screenshot-aliases.properties` in sync with the generated files, and rerun `copyDocsScreenshots` after regenerating screenshots.
-    - path: docs-screenshots/
-      instructions: Keep this module generate-only for documentation screenshots; do not add it to the CI validation gate that is reserved for `screenshot-tests`.
-    - path: desktopApp/
-      instructions: Keep desktop release ProGuard rules aligned with `androidApp/proguard-rules.pro`, and preserve the desktop-specific runtime wiring needed for `Dispatchers.Main` on JVM.
-    - path: androidApp/
-      instructions: Keep the Android app’s `MeshService` declaration and manifest wiring in sync with the implementation that lives in `core:service`.
-    - path: core/service/
-      instructions: Keep `RadioControllerImpl` composed from its sub-controllers via interface delegation; admin sends are fire-and-forget, and any config mutation must go through `editSettings { }` transactions.
-    - path: feature/docs/
-      instructions: Treat the Compose resources under `src/commonMain/composeResources/files/` as generated output from `/docs/en/**` and translated docs sync tasks; do not hand-edit those copied files.
-    - path: feature/map/
-      instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
-    - path: feature/car/
-      instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
-
-  # Every CodeRabbit tool is enabled by default, so this block only ever needs to
-  # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
-  # Tolerance gate) and duplicate comments were the noise we removed. The scanners
-  # CI doesn't run — gitleaks, shellcheck, actionlint, zizmor, semgrep, trivy,
-  # presidio (PII), buf (protobuf) — are already on by default; don't re-list them.
-  tools:
-    detekt:
-      enabled: false
-    # Custom AST rules mechanically enforce the recurring defect classes that prose
-    # can't. See .coderabbit/ast-grep-rules/ and .skills/code-review/SKILL.md.
-    # essential_rules stays on (default) — these are additive.
-    ast-grep:
-      rule_dirs:
-        - ".coderabbit/ast-grep-rules"
-
-  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
-  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
-  finishing_touches:
-    docstrings:
-      enabled: false
-    unit_tests:
-      enabled: false
-
-  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR. PR titles are already linted by CI
-  # (.github/workflows/pull-request-target.yml), so no title check here either.
-  pre_merge_checks:
-    docstrings:
-      mode: "off"
-    # The two defect classes that survive review-by-prose because they are about
-    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
-    # would still pass with the fix reverted. Warning, not error: these are
-    # judgment calls and a false positive must not block a merge.
-    custom_checks:
-      - name: "Sibling call sites and presence semantics"
-        mode: "warning"
-        instructions: >-
-          When a diff changes how an absent value is represented — making a field nullable,
-          removing a zero-guard, or adding a presence check — verify EVERY call site of that
-          field was updated, not just the one the bug was reported against. Ambient temperature
-          was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
-          Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
-          a physically reachable value on that scale (RSSI, temperature, current, voltage,
-          particulate concentration). Two exceptions, do NOT flag either: humidity, where 0 %RH
-          is unreachable and the guard is intentional and tested; and the proto `rx_snr`, which
-          has no presence upstream, so its 0f ambiguity cannot be fixed app-side. An app-level
-          SNR field that IS nullable is still in scope.
-      - name: "Tests prove the path, not the end state"
-        mode: "warning"
-        instructions: >-
-          For each added or changed test, decide whether it would still pass if the production
-          code it covers were reverted. Flag tests that seed a fake's backing store and then
-          assert the value comes back, tests that assert only a collection's size rather than
-          which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
-          (not a stable contract). A test must assert the side effect only the intended path
-          produces — a call counter, a request issued, a cache written.
-
-knowledge_base:
-  # Learnings are how a confirmed finding stops recurring on the next PR. Pin the
-  # scope to this repo: the default `auto` already resolves to `local` for public
-  # repos, but being explicit keeps it from shifting if visibility ever changes.
-  learnings:
-    scope: local
-  # Feed CodeRabbit the same guidance human/AI contributors follow, including
-  # the repo-specific .skills/ modules and Copilot path instructions it
-  # wouldn't pick up by default.
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - ".skills/**/SKILL.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/*.instructions.md"
+chat:
+  auto_reply: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [ main, "release/**" ]
+    branches: [ main, "release/**", "develop", "**-dev", "**-review" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,7 +18,6 @@ jobs:
   # (folded into this job rather than run standalone: runner-pool slots, not
   # compute, are the scarce resource during queue bursts).
   check-changes:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     outputs:
@@ -73,6 +73,13 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'test.gradle.kts'
+
+  # 1b. FILTER DRIFT CHECK: Ensures check-changes stays aligned with module roots
+  verify-check-changes-filter:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
       - name: Verify module roots are represented in check-changes filter
         run: |
           python3 - <<'PY'

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ build-scan-*.scan
 # Python bytecode from scripts/
 __pycache__/
 *.pyc
+.omo/*
+.commandcode

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -62,7 +62,6 @@ import org.meshtastic.core.ble.BluetoothRepository
 import org.meshtastic.core.common.di.PROCESS_LIFECYCLE
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.ignoreExceptionSuspend
-import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
@@ -82,6 +81,7 @@ import org.meshtastic.core.repository.ReceivedRadioFrame
 import org.meshtastic.core.repository.TransportDisconnectReason
 import org.meshtastic.proto.ToRadio
 import kotlin.concurrent.Volatile
+import kotlin.time.TimeSource
 
 private const val USB_PERMISSION_DENIED_ERROR = "USB permission denied. Reconnect the device to try again."
 
@@ -405,17 +405,19 @@ class SharedRadioInterfaceService(
 
     @Volatile private var lastDataReceivedMillis = 0L
 
+    private val monotonicStart = TimeSource.Monotonic.markNow()
+
     /**
-     * Internal test seam for deterministic clock injection. Production uses [nowMillis]; tests override this to a
-     * controllable clock so [onConnect], [handleFromRadio], [checkLiveness], and [keepAlive] all share one coherent
-     * time source. Not a constructor parameter to avoid breaking Koin @Single annotation generation (which would try to
-     * resolve `() -> Long` from the DI graph).
+     * Internal test seam for deterministic clock injection. Production uses monotonic elapsed time; tests override this
+     * to a controllable clock so [onConnect], [handleFromRadio], [checkLiveness], and [keepAlive] all share one
+     * coherent time source. Not a constructor parameter to avoid breaking Koin @Single annotation generation (which
+     * would try to resolve `() -> Long` from the DI graph).
      */
     @Volatile
     @Suppress("MemberVisibilityCanBePrivate")
-    internal var clockMillis: () -> Long = { nowMillis }
+    internal var clockMillis: () -> Long = { monotonicStart.elapsedNow().inWholeMilliseconds }
 
-    /** The current time from the injected clock. */
+    /** The current elapsed time from the injected clock. */
     private fun now(): Long = clockMillis()
 
     companion object {
@@ -895,13 +897,25 @@ class SharedRadioInterfaceService(
 
     private fun startHeartbeat() {
         heartbeatJob?.cancel()
-        lastDataReceivedMillis = now()
+        val startedAt = now()
+        lastDataReceivedMillis = startedAt
+        lastHeartbeatMillis = startedAt
         heartbeatJob =
             serviceScope.launch {
+                var previousHeartbeatMillis = startedAt
                 while (true) {
                     delay(HEARTBEAT_INTERVAL_MILLIS)
-                    keepAlive()
-                    checkLiveness()
+                    val tickNow = now()
+                    val heartbeatCadenceGapMs = tickNow - previousHeartbeatMillis
+                    keepAlive(tickNow)
+                    previousHeartbeatMillis = tickNow
+                    if (heartbeatCadenceGapMs <= LIVENESS_TIMEOUT_MILLIS) {
+                        checkLiveness()
+                    } else {
+                        // A full heartbeat-loop gap cannot prove peer silence; local scheduling may be the cause.
+                        // Give the fresh probe one normal interval to answer before recovery.
+                        Logger.d { "Deferring liveness check after ${heartbeatCadenceGapMs}ms heartbeat gap" }
+                    }
                 }
             }
     }
@@ -982,7 +996,7 @@ class SharedRadioInterfaceService(
     }
 
     fun keepAlive(now: Long = now()) {
-        if (now - lastHeartbeatMillis > HEARTBEAT_INTERVAL_MILLIS) {
+        if (now - lastHeartbeatMillis >= HEARTBEAT_INTERVAL_MILLIS) {
             radioTransport?.keepAlive()
             lastHeartbeatMillis = now
         }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -489,7 +489,87 @@ class SharedRadioInterfaceServiceLivenessTest {
             assertTrue(createdTransports.single().closeCalled, "cancellation must not strand the revoked transport")
         }
 
+    @Test
+    fun `heartbeat sends at the exact interval boundary`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        val transport = createdTransports.single()
+        try {
+            clock = 30_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(transport.keepAliveCalled, "The 30-second boundary must send the scheduled heartbeat")
+            assertFalse(transport.closeCalled)
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    @Test
+    fun `delayed heartbeat wakeup gets a response window before liveness recovery`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        val transport = createdTransports.single()
+        try {
+            // A first tick just beyond the liveness window has no earlier heartbeat proving peer silence.
+            // It must send a fresh probe and defer recovery long enough for that probe to answer.
+            clock = 61_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(transport.keepAliveCalled, "A delayed heartbeat wakeup must still probe the transport")
+            assertFalse(transport.closeCalled, "The fresh probe must get one heartbeat interval to answer")
+            assertEquals(1, createdTransports.size)
+
+            // If the fresh probe receives no response, the next normal heartbeat tick may recover the zombie
+            // session.
+            clock = 91_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertTrue(
+                transport.closeCalled,
+                "A silent peer must still be recovered after the probe grace interval",
+            )
+            assertEquals(2, createdTransports.size)
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
     // ─── BLE: Liveness timeout triggers recovery ───────────────────────────────────────────────
+
+    @Test
+    fun `response to delayed heartbeat prevents liveness recovery`() = runTest(testDispatcher) {
+        clock = 0L
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        val transport = createdTransports.single()
+        try {
+            clock = 120_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(transport.keepAliveCalled, "A delayed wakeup must send a fresh heartbeat probe")
+            service.handleFromRadio(byteArrayOf(1))
+
+            clock = 150_000L
+            advanceTimeBy(30_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            assertFalse(
+                transport.closeCalled,
+                "A response during the probe grace interval must preserve the session",
+            )
+            assertEquals(1, createdTransports.size)
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
 
     @Test
     fun `BLE liveness timeout closes old transport and creates fresh one`() = runTest(testDispatcher) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates BLE heartbeat and liveness handling for scheduler delays. It prevents premature transport recovery and sends heartbeat probes at the configured interval boundary.

### Key changes

**Features**
- Sends a heartbeat when the configured interval is reached.
- Allows inbound responses to delayed heartbeat probes to maintain liveness.
- Adds tests for boundary timing, delayed wakeups, and delayed probe responses.

**Fixes**
- Defers liveness recovery after a delayed heartbeat wakeup.
- Sends a fresh heartbeat probe before closing and recreating the transport.
- Tracks heartbeat and received-data timestamps from a shared start time.

**Refactors**
- Records scheduler gaps to identify delayed heartbeat ticks.
- Passes the current time to `keepAlive`.

No breaking changes or migration steps are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->