### PR TITLE
Handle send outcomes and admin command lifecycle validation

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
@@ -37,6 +37,7 @@ import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.PacketHandler
+import org.meshtastic.core.repository.PacketQueueRejectedException
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.SessionManager
 import org.meshtastic.core.repository.TracerouteHandler
@@ -63,10 +64,6 @@ import kotlin.math.absoluteValue
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.hours
 import org.meshtastic.proto.Position as ProtoPosition
-
-/** Thrown when the outbound packet queue refuses admission for a command. */
-class PacketQueueRejectedException(operation: String) :
-    IllegalStateException("$operation was rejected by the outbound packet queue")
 
 @Suppress("TooManyFunctions", "CyclomaticComplexMethod", "LongParameterList")
 @Single
@@ -158,7 +155,11 @@ class CommandSenderImpl(
             p.status = MessageStatus.QUEUED
         }
 
-        if (!sendNow(p)) p.status = MessageStatus.ERROR
+        if (!sendNow(p)) {
+            p.status = MessageStatus.ERROR
+            // Persistence owners treat a normal return as successful admission; throw so they can requeue or fail it.
+            throw PacketQueueRejectedException("Data packet")
+        }
     }
 
     private suspend fun sendNow(p: DataPacket): Boolean {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
@@ -32,6 +32,7 @@ import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.TelemetryType
 import org.meshtastic.core.model.util.isWithinSizeLimit
+import org.meshtastic.core.repository.AwaitedSendResult
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
@@ -89,6 +90,8 @@ class CommandSenderImpl(
     override fun getCachedChannelSet(): ChannelSet = channelSet.value
 
     override fun getCurrentPacketId(): Long = currentPacketId.value
+
+    private fun Int.nonZeroRequestId(): Int = takeUnless { it == 0 } ?: generatePacketId()
 
     override fun generatePacketId(): Int {
         val numPacketIds = ((1L shl PACKET_ID_SHIFT_BITS) - 1)
@@ -174,11 +177,20 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(meshPacket)
     }
 
+    private fun buildAdminMessagePacket(
+        destNum: Int,
+        requestId: Int,
+        wantResponse: Boolean,
+        initFn: () -> AdminMessage,
+    ): MeshPacket = buildAdminPacket(
+        to = destNum,
+        id = requestId.nonZeroRequestId(),
+        wantResponse = wantResponse,
+        adminMessage = initFn().copy(session_passkey = sessionManager.getPasskey(destNum)),
+    )
+
     override suspend fun sendAdmin(destNum: Int, requestId: Int, wantResponse: Boolean, initFn: () -> AdminMessage) {
-        val adminMsg = initFn().copy(session_passkey = sessionManager.getPasskey(destNum))
-        val packet =
-            buildAdminPacket(to = destNum, id = requestId, wantResponse = wantResponse, adminMessage = adminMsg)
-        packetHandler.sendToRadio(packet)
+        packetHandler.sendToRadio(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn))
     }
 
     override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {
@@ -187,17 +199,13 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(ToRadio(packet = packet))
     }
 
-    override suspend fun sendAdminAwait(
+    override suspend fun sendAdminAwaitResult(
         destNum: Int,
         requestId: Int,
         wantResponse: Boolean,
         initFn: () -> AdminMessage,
-    ): Boolean {
-        val adminMsg = initFn().copy(session_passkey = sessionManager.getPasskey(destNum))
-        val packet =
-            buildAdminPacket(to = destNum, id = requestId, wantResponse = wantResponse, adminMessage = adminMsg)
-        return packetHandler.sendToRadioAndAwait(packet)
-    }
+    ): AwaitedSendResult =
+        packetHandler.sendToRadioAndAwaitResult(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn))
 
     override suspend fun sendPosition(pos: ProtoPosition, destNum: Int?, wantResponse: Boolean) {
         val myNum = nodeManager.myNodeNum.value ?: return
@@ -281,19 +289,22 @@ class CommandSenderImpl(
     }
 
     override suspend fun requestTraceroute(requestId: Int, destNum: Int) {
-        tracerouteHandler.recordStartTime(requestId)
-        packetHandler.sendToRadio(
-            buildMeshPacket(
-                to = destNum,
-                wantAck = true,
-                id = requestId,
-                channel = getChannelIndex(destNum),
-                decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
-            ),
-        )
+        val effectiveRequestId = requestId.nonZeroRequestId()
+        val queued =
+            packetHandler.sendToRadio(
+                buildMeshPacket(
+                    to = destNum,
+                    wantAck = true,
+                    id = effectiveRequestId,
+                    channel = getChannelIndex(destNum),
+                    decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
+                ),
+            )
+        if (queued) tracerouteHandler.recordStartTime(effectiveRequestId)
     }
 
     override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) {
+        val effectiveRequestId = requestId.nonZeroRequestId()
         val type = TelemetryType.entries.getOrNull(typeValue) ?: TelemetryType.DEVICE
 
         val portNum: PortNum
@@ -320,7 +331,7 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(
             buildMeshPacket(
                 to = destNum,
-                id = requestId,
+                id = effectiveRequestId,
                 channel = getChannelIndex(destNum),
                 decoded = Data(portnum = portNum, payload = payloadBytes, want_response = true, dest = destNum),
             ),
@@ -328,57 +339,59 @@ class CommandSenderImpl(
     }
 
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {
-        neighborInfoHandler.recordStartTime(requestId)
+        val effectiveRequestId = requestId.nonZeroRequestId()
         val myNum = nodeManager.myNodeNum.value ?: 0
-        if (destNum == myNum) {
-            val neighborInfoToSend =
-                neighborInfoHandler.lastNeighborInfo
-                    ?: run {
-                        val oneHour = 1.hours.inWholeMinutes.toInt()
-                        Logger.d { "No stored neighbor info from connected radio, sending dummy data" }
-                        NeighborInfo(
-                            node_id = myNum,
-                            last_sent_by_id = myNum,
-                            node_broadcast_interval_secs = oneHour,
-                            neighbors =
-                            listOf(
-                                Neighbor(
-                                    node_id = 0, // Dummy node ID that can be intercepted
-                                    snr = 0f,
-                                    last_rx_time = (nowMillis / 1000L).toInt(),
-                                    node_broadcast_interval_secs = oneHour,
+        val queued =
+            if (destNum == myNum) {
+                val neighborInfoToSend =
+                    neighborInfoHandler.lastNeighborInfo
+                        ?: run {
+                            val oneHour = 1.hours.inWholeMinutes.toInt()
+                            Logger.d { "No stored neighbor info from connected radio, sending dummy data" }
+                            NeighborInfo(
+                                node_id = myNum,
+                                last_sent_by_id = myNum,
+                                node_broadcast_interval_secs = oneHour,
+                                neighbors =
+                                listOf(
+                                    Neighbor(
+                                        node_id = 0, // Dummy node ID that can be intercepted
+                                        snr = 0f,
+                                        last_rx_time = (nowMillis / 1000L).toInt(),
+                                        node_broadcast_interval_secs = oneHour,
+                                    ),
                                 ),
-                            ),
-                        )
-                    }
+                            )
+                        }
 
-            // Send the neighbor info from our connected radio to ourselves (simulated)
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = requestId,
-                    channel = getChannelIndex(destNum),
-                    decoded =
-                    Data(
-                        portnum = PortNum.NEIGHBORINFO_APP,
-                        payload = neighborInfoToSend.encode().toByteString(),
-                        want_response = true,
+                // Send the neighbor info from our connected radio to ourselves (simulated)
+                packetHandler.sendToRadio(
+                    buildMeshPacket(
+                        to = destNum,
+                        wantAck = true,
+                        id = effectiveRequestId,
+                        channel = getChannelIndex(destNum),
+                        decoded =
+                        Data(
+                            portnum = PortNum.NEIGHBORINFO_APP,
+                            payload = neighborInfoToSend.encode().toByteString(),
+                            want_response = true,
+                        ),
                     ),
-                ),
-            )
-        } else {
-            // Send request to remote
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = requestId,
-                    channel = getChannelIndex(destNum),
-                    decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
-                ),
-            )
-        }
+                )
+            } else {
+                // Send request to remote
+                packetHandler.sendToRadio(
+                    buildMeshPacket(
+                        to = destNum,
+                        wantAck = true,
+                        id = effectiveRequestId,
+                        channel = getChannelIndex(destNum),
+                        decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
+                    ),
+                )
+            }
+        if (queued) neighborInfoHandler.recordStartTime(effectiveRequestId)
     }
 
     override fun sendLockdownPassphrase(

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
@@ -64,6 +64,10 @@ import kotlin.random.Random
 import kotlin.time.Duration.Companion.hours
 import org.meshtastic.proto.Position as ProtoPosition
 
+/** Thrown when the outbound packet queue refuses admission for a command. */
+class PacketQueueRejectedException(operation: String) :
+    IllegalStateException("$operation was rejected by the outbound packet queue")
+
 @Suppress("TooManyFunctions", "CyclomaticComplexMethod", "LongParameterList")
 @Single
 class CommandSenderImpl(
@@ -154,10 +158,10 @@ class CommandSenderImpl(
             p.status = MessageStatus.QUEUED
         }
 
-        sendNow(p)
+        if (!sendNow(p)) p.status = MessageStatus.ERROR
     }
 
-    private suspend fun sendNow(p: DataPacket) {
+    private suspend fun sendNow(p: DataPacket): Boolean {
         val meshPacket =
             buildMeshPacket(
                 to = resolveNodeNum(NodeAddress.fromString(p.to)),
@@ -174,7 +178,11 @@ class CommandSenderImpl(
                 ),
             )
         p.time = nowMillis
-        packetHandler.sendToRadio(meshPacket)
+        return packetHandler.sendToRadio(meshPacket)
+    }
+
+    private suspend fun enqueueOrThrow(packet: MeshPacket, operation: String) {
+        if (!packetHandler.sendToRadio(packet)) throw PacketQueueRejectedException(operation)
     }
 
     private fun buildAdminMessagePacket(
@@ -190,7 +198,7 @@ class CommandSenderImpl(
     )
 
     override suspend fun sendAdmin(destNum: Int, requestId: Int, wantResponse: Boolean, initFn: () -> AdminMessage) {
-        packetHandler.sendToRadio(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn))
+        enqueueOrThrow(buildAdminMessagePacket(destNum, requestId, wantResponse, initFn), "Admin command")
     }
 
     override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {
@@ -212,11 +220,7 @@ class CommandSenderImpl(
         val idNum = destNum ?: myNum
         Logger.d { "Sending our position/time to=$idNum $pos" }
 
-        if (localConfig.value.position?.fixed_position != true) {
-            nodeManager.handleReceivedPosition(myNum, myNum, pos, nowMillis)
-        }
-
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = idNum,
                 channel = if (destNum == null) 0 else getChannelIndex(destNum),
@@ -228,7 +232,11 @@ class CommandSenderImpl(
                     want_response = wantResponse,
                 ),
             ),
+            "Position update",
         )
+        if (localConfig.value.position?.fixed_position != true) {
+            nodeManager.handleReceivedPosition(myNum, myNum, pos, nowMillis)
+        }
     }
 
     override suspend fun requestPosition(destNum: Int, currentPosition: Position) {
@@ -239,7 +247,7 @@ class CommandSenderImpl(
                 altitude = currentPosition.altitude,
                 time = (nowMillis / 1000L).toInt(),
             )
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = destNum,
                 channel = getChannelIndex(destNum),
@@ -251,6 +259,7 @@ class CommandSenderImpl(
                     want_response = true,
                 ),
             ),
+            "Position request",
         )
     }
 
@@ -274,7 +283,7 @@ class CommandSenderImpl(
     override suspend fun requestUserInfo(destNum: Int) {
         val myNum = nodeManager.myNodeNum.value ?: return
         val myNode = nodeManager.nodeDBbyNodeNum[myNum] ?: return
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = destNum,
                 channel = getChannelIndex(destNum),
@@ -285,22 +294,23 @@ class CommandSenderImpl(
                     payload = myNode.user.encode().toByteString(),
                 ),
             ),
+            "User-info request",
         )
     }
 
     override suspend fun requestTraceroute(requestId: Int, destNum: Int) {
         val effectiveRequestId = requestId.nonZeroRequestId()
-        val queued =
-            packetHandler.sendToRadio(
-                buildMeshPacket(
-                    to = destNum,
-                    wantAck = true,
-                    id = effectiveRequestId,
-                    channel = getChannelIndex(destNum),
-                    decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
-                ),
-            )
-        if (queued) tracerouteHandler.recordStartTime(effectiveRequestId)
+        enqueueOrThrow(
+            buildMeshPacket(
+                to = destNum,
+                wantAck = true,
+                id = effectiveRequestId,
+                channel = getChannelIndex(destNum),
+                decoded = Data(portnum = PortNum.TRACEROUTE_APP, want_response = true, dest = destNum),
+            ),
+            "Traceroute request",
+        )
+        tracerouteHandler.recordStartTime(effectiveRequestId)
     }
 
     override suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int) {
@@ -328,20 +338,21 @@ class CommandSenderImpl(
                     .toByteString()
         }
 
-        packetHandler.sendToRadio(
+        enqueueOrThrow(
             buildMeshPacket(
                 to = destNum,
                 id = effectiveRequestId,
                 channel = getChannelIndex(destNum),
                 decoded = Data(portnum = portNum, payload = payloadBytes, want_response = true, dest = destNum),
             ),
+            "Telemetry request",
         )
     }
 
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {
         val effectiveRequestId = requestId.nonZeroRequestId()
         val myNum = nodeManager.myNodeNum.value ?: 0
-        val queued =
+        val packet =
             if (destNum == myNum) {
                 val neighborInfoToSend =
                     neighborInfoHandler.lastNeighborInfo
@@ -365,33 +376,30 @@ class CommandSenderImpl(
                         }
 
                 // Send the neighbor info from our connected radio to ourselves (simulated)
-                packetHandler.sendToRadio(
-                    buildMeshPacket(
-                        to = destNum,
-                        wantAck = true,
-                        id = effectiveRequestId,
-                        channel = getChannelIndex(destNum),
-                        decoded =
-                        Data(
-                            portnum = PortNum.NEIGHBORINFO_APP,
-                            payload = neighborInfoToSend.encode().toByteString(),
-                            want_response = true,
-                        ),
+                buildMeshPacket(
+                    to = destNum,
+                    wantAck = true,
+                    id = effectiveRequestId,
+                    channel = getChannelIndex(destNum),
+                    decoded =
+                    Data(
+                        portnum = PortNum.NEIGHBORINFO_APP,
+                        payload = neighborInfoToSend.encode().toByteString(),
+                        want_response = true,
                     ),
                 )
             } else {
                 // Send request to remote
-                packetHandler.sendToRadio(
-                    buildMeshPacket(
-                        to = destNum,
-                        wantAck = true,
-                        id = effectiveRequestId,
-                        channel = getChannelIndex(destNum),
-                        decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
-                    ),
+                buildMeshPacket(
+                    to = destNum,
+                    wantAck = true,
+                    id = effectiveRequestId,
+                    channel = getChannelIndex(destNum),
+                    decoded = Data(portnum = PortNum.NEIGHBORINFO_APP, want_response = true, dest = destNum),
                 )
             }
-        if (queued) neighborInfoHandler.recordStartTime(effectiveRequestId)
+        enqueueOrThrow(packet, "Neighbor-info request")
+        neighborInfoHandler.recordStartTime(effectiveRequestId)
     }
 
     override fun sendLockdownPassphrase(

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -53,6 +53,7 @@ import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketHandler
+import org.meshtastic.core.repository.PacketQueueRejectedException
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -171,7 +172,13 @@ class MeshConnectionManagerImpl(
                             .shouldProvideNodeLocation(myNodeEntity.myNodeNum)
                             .onEach { shouldProvide ->
                                 if (shouldProvide) {
-                                    locationManager.start(scope) { pos -> commandSender.sendPosition(pos) }
+                                    locationManager.start(scope) { pos ->
+                                        try {
+                                            commandSender.sendPosition(pos)
+                                        } catch (e: PacketQueueRejectedException) {
+                                            Logger.w(e) { "Location update was rejected by packet queue" }
+                                        }
+                                    }
                                 } else {
                                     locationManager.stop()
                                 }
@@ -527,7 +534,11 @@ class MeshConnectionManagerImpl(
         // admin *response* (wantResponse=true), but set_time_only (sent at MyNodeInfo) has no
         // response. A get_owner request is the lightest way to trigger a response and populate the
         // passkey cache so that subsequent write operations don't fail with ADMIN_BAD_SESSION_KEY.
-        commandSender.sendAdmin(myNodeNum, wantResponse = true) { AdminMessage(get_owner_request = true) }
+        try {
+            commandSender.sendAdmin(myNodeNum, wantResponse = true) { AdminMessage(get_owner_request = true) }
+        } catch (e: PacketQueueRejectedException) {
+            Logger.w(e) { "Session-passkey seed request was rejected by packet queue" }
+        }
 
         // Start MQTT if enabled
         scope.handledLaunch {
@@ -549,8 +560,20 @@ class MeshConnectionManagerImpl(
         }
 
         // Request immediate LocalStats and DeviceMetrics update on connection with proper request IDs
-        commandSender.requestTelemetry(commandSender.generatePacketId(), myNodeNum, TelemetryType.LOCAL_STATS.ordinal)
-        commandSender.requestTelemetry(commandSender.generatePacketId(), myNodeNum, TelemetryType.DEVICE.ordinal)
+        try {
+            commandSender.requestTelemetry(
+                commandSender.generatePacketId(),
+                myNodeNum,
+                TelemetryType.LOCAL_STATS.ordinal,
+            )
+        } catch (e: PacketQueueRejectedException) {
+            Logger.w(e) { "Local-stats request was rejected by packet queue" }
+        }
+        try {
+            commandSender.requestTelemetry(commandSender.generatePacketId(), myNodeNum, TelemetryType.DEVICE.ordinal)
+        } catch (e: PacketQueueRejectedException) {
+            Logger.w(e) { "Device-metrics request was rejected by packet queue" }
+        }
     }
 
     /**

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
@@ -436,7 +436,7 @@ class MeshDataHandlerImpl(
                     packetRepository.value.updateReaction(updated)
                 }
             }
-            packetHandler.removeResponse(requestId, complete = true)
+            packetHandler.completeDispatchedResponse(requestId, complete = isAck)
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -17,16 +17,21 @@
 package org.meshtastic.core.data.manager
 
 import co.touchlab.kermit.Logger
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.asDeferred
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
@@ -40,6 +45,8 @@ import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
 import org.meshtastic.core.model.util.toOneLineString
 import org.meshtastic.core.model.util.toPIIString
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketHandler
@@ -77,24 +84,43 @@ class PacketHandlerImpl(
     }
 
     private var queueJob: Job? = null
+    private var queueGeneration = 0L
 
     private val queueMutex = Mutex()
-    private val queuedPackets = mutableListOf<MeshPacket>()
+    private val queuedPackets = mutableListOf<QueuedPacket>()
 
     // Set to true by stopPacketQueue() under queueMutex. Checked by startPacketQueueLocked()
     // and the queue processor's finally block to prevent restarting a stopped queue.
     private var queueStopped = false
 
     private val responseMutex = Mutex()
-    private val queueResponse = mutableMapOf<Int, CompletableDeferred<Boolean>>()
+
+    private data class QueuedPacket(val packet: MeshPacket, val pending: PendingResponse)
+
+    private class PendingResponse {
+        val deferred: CompletableDeferred<AwaitedSendStatus> = CompletableDeferred()
+        private val dispatched = atomic(false)
+
+        val wasDispatched: Boolean
+            get() = dispatched.value
+
+        fun recordDispatch(accepted: Boolean) {
+            dispatched.value = accepted
+        }
+    }
+
+    private val queueResponse = mutableMapOf<Int, PendingResponse>()
 
     override fun sendToRadio(p: ToRadio) {
+        dispatchToRadio(p)
+    }
+
+    private fun dispatchToRadio(p: ToRadio): Boolean {
         Logger.d { "Sending to radio ${p.toPIIString()}" }
-        val b = p.encode()
+        val dispatched = radioInterfaceService.trySendToRadio(p.encode())
+        if (!dispatched) return false
 
-        radioInterfaceService.sendToRadio(b)
         p.packet?.id?.let { changeStatus(it, MessageStatus.ENROUTE) }
-
         val packet = p.packet
         if (packet?.decoded != null) {
             val packetToSave =
@@ -109,6 +135,7 @@ class PacketHandlerImpl(
                 )
             insertMeshLog(packetToSave)
         }
+        return true
     }
 
     /**
@@ -117,38 +144,86 @@ class PacketHandlerImpl(
      * multiple calls — e.g. an `editSettings { … }` begin → writes → commit sequence — MUST be issued from a single
      * coroutine; concurrent senders share FIFO only at the per-call grain.
      */
-    override suspend fun sendToRadio(packet: MeshPacket) {
-        queueMutex.withLock {
-            queueStopped = false
-            queuedPackets.add(packet)
-            startPacketQueueLocked()
+    override suspend fun sendToRadio(packet: MeshPacket): Boolean {
+        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
+        when {
+            packet.id == 0 -> Logger.w { "Dropping queued packet without an ID" }
+
+            pending == null && !scope.isActive ->
+                Logger.w { "Rejecting packet id=${packet.id.toUInt()}: service scope is no longer active" }
+
+            pending == null -> Logger.w { "Dropping duplicate queued packet id=${packet.id.toUInt()}" }
         }
+        return pending != null
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    override suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean {
-        // Pre-register the deferred so the queue processor and QueueStatus handler
-        // can find it immediately — no polling required.
-        val deferred = CompletableDeferred<Boolean>()
-        responseMutex.withLock { queueResponse[packet.id] = deferred }
-        queueMutex.withLock {
-            queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
-            queuedPackets.add(packet)
-            startPacketQueueLocked()
+    override suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult {
+        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
+        if (pending == null) {
+            val status =
+                when {
+                    packet.id == 0 -> {
+                        Logger.w { "Rejecting awaited packet without an ID" }
+                        AwaitedSendStatus.REJECTED
+                    }
+
+                    !scope.isActive -> {
+                        Logger.w {
+                            "Rejecting awaited packet id=${packet.id.toUInt()}: service scope is no longer active"
+                        }
+                        AwaitedSendStatus.TRANSPORT_STOPPED
+                    }
+
+                    else -> {
+                        Logger.w { "Rejecting duplicate awaited packet id=${packet.id.toUInt()}" }
+                        AwaitedSendStatus.REJECTED
+                    }
+                }
+            return AwaitedSendResult(status = status, dispatched = false)
         }
         return try {
-            withTimeout(TIMEOUT) { deferred.await() }
-        } catch (e: TimeoutCancellationException) {
-            Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} timeout" }
-            false
+            // The queue processor owns both the response timeout and the ID reservation. Permanent
+            // service-scope shutdown is the only caller-observed terminal condition because no worker may exist.
+            AwaitedSendResult(status = awaitPendingResponse(pending), dispatched = pending.wasDispatched)
         } catch (e: CancellationException) {
             throw e // Preserve structured concurrency cancellation propagation.
         } catch (e: Exception) {
             Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} failed: ${e.message}" }
-            false
-        } finally {
-            responseMutex.withLock { queueResponse.remove(packet.id) }
+            AwaitedSendResult(status = AwaitedSendStatus.SEND_FAILED, dispatched = pending.wasDispatched)
         }
+    }
+
+    /**
+     * Reserves [packet]'s non-zero ID and queues it as one atomic admission. The reservation spans both queued and
+     * in-flight work, so a second sender cannot replace the original caller's [PendingResponse].
+     */
+    private suspend fun enqueuePacket(packet: MeshPacket): PendingResponse? = queueMutex.withLock {
+        responseMutex.withLock responseLock@{
+            if (!scope.isActive || queueResponse.containsKey(packet.id)) return@responseLock null
+
+            val pending = PendingResponse()
+            queueResponse[packet.id] = pending
+            queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
+            queuedPackets.add(QueuedPacket(packet = packet, pending = pending))
+            startPacketQueueLocked()
+            pending
+        }
+    }
+
+    /** Waits for the queue-owned result, draining synchronously if service-scope shutdown wins admission. */
+    private suspend fun awaitPendingResponse(pending: PendingResponse): AwaitedSendStatus {
+        val scopeJob = scope.coroutineContext[Job] ?: return pending.deferred.await()
+        val serviceStopped = select {
+            pending.deferred.onAwait { false }
+            scopeJob.onJoin { true }
+        }
+        if (serviceStopped) {
+            withContext(NonCancellable) {
+                queueMutex.withLock { if (!pending.deferred.isCompleted) stopAndDrainPacketQueueLocked() }
+            }
+        }
+        return pending.deferred.await()
     }
 
     override fun stopPacketQueue() {
@@ -160,11 +235,9 @@ class PacketHandlerImpl(
                 queueStopped = true
                 queueJob?.cancel()
                 queueJob = null
+                queueGeneration++
                 queuedPackets.clear()
-            }
-            responseMutex.withLock {
-                queueResponse.values.forEach { if (!it.isCompleted) it.complete(false) }
-                queueResponse.clear()
+                completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
             }
         }
     }
@@ -181,16 +254,19 @@ class PacketHandlerImpl(
         scope.launch {
             responseMutex.withLock {
                 if (requestId != 0) {
-                    queueResponse.remove(requestId)?.complete(success)
+                    queueResponse[requestId]?.deferred?.complete(success.toAwaitedSendStatus())
                 } else {
-                    queueResponse.values.firstOrNull { !it.isCompleted }?.complete(success)
+                    queueResponse.values
+                        .firstOrNull { !it.deferred.isCompleted }
+                        ?.deferred
+                        ?.complete(success.toAwaitedSendStatus())
                 }
             }
         }
     }
 
     override suspend fun removeResponse(dataRequestId: Int, complete: Boolean) {
-        responseMutex.withLock { queueResponse.remove(dataRequestId)?.complete(complete) }
+        responseMutex.withLock { queueResponse[dataRequestId]?.deferred?.complete(complete.toAwaitedSendStatus()) }
     }
 
     /**
@@ -198,45 +274,85 @@ class PacketHandlerImpl(
      * atomic — preventing two concurrent callers from launching duplicate processors.
      */
     private fun startPacketQueueLocked() {
-        if (queueStopped) return
-        if (queueJob?.isActive == true) return
+        if (queueStopped || queueJob?.isActive == true) return
+
+        val generation = ++queueGeneration
+        // Install cleanup before admission releases queueMutex so cancellation cannot bypass the worker's finally.
         queueJob =
-            scope.handledLaunch {
+            scope.handledLaunch(start = CoroutineStart.UNDISPATCHED) {
                 try {
                     while (connectionStateProvider.connectionState.value == ConnectionState.Connected) {
-                        val packet = queueMutex.withLock { queuedPackets.removeFirstOrNull() } ?: break
-                        @Suppress("TooGenericExceptionCaught", "SwallowedException")
-                        try {
-                            val response = sendPacket(packet)
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
-                            val success = withTimeout(TIMEOUT) { response.await() }
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} success $success" }
-                        } catch (e: TimeoutCancellationException) {
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} timeout" }
-                            // Clean up the deferred for this packet. sendToRadioAndAwait callers
-                            // also clean up in their own finally block (idempotent remove).
-                            responseMutex.withLock { queueResponse.remove(packet.id) }
-                        } catch (e: CancellationException) {
-                            throw e // Preserve structured concurrency cancellation propagation.
-                        } catch (e: Exception) {
-                            Logger.d { "queueJob packet id=${packet.id.toUInt()} failed" }
-                            responseMutex.withLock { queueResponse.remove(packet.id) }
-                        }
-                        // Deferred cleanup is now handled in the catch blocks above.
-                        // handleQueueStatus (normal success) and stopPacketQueue (bulk cleanup)
-                        // also remove entries, and these removals are idempotent.
+                        val queuedPacket = queueMutex.withLock { queuedPackets.removeFirstOrNull() } ?: break
+                        processQueuedPacket(queuedPacket)
                     }
                 } finally {
-                    // Hold queueMutex so that clearing queueJob and the restart decision are
-                    // atomic with respect to new senders calling startPacketQueueLocked().
-                    queueMutex.withLock {
-                        queueJob = null
-                        if (!queueStopped && queuedPackets.isNotEmpty()) {
-                            startPacketQueueLocked()
-                        }
-                    }
+                    finishPacketQueueGeneration(generation)
                 }
             }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun processQueuedPacket(queuedPacket: QueuedPacket) {
+        val (packet, pending) = queuedPacket
+        try {
+            val response = sendPacket(packet, pending)
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
+            val status = withTimeout(TIMEOUT) { response.await() }
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} status $status" }
+            // External status paths only complete the response; the queue worker owns reservation removal so an ID
+            // cannot be reused while its original packet can still be transmitted.
+            removePendingResponse(packet.id, pending)
+        } catch (e: TimeoutCancellationException) {
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} timeout" }
+            // Complete an awaiting caller before removing the response. Its timeout starts here, after the packet is
+            // actually sent, rather than while it waits behind the existing FIFO backlog.
+            pending.deferred.complete(AwaitedSendStatus.TIMED_OUT)
+            removePendingResponse(packet.id, pending)
+        } catch (e: CancellationException) {
+            // A later queued packet makes finishPacketQueueGeneration restart the worker instead of draining the
+            // interrupted entry. Complete and remove this reservation before propagating cancellation.
+            pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
+            removePendingResponse(packet.id, pending)
+            throw e // Preserve structured concurrency cancellation propagation.
+        } catch (e: Exception) {
+            Logger.d { "queueJob packet id=${packet.id.toUInt()} failed" }
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+            removePendingResponse(packet.id, pending)
+        }
+        // Queue shutdown can clear the same entry concurrently; identity-checked removal keeps every path idempotent.
+    }
+
+    private suspend fun finishPacketQueueGeneration(generation: Long) = withContext(NonCancellable) {
+        // Keep completion, replacement, and disconnect draining atomic with new admissions. queueGeneration
+        // advances only under queueMutex: stopPacketQueue() drains every pending response, while
+        // startPacketQueueLocked() advances it only after the previous queueJob is inactive. Therefore a stale
+        // worker
+        // has already lost ownership to a path that drained or replaced it and must not clear that replacement job.
+        queueMutex.withLock {
+            if (generation != queueGeneration) return@withLock
+            queueJob = null
+            when {
+                queueStopped || !scope.isActive -> stopAndDrainPacketQueueLocked()
+
+                connectionStateProvider.connectionState.value != ConnectionState.Connected ->
+                    stopAndDrainPacketQueueLocked()
+
+                queuedPackets.isNotEmpty() -> startPacketQueueLocked()
+
+                else -> {
+                    // A normally completed worker has no pending response. Anything left here belongs to an
+                    // in-flight
+                    // packet interrupted by cancellation or an unexpected worker exit.
+                    completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                }
+            }
+        }
+    }
+
+    private suspend fun stopAndDrainPacketQueueLocked() {
+        queueStopped = true
+        queuedPackets.clear()
+        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
     }
 
     private fun changeStatus(packetId: Int, m: MessageStatus) = scope.handledLaunch {
@@ -258,25 +374,45 @@ class PacketHandlerImpl(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun sendPacket(packet: MeshPacket): Deferred<Boolean> {
-        // Reuse a deferred pre-registered by sendToRadioAndAwait, or create a new one.
-        val deferred = responseMutex.withLock { queueResponse.getOrPut(packet.id) { CompletableDeferred() } }
+    private suspend fun sendPacket(packet: MeshPacket, pending: PendingResponse): Deferred<AwaitedSendStatus> {
         try {
-            if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
-                throw RadioNotConnectedException()
+            requireConnected()
+            pending.recordDispatch(dispatchToRadio(ToRadio(packet = packet)))
+            if (!pending.wasDispatched) {
+                Logger.w { "sendToRadio dropped: no active transport accepted id=${packet.id.toUInt()}" }
+                pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
             }
-            sendToRadio(ToRadio(packet = packet))
         } catch (ex: RadioNotConnectedException) {
             Logger.w(ex) { "sendToRadio skipped: Not connected to radio" }
-            deferred.complete(false)
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+        } catch (ex: CancellationException) {
+            throw ex
         } catch (ex: Exception) {
             Logger.e(ex) { "sendToRadio error: ${ex.message}" }
-            deferred.complete(false)
+            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
         }
-        // Return a read-only Deferred view (kotlinx.coroutines 1.11+) so callers can await it
-        // without being able to complete the underlying CompletableDeferred; cancellation is
-        // still exposed via Deferred/Job.
-        return deferred.asDeferred()
+        // The declared Deferred return type exposes only read-only completion to callers.
+        return pending.deferred
+    }
+
+    private suspend fun removePendingResponse(packetId: Int, pending: PendingResponse) = withContext(NonCancellable) {
+        responseMutex.withLock { if (queueResponse[packetId] === pending) queueResponse.remove(packetId) }
+    }
+
+    private fun requireConnected() {
+        if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
+            throw RadioNotConnectedException()
+        }
+    }
+
+    private fun Boolean.toAwaitedSendStatus(): AwaitedSendStatus =
+        if (this) AwaitedSendStatus.ACCEPTED else AwaitedSendStatus.REJECTED
+
+    private suspend fun completePendingResponses(status: AwaitedSendStatus) {
+        responseMutex.withLock {
+            queueResponse.values.forEach { pending -> pending.deferred.complete(status) }
+            queueResponse.clear()
+        }
     }
 
     private fun insertMeshLog(packetToSave: MeshLog) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -39,7 +38,6 @@ import org.meshtastic.core.common.di.ServiceScope
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.ConnectionState
-import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
@@ -152,7 +150,7 @@ class PacketHandlerImpl(
             pending == null && !scope.isActive ->
                 Logger.w { "Rejecting packet id=${packet.id.toUInt()}: service scope is no longer active" }
 
-            pending == null -> Logger.w { "Dropping duplicate queued packet id=${packet.id.toUInt()}" }
+            pending == null -> Logger.w { "Rejecting packet with reserved id=${packet.id.toUInt()}" }
         }
         return pending != null
     }
@@ -220,7 +218,11 @@ class PacketHandlerImpl(
         }
         if (serviceStopped) {
             withContext(NonCancellable) {
-                queueMutex.withLock { if (!pending.deferred.isCompleted) stopAndDrainPacketQueueLocked() }
+                val failedPacketIds =
+                    queueMutex.withLock {
+                        if (!pending.deferred.isCompleted) stopAndDrainPacketQueueLocked() else emptyList()
+                    }
+                changeStatusesNow(failedPacketIds, MessageStatus.ERROR)
             }
         }
         return pending.deferred.await()
@@ -229,15 +231,19 @@ class PacketHandlerImpl(
     override fun stopPacketQueue() {
         // Run async so callers (non-suspend) don't block, but all mutations are
         // serialized under the same mutexes used by the queue processor and senders.
-        scope.launch {
+        scope.handledLaunch {
             Logger.i { "Stopping packet queueJob" }
-            queueMutex.withLock {
-                queueStopped = true
-                queueJob?.cancel()
-                queueJob = null
-                queueGeneration++
-                queuedPackets.clear()
-                completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+            withContext(NonCancellable) {
+                val failedPacketIds =
+                    queueMutex.withLock {
+                        queueStopped = true
+                        queueJob?.cancel()
+                        queueJob = null
+                        queueGeneration++
+                        queuedPackets.clear()
+                        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                    }
+                changeStatusesNow(failedPacketIds, MessageStatus.ERROR)
             }
         }
     }
@@ -251,13 +257,16 @@ class PacketHandlerImpl(
         // would hang until TIMEOUT.
         if (queueStatus.res == 0 && isFull) return
 
-        scope.launch {
+        scope.handledLaunch {
             responseMutex.withLock {
                 if (requestId != 0) {
-                    queueResponse[requestId]?.deferred?.complete(success.toAwaitedSendStatus())
+                    queueResponse[requestId]
+                        ?.takeIf { it.wasDispatched }
+                        ?.deferred
+                        ?.complete(success.toAwaitedSendStatus())
                 } else {
                     queueResponse.values
-                        .firstOrNull { !it.deferred.isCompleted }
+                        .firstOrNull { it.wasDispatched && !it.deferred.isCompleted }
                         ?.deferred
                         ?.complete(success.toAwaitedSendStatus())
                 }
@@ -266,7 +275,12 @@ class PacketHandlerImpl(
     }
 
     override suspend fun removeResponse(dataRequestId: Int, complete: Boolean) {
-        responseMutex.withLock { queueResponse[dataRequestId]?.deferred?.complete(complete.toAwaitedSendStatus()) }
+        responseMutex.withLock {
+            queueResponse[dataRequestId]
+                ?.takeIf { it.wasDispatched }
+                ?.deferred
+                ?.complete(complete.toAwaitedSendStatus())
+        }
     }
 
     /**
@@ -274,10 +288,13 @@ class PacketHandlerImpl(
      * atomic — preventing two concurrent callers from launching duplicate processors.
      */
     private fun startPacketQueueLocked() {
+        check(queueMutex.isLocked) { "Packet queue workers must start while queueMutex is held" }
         if (queueStopped || queueJob?.isActive == true) return
 
         val generation = ++queueGeneration
         // Install cleanup before admission releases queueMutex so cancellation cannot bypass the worker's finally.
+        // UNDISPATCHED enters immediately, then suspends on queueMutex until enqueuePacket releases the admission
+        // lock; this closes the cancellation gap without running queue mutation inside the caller's critical section.
         queueJob =
             scope.handledLaunch(start = CoroutineStart.UNDISPATCHED) {
                 try {
@@ -299,6 +316,7 @@ class PacketHandlerImpl(
             Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
             val status = withTimeout(TIMEOUT) { response.await() }
             Logger.d { "queueJob packet id=${packet.id.toUInt()} status $status" }
+            if (status != AwaitedSendStatus.ACCEPTED) changeStatus(packet.id, MessageStatus.ERROR)
             // External status paths only complete the response; the queue worker owns reservation removal so an ID
             // cannot be reused while its original packet can still be transmitted.
             removePendingResponse(packet.id, pending)
@@ -307,16 +325,25 @@ class PacketHandlerImpl(
             // Complete an awaiting caller before removing the response. Its timeout starts here, after the packet is
             // actually sent, rather than while it waits behind the existing FIFO backlog.
             pending.deferred.complete(AwaitedSendStatus.TIMED_OUT)
+            // A response the transport already accepted must not be reclassified by the timeout.
+            if (pending.deferred.getCompleted() != AwaitedSendStatus.ACCEPTED) {
+                changeStatus(packet.id, MessageStatus.ERROR)
+            }
             removePendingResponse(packet.id, pending)
         } catch (e: CancellationException) {
             // A later queued packet makes finishPacketQueueGeneration restart the worker instead of draining the
-            // interrupted entry. Complete and remove this reservation before propagating cancellation.
+            // interrupted entry. Complete and remove this reservation before propagating cancellation. A response
+            // the transport already accepted keeps its ACCEPTED status: shutdown preemption cannot reclassify it.
             pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
+            if (pending.deferred.getCompleted() != AwaitedSendStatus.ACCEPTED) {
+                changeStatus(packet.id, MessageStatus.ERROR)
+            }
             removePendingResponse(packet.id, pending)
             throw e // Preserve structured concurrency cancellation propagation.
         } catch (e: Exception) {
             Logger.d { "queueJob packet id=${packet.id.toUInt()} failed" }
             pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+            changeStatus(packet.id, MessageStatus.ERROR)
             removePendingResponse(packet.id, pending)
         }
         // Queue shutdown can clear the same entry concurrently; identity-checked removal keeps every path idempotent.
@@ -326,65 +353,75 @@ class PacketHandlerImpl(
         // Keep completion, replacement, and disconnect draining atomic with new admissions. queueGeneration
         // advances only under queueMutex: stopPacketQueue() drains every pending response, while
         // startPacketQueueLocked() advances it only after the previous queueJob is inactive. Therefore a stale
-        // worker
-        // has already lost ownership to a path that drained or replaced it and must not clear that replacement job.
-        queueMutex.withLock {
-            if (generation != queueGeneration) return@withLock
-            queueJob = null
-            when {
-                queueStopped || !scope.isActive -> stopAndDrainPacketQueueLocked()
+        // worker has already lost ownership to a path that drained or replaced it and must not clear that
+        // replacement
+        // job.
+        val failedPacketIds =
+            queueMutex.withLock {
+                if (generation != queueGeneration) return@withLock emptyList()
+                queueJob = null
+                when {
+                    queueStopped || !scope.isActive -> stopAndDrainPacketQueueLocked()
 
-                connectionStateProvider.connectionState.value != ConnectionState.Connected ->
-                    stopAndDrainPacketQueueLocked()
+                    connectionStateProvider.connectionState.value != ConnectionState.Connected ->
+                        stopAndDrainPacketQueueLocked()
 
-                queuedPackets.isNotEmpty() -> startPacketQueueLocked()
+                    queuedPackets.isNotEmpty() -> {
+                        startPacketQueueLocked()
+                        emptyList()
+                    }
 
-                else -> {
-                    // A normally completed worker has no pending response. Anything left here belongs to an
-                    // in-flight
-                    // packet interrupted by cancellation or an unexpected worker exit.
-                    completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                    else -> {
+                        // A normally completed worker has no pending response. Anything left here belongs to an
+                        // in-flight packet interrupted by cancellation or an unexpected worker exit.
+                        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+                    }
                 }
             }
-        }
+        changeStatusesNow(failedPacketIds, MessageStatus.ERROR)
     }
 
-    private suspend fun stopAndDrainPacketQueueLocked() {
+    private suspend fun stopAndDrainPacketQueueLocked(): List<Int> {
         queueStopped = true
         queuedPackets.clear()
-        completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
+        return completePendingResponses(AwaitedSendStatus.TRANSPORT_STOPPED)
     }
 
-    private fun changeStatus(packetId: Int, m: MessageStatus) = scope.handledLaunch {
-        if (packetId != 0) {
-            getDataPacketById(packetId)?.let { p ->
-                if (p.status == m) return@handledLaunch
-                packetRepository.value.updateMessageStatus(p, m)
+    private fun changeStatus(packetId: Int, m: MessageStatus) =
+        scope.handledLaunch { changeStatusesNow(listOf(packetId), m) }
+
+    /** Resolves and updates all known packet IDs within one shared bound, including during non-cancellable teardown. */
+    private suspend fun changeStatusesNow(packetIds: Collection<Int>, status: MessageStatus) {
+        val remaining = packetIds.filterTo(mutableSetOf()) { it != 0 }
+        withTimeoutOrNull(1.seconds) {
+            while (remaining.isNotEmpty()) {
+                remaining.toList().forEach { packetId ->
+                    val packet = packetRepository.value.getPacketById(packetId) ?: return@forEach
+                    if (packet.status != status) packetRepository.value.updateMessageStatus(packet, status)
+                    remaining.remove(packetId)
+                }
+                if (remaining.isNotEmpty()) delay(100.milliseconds)
             }
         }
-    }
-
-    private suspend fun getDataPacketById(packetId: Int): DataPacket? = withTimeoutOrNull(1.seconds) {
-        var dataPacket: DataPacket? = null
-        while (dataPacket == null) {
-            dataPacket = packetRepository.value.getPacketById(packetId)
-            if (dataPacket == null) delay(100.milliseconds)
+        if (remaining.isNotEmpty()) {
+            Logger.w { "Could not apply $status to ${remaining.size} unresolved packet IDs within 1 second" }
         }
-        dataPacket
     }
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun sendPacket(packet: MeshPacket, pending: PendingResponse): Deferred<AwaitedSendStatus> {
         try {
             requireConnected()
-            pending.recordDispatch(dispatchToRadio(ToRadio(packet = packet)))
+            // Serialize dispatch publication with response callbacks. Even a transport that schedules a callback
+            // immediately cannot complete this response before wasDispatched reflects the admission result.
+            responseMutex.withLock { pending.recordDispatch(dispatchToRadio(ToRadio(packet = packet))) }
             if (!pending.wasDispatched) {
                 Logger.w { "sendToRadio dropped: no active transport accepted id=${packet.id.toUInt()}" }
                 pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
             }
         } catch (ex: RadioNotConnectedException) {
             Logger.w(ex) { "sendToRadio skipped: Not connected to radio" }
-            pending.deferred.complete(AwaitedSendStatus.SEND_FAILED)
+            pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
         } catch (ex: CancellationException) {
             throw ex
         } catch (ex: Exception) {
@@ -406,13 +443,15 @@ class PacketHandlerImpl(
     }
 
     private fun Boolean.toAwaitedSendStatus(): AwaitedSendStatus =
-        if (this) AwaitedSendStatus.ACCEPTED else AwaitedSendStatus.REJECTED
+        if (this) AwaitedSendStatus.ACCEPTED else AwaitedSendStatus.RADIO_REJECTED
 
-    private suspend fun completePendingResponses(status: AwaitedSendStatus) {
-        responseMutex.withLock {
-            queueResponse.values.forEach { pending -> pending.deferred.complete(status) }
-            queueResponse.clear()
-        }
+    private suspend fun completePendingResponses(status: AwaitedSendStatus): List<Int> = responseMutex.withLock {
+        val completedPacketIds =
+            queueResponse.mapNotNull { (packetId, pending) ->
+                packetId.takeIf { pending.deferred.complete(status) }
+            }
+        queueResponse.clear()
+        completedPacketIds
     }
 
     private fun insertMeshLog(packetToSave: MeshLog) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -25,14 +25,12 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.di.ServiceScope
 import org.meshtastic.core.common.util.handledLaunch
@@ -54,7 +52,6 @@ import org.meshtastic.proto.FromRadio
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.QueueStatus
 import org.meshtastic.proto.ToRadio
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
 
@@ -69,7 +66,7 @@ class PacketHandlerImpl(
 ) : PacketHandler {
 
     companion object {
-        private val TIMEOUT = 5.seconds
+        internal val RESPONSE_TIMEOUT = 5.seconds
 
         /**
          * Firmware-internal `ErrorCode` (MeshTypes.h `ERRNO_SHOULD_RELEASE`) leaked into `QueueStatus.res`: "no error,
@@ -87,8 +84,8 @@ class PacketHandlerImpl(
     private val queueMutex = Mutex()
     private val queuedPackets = mutableListOf<QueuedPacket>()
 
-    // Set to true by stopPacketQueue() under queueMutex. Checked by startPacketQueueLocked()
-    // and the queue processor's finally block to prevent restarting a stopped queue.
+    // Marks the current queue generation as drained. The next admission clears it so reconnect recovery can start a
+    // fresh worker; stale workers retain their generation and cannot replace that worker.
     private var queueStopped = false
 
     private val responseMutex = Mutex()
@@ -107,10 +104,20 @@ class PacketHandlerImpl(
         }
     }
 
+    private sealed interface QueueAdmission {
+        data class Admitted(val pending: PendingResponse) : QueueAdmission
+
+        data object DuplicateId : QueueAdmission
+
+        data object ScopeInactive : QueueAdmission
+    }
+
     private val queueResponse = mutableMapOf<Int, PendingResponse>()
 
     override fun sendToRadio(p: ToRadio) {
-        dispatchToRadio(p)
+        if (!dispatchToRadio(p)) {
+            Logger.w { "sendToRadio dropped: no active transport accepted outbound command" }
+        }
     }
 
     private fun dispatchToRadio(p: ToRadio): Boolean {
@@ -143,69 +150,71 @@ class PacketHandlerImpl(
      * coroutine; concurrent senders share FIFO only at the per-call grain.
      */
     override suspend fun sendToRadio(packet: MeshPacket): Boolean {
-        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
-        when {
-            packet.id == 0 -> Logger.w { "Dropping queued packet without an ID" }
-
-            pending == null && !scope.isActive ->
-                Logger.w { "Rejecting packet id=${packet.id.toUInt()}: service scope is no longer active" }
-
-            pending == null -> Logger.w { "Rejecting packet with reserved id=${packet.id.toUInt()}" }
+        if (packet.id == 0) {
+            Logger.w { "Dropping queued packet without an ID" }
+            return false
         }
-        return pending != null
+        return when (enqueuePacket(packet)) {
+            is QueueAdmission.Admitted -> true
+
+            QueueAdmission.ScopeInactive -> {
+                Logger.w { "Rejecting packet id=${packet.id.toUInt()}: service scope is no longer active" }
+                false
+            }
+
+            QueueAdmission.DuplicateId -> {
+                Logger.w { "Rejecting packet with reserved id=${packet.id.toUInt()}" }
+                false
+            }
+        }
+    }
+
+    override suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult = if (packet.id == 0) {
+        Logger.w { "Rejecting awaited packet without an ID" }
+        AwaitedSendResult(status = AwaitedSendStatus.REJECTED, dispatched = false)
+    } else {
+        when (val admission = enqueuePacket(packet)) {
+            is QueueAdmission.Admitted -> awaitAdmittedPacket(packet, admission.pending)
+
+            QueueAdmission.ScopeInactive -> {
+                Logger.w { "Rejecting awaited packet id=${packet.id.toUInt()}: service scope is no longer active" }
+                AwaitedSendResult(status = AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false)
+            }
+
+            QueueAdmission.DuplicateId -> {
+                Logger.w { "Rejecting duplicate awaited packet id=${packet.id.toUInt()}" }
+                AwaitedSendResult(status = AwaitedSendStatus.REJECTED, dispatched = false)
+            }
+        }
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    override suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult {
-        val pending = packet.takeIf { it.id != 0 }?.let { enqueuePacket(it) }
-        if (pending == null) {
-            val status =
-                when {
-                    packet.id == 0 -> {
-                        Logger.w { "Rejecting awaited packet without an ID" }
-                        AwaitedSendStatus.REJECTED
-                    }
-
-                    !scope.isActive -> {
-                        Logger.w {
-                            "Rejecting awaited packet id=${packet.id.toUInt()}: service scope is no longer active"
-                        }
-                        AwaitedSendStatus.TRANSPORT_STOPPED
-                    }
-
-                    else -> {
-                        Logger.w { "Rejecting duplicate awaited packet id=${packet.id.toUInt()}" }
-                        AwaitedSendStatus.REJECTED
-                    }
-                }
-            return AwaitedSendResult(status = status, dispatched = false)
-        }
-        return try {
-            // The queue processor owns both the response timeout and the ID reservation. Permanent
-            // service-scope shutdown is the only caller-observed terminal condition because no worker may exist.
-            AwaitedSendResult(status = awaitPendingResponse(pending), dispatched = pending.wasDispatched)
-        } catch (e: CancellationException) {
-            throw e // Preserve structured concurrency cancellation propagation.
-        } catch (e: Exception) {
-            Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} failed: ${e.message}" }
-            AwaitedSendResult(status = AwaitedSendStatus.SEND_FAILED, dispatched = pending.wasDispatched)
-        }
+    private suspend fun awaitAdmittedPacket(packet: MeshPacket, pending: PendingResponse): AwaitedSendResult = try {
+        // The queue processor owns both the response timeout and the ID reservation. Permanent
+        // service-scope shutdown is the only caller-observed terminal condition because no worker may exist.
+        AwaitedSendResult(status = awaitPendingResponse(pending), dispatched = pending.wasDispatched)
+    } catch (e: CancellationException) {
+        throw e // Preserve structured concurrency cancellation propagation.
+    } catch (e: Exception) {
+        Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} failed: ${e.message}" }
+        AwaitedSendResult(status = AwaitedSendStatus.SEND_FAILED, dispatched = pending.wasDispatched)
     }
 
     /**
      * Reserves [packet]'s non-zero ID and queues it as one atomic admission. The reservation spans both queued and
      * in-flight work, so a second sender cannot replace the original caller's [PendingResponse].
      */
-    private suspend fun enqueuePacket(packet: MeshPacket): PendingResponse? = queueMutex.withLock {
+    private suspend fun enqueuePacket(packet: MeshPacket): QueueAdmission = queueMutex.withLock {
         responseMutex.withLock responseLock@{
-            if (!scope.isActive || queueResponse.containsKey(packet.id)) return@responseLock null
+            if (!scope.isActive) return@responseLock QueueAdmission.ScopeInactive
+            if (queueResponse.containsKey(packet.id)) return@responseLock QueueAdmission.DuplicateId
 
             val pending = PendingResponse()
             queueResponse[packet.id] = pending
             queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
             queuedPackets.add(QueuedPacket(packet = packet, pending = pending))
             startPacketQueueLocked()
-            pending
+            QueueAdmission.Admitted(pending)
         }
     }
 
@@ -214,6 +223,8 @@ class PacketHandlerImpl(
         val scopeJob = scope.coroutineContext[Job] ?: return pending.deferred.await()
         val serviceStopped = select {
             pending.deferred.onAwait { false }
+            // External callers observe service shutdown as TRANSPORT_STOPPED; callers inside the service scope retain
+            // structured cancellation and leave through the surrounding CancellationException path.
             scopeJob.onJoin { true }
         }
         if (serviceStopped) {
@@ -254,7 +265,7 @@ class PacketHandlerImpl(
             with(queueStatus) { Triple(res == 0 || res == ERRNO_SHOULD_RELEASE, free == 0, mesh_packet_id) }
         // Only the plain res==0 "queue accepted, now full" echo is skipped here. ERRNO_SHOULD_RELEASE denotes a
         // synchronous local-loopback delivery that still needs its queueResponse completed, even when free==0, or it
-        // would hang until TIMEOUT.
+        // would hang until RESPONSE_TIMEOUT.
         if (queueStatus.res == 0 && isFull) return
 
         scope.handledLaunch {
@@ -265,6 +276,8 @@ class PacketHandlerImpl(
                         ?.deferred
                         ?.complete(success.toAwaitedSendStatus())
                 } else {
+                    // Firmware omits requestId for the active queue entry. The worker is serial, so at most one
+                    // dispatched response can still be pending; preserve that invariant if dispatch is parallelized.
                     queueResponse.values
                         .firstOrNull { it.wasDispatched && !it.deferred.isCompleted }
                         ?.deferred
@@ -274,7 +287,7 @@ class PacketHandlerImpl(
         }
     }
 
-    override suspend fun removeResponse(dataRequestId: Int, complete: Boolean) {
+    override suspend fun completeDispatchedResponse(dataRequestId: Int, complete: Boolean) {
         responseMutex.withLock {
             queueResponse[dataRequestId]
                 ?.takeIf { it.wasDispatched }
@@ -314,7 +327,7 @@ class PacketHandlerImpl(
         try {
             val response = sendPacket(packet, pending)
             Logger.d { "queueJob packet id=${packet.id.toUInt()} waiting" }
-            val status = withTimeout(TIMEOUT) { response.await() }
+            val status = withTimeout(RESPONSE_TIMEOUT) { response.await() }
             Logger.d { "queueJob packet id=${packet.id.toUInt()} status $status" }
             if (status != AwaitedSendStatus.ACCEPTED) changeStatus(packet.id, MessageStatus.ERROR)
             // External status paths only complete the response; the queue worker owns reservation removal so an ID
@@ -324,20 +337,23 @@ class PacketHandlerImpl(
             Logger.d { "queueJob packet id=${packet.id.toUInt()} timeout" }
             // Complete an awaiting caller before removing the response. Its timeout starts here, after the packet is
             // actually sent, rather than while it waits behind the existing FIFO backlog.
-            pending.deferred.complete(AwaitedSendStatus.TIMED_OUT)
+            val completedByTimeout = pending.deferred.complete(AwaitedSendStatus.TIMED_OUT)
             // A response the transport already accepted must not be reclassified by the timeout.
-            if (pending.deferred.getCompleted() != AwaitedSendStatus.ACCEPTED) {
-                changeStatus(packet.id, MessageStatus.ERROR)
-            }
+            val terminalStatus = if (completedByTimeout) AwaitedSendStatus.TIMED_OUT else pending.deferred.await()
+            if (terminalStatus != AwaitedSendStatus.ACCEPTED) changeStatus(packet.id, MessageStatus.ERROR)
             removePendingResponse(packet.id, pending)
         } catch (e: CancellationException) {
             // A later queued packet makes finishPacketQueueGeneration restart the worker instead of draining the
             // interrupted entry. Complete and remove this reservation before propagating cancellation. A response
             // the transport already accepted keeps its ACCEPTED status: shutdown preemption cannot reclassify it.
-            pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
-            if (pending.deferred.getCompleted() != AwaitedSendStatus.ACCEPTED) {
-                changeStatus(packet.id, MessageStatus.ERROR)
-            }
+            val completedByCancellation = pending.deferred.complete(AwaitedSendStatus.TRANSPORT_STOPPED)
+            val terminalStatus =
+                if (completedByCancellation) {
+                    AwaitedSendStatus.TRANSPORT_STOPPED
+                } else {
+                    withContext(NonCancellable) { pending.deferred.await() }
+                }
+            if (terminalStatus != AwaitedSendStatus.ACCEPTED) changeStatus(packet.id, MessageStatus.ERROR)
             removePendingResponse(packet.id, pending)
             throw e // Preserve structured concurrency cancellation propagation.
         } catch (e: Exception) {
@@ -353,9 +369,7 @@ class PacketHandlerImpl(
         // Keep completion, replacement, and disconnect draining atomic with new admissions. queueGeneration
         // advances only under queueMutex: stopPacketQueue() drains every pending response, while
         // startPacketQueueLocked() advances it only after the previous queueJob is inactive. Therefore a stale
-        // worker has already lost ownership to a path that drained or replaced it and must not clear that
-        // replacement
-        // job.
+        // worker has already lost ownership to a path that drained or replaced it and must not clear its successor.
         val failedPacketIds =
             queueMutex.withLock {
                 if (generation != queueGeneration) return@withLock emptyList()
@@ -390,22 +404,20 @@ class PacketHandlerImpl(
     private fun changeStatus(packetId: Int, m: MessageStatus) =
         scope.handledLaunch { changeStatusesNow(listOf(packetId), m) }
 
-    /** Resolves and updates all known packet IDs within one shared bound, including during non-cancellable teardown. */
+    /** Applies [status] once to any durable packet row already associated with the mesh packet IDs. */
     private suspend fun changeStatusesNow(packetIds: Collection<Int>, status: MessageStatus) {
-        val remaining = packetIds.filterTo(mutableSetOf()) { it != 0 }
-        withTimeoutOrNull(1.seconds) {
-            while (remaining.isNotEmpty()) {
-                remaining.toList().forEach { packetId ->
-                    val packet = packetRepository.value.getPacketById(packetId) ?: return@forEach
-                    if (packet.status != status) packetRepository.value.updateMessageStatus(packet, status)
-                    remaining.remove(packetId)
+        packetIds
+            .asSequence()
+            .filter { it != 0 }
+            .distinct()
+            .forEach { packetId ->
+                val packet = packetRepository.value.getPacketByPacketId(packetId)
+                if (packet == null) {
+                    Logger.d { "Skipping $status for mesh packet id=${packetId.toUInt()}: no persisted packet row" }
+                } else if (packet.status != status) {
+                    packetRepository.value.updateMessageStatus(packet, status)
                 }
-                if (remaining.isNotEmpty()) delay(100.milliseconds)
             }
-        }
-        if (remaining.isNotEmpty()) {
-            Logger.w { "Could not apply $status to ${remaining.size} unresolved packet IDs within 1 second" }
-        }
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -21,9 +21,11 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.capture.capture
 import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -36,6 +38,8 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.PacketHandler
@@ -162,7 +166,7 @@ class CommandSenderImplTest {
     fun sendData_setsIdWhenZero() = runTest {
         val packet = DataPacket(to = "^all", bytes = "hi".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
         packet.id = 0
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.sendData(packet)
         assertNotEquals(0, packet.id)
@@ -171,7 +175,7 @@ class CommandSenderImplTest {
     @Test
     fun sendData_setsStatusQueued() = runTest {
         val packet = DataPacket(to = "^all", bytes = "hello".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.sendData(packet)
         assertEquals(MessageStatus.QUEUED, packet.status)
@@ -199,11 +203,38 @@ class CommandSenderImplTest {
     fun sendAdmin_injectsSessionPasskey() = runTest {
         val passkey = "secret".encodeUtf8()
         every { sessionManager.getPasskey(DEST_NODE) } returns passkey
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
 
-        commandSender.sendAdmin(DEST_NODE) { org.meshtastic.proto.AdminMessage(get_owner_request = true) }
+        commandSender.sendAdmin(DEST_NODE) { AdminMessage(get_owner_request = true) }
 
-        verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
+        val adminMessage = AdminMessage.ADAPTER.decode(requireNotNull(packets.single().decoded).payload)
+        assertEquals(passkey, adminMessage.session_passkey)
+    }
+
+    @Test
+    fun sendAdmin_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
+
+        commandSender.sendAdmin(DEST_NODE, requestId = 0) {
+            org.meshtastic.proto.AdminMessage(get_owner_request = true)
+        }
+
+        assertNotEquals(0, packets.single().id)
+    }
+
+    @Test
+    fun sendAdminAwaitResult_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadioAndAwaitResult(capture(packets)) } returns
+            AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
+        commandSender.sendAdminAwaitResult(DEST_NODE, requestId = 0) {
+            org.meshtastic.proto.AdminMessage(get_owner_request = true)
+        }
+
+        assertNotEquals(0, packets.single().id)
     }
 
     // --- sendAdminImmediate ---
@@ -238,11 +269,32 @@ class CommandSenderImplTest {
 
     @Test
     fun requestTraceroute_recordsStartTime() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
 
         verify { tracerouteHandler.recordStartTime(42) }
+    }
+
+    @Test
+    fun requestTraceroute_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
+
+        verify(exactly(0)) { tracerouteHandler.recordStartTime(any()) }
+    }
+
+    @Test
+    fun requestTraceroute_generatesNonZeroIdWhenCallerSuppliesZero() = runTest {
+        val packets = mutableListOf<MeshPacket>()
+        everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
+
+        commandSender.requestTraceroute(requestId = 0, destNum = DEST_NODE)
+
+        val generatedId = packets.single().id
+        assertNotEquals(0, generatedId)
+        verify { tracerouteHandler.recordStartTime(generatedId) }
     }
 
     // --- requestNeighborInfo ---
@@ -251,7 +303,7 @@ class CommandSenderImplTest {
     fun requestNeighborInfo_localNode_usesCachedNeighborInfo() = runTest {
         val cached = NeighborInfo(node_id = MY_NODE_NUM, last_sent_by_id = MY_NODE_NUM)
         every { neighborInfoHandler.lastNeighborInfo } returns cached
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
@@ -261,7 +313,7 @@ class CommandSenderImplTest {
     @Test
     fun requestNeighborInfo_localNode_generatesDummyWhenNoCached() = runTest {
         every { neighborInfoHandler.lastNeighborInfo } returns null
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
 
@@ -270,7 +322,7 @@ class CommandSenderImplTest {
 
     @Test
     fun requestNeighborInfo_remoteNode_sendsRequest() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
 
@@ -281,7 +333,7 @@ class CommandSenderImplTest {
 
     @Test
     fun sendPosition_updatesLocalPositionWhenNotFixed() = runTest {
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
         commandSender.sendPosition(pos)
@@ -308,7 +360,7 @@ class CommandSenderImplTest {
                 scope = testScope.asServiceScope(),
             )
         testScope.testScheduler.advanceUntilIdle()
-        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns Unit
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns true
 
         val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
         fixedSender.sendPosition(pos)

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -44,6 +44,7 @@ import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.PacketHandler
+import org.meshtastic.core.repository.PacketQueueRejectedException
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.SessionManager
 import org.meshtastic.core.repository.TracerouteHandler
@@ -183,12 +184,13 @@ class CommandSenderImplTest {
     }
 
     @Test
-    fun sendData_marksPacketErrorWhenQueueRejectsIt() = runTest {
+    fun sendData_marksPacketErrorAndThrowsWhenQueueRejectsIt() = runTest {
         val packet = DataPacket(to = "^all", bytes = "hello".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
         everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
 
-        commandSender.sendData(packet)
+        val failure = assertFailsWith<PacketQueueRejectedException> { commandSender.sendData(packet) }
 
+        assertEquals("Data packet was rejected by the outbound packet queue", failure.message)
         assertEquals(MessageStatus.ERROR, packet.status)
     }
 
@@ -228,9 +230,7 @@ class CommandSenderImplTest {
         val packets = mutableListOf<MeshPacket>()
         everySuspend { packetHandler.sendToRadio(capture(packets)) } returns true
 
-        commandSender.sendAdmin(DEST_NODE, requestId = 0) {
-            org.meshtastic.proto.AdminMessage(get_owner_request = true)
-        }
+        commandSender.sendAdmin(DEST_NODE, requestId = 0) { AdminMessage(get_owner_request = true) }
 
         assertNotEquals(0, packets.single().id)
     }
@@ -251,9 +251,7 @@ class CommandSenderImplTest {
         everySuspend { packetHandler.sendToRadioAndAwaitResult(capture(packets)) } returns
             AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
 
-        commandSender.sendAdminAwaitResult(DEST_NODE, requestId = 0) {
-            org.meshtastic.proto.AdminMessage(get_owner_request = true)
-        }
+        commandSender.sendAdminAwaitResult(DEST_NODE, requestId = 0) { AdminMessage(get_owner_request = true) }
 
         assertNotEquals(0, packets.single().id)
     }
@@ -306,6 +304,15 @@ class CommandSenderImplTest {
         }
 
         verify(exactly(0)) { tracerouteHandler.recordStartTime(any()) }
+    }
+
+    @Test
+    fun requestTelemetry_surfacesQueueRejection() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.requestTelemetry(requestId = 42, destNum = DEST_NODE, typeValue = 0)
+        }
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -38,6 +38,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AwaitedSendResult
 import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.NeighborInfoHandler
@@ -182,6 +183,16 @@ class CommandSenderImplTest {
     }
 
     @Test
+    fun sendData_marksPacketErrorWhenQueueRejectsIt() = runTest {
+        val packet = DataPacket(to = "^all", bytes = "hello".encodeUtf8(), dataType = PortNum.TEXT_MESSAGE_APP.value)
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        commandSender.sendData(packet)
+
+        assertEquals(MessageStatus.ERROR, packet.status)
+    }
+
+    @Test
     fun sendData_rejectsOversizedPayload() = runTest {
         val oversizedBytes = ByteString.of(*ByteArray(300) { 0x42 })
         val packet = DataPacket(to = "^all", bytes = oversizedBytes, dataType = PortNum.TEXT_MESSAGE_APP.value)
@@ -222,6 +233,16 @@ class CommandSenderImplTest {
         }
 
         assertNotEquals(0, packets.single().id)
+    }
+
+    @Test
+    fun sendAdminSurfacesQueueRejection() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        val failure =
+            assertFailsWith<PacketQueueRejectedException> { commandSender.sendAdmin(DEST_NODE) { AdminMessage() } }
+
+        assertEquals("Admin command was rejected by the outbound packet queue", failure.message)
     }
 
     @Test
@@ -280,7 +301,9 @@ class CommandSenderImplTest {
     fun requestTraceroute_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
         everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
 
-        commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.requestTraceroute(requestId = 42, destNum = DEST_NODE)
+        }
 
         verify(exactly(0)) { tracerouteHandler.recordStartTime(any()) }
     }
@@ -329,6 +352,29 @@ class CommandSenderImplTest {
         verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
     }
 
+    @Test
+    fun requestNeighborInfo_localNode_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
+        every { neighborInfoHandler.lastNeighborInfo } returns null
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.requestNeighborInfo(requestId = 1, destNum = MY_NODE_NUM)
+        }
+
+        verify(exactly(0)) { neighborInfoHandler.recordStartTime(any()) }
+    }
+
+    @Test
+    fun requestNeighborInfo_remoteNode_doesNotStartTimerWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.requestNeighborInfo(requestId = 1, destNum = DEST_NODE)
+        }
+
+        verify(exactly(0)) { neighborInfoHandler.recordStartTime(any()) }
+    }
+
     // --- sendPosition ---
 
     @Test
@@ -339,6 +385,27 @@ class CommandSenderImplTest {
         commandSender.sendPosition(pos)
 
         verify { nodeManager.handleReceivedPosition(MY_NODE_NUM, MY_NODE_NUM, any(), any()) }
+    }
+
+    @Test
+    fun sendPosition_doesNotUpdateLocalPositionWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+        val pos = org.meshtastic.proto.Position(latitude_i = 10000000, longitude_i = 20000000)
+
+        assertFailsWith<PacketQueueRejectedException> { commandSender.sendPosition(pos) }
+
+        verify(exactly(0)) { nodeManager.handleReceivedPosition(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun setFixedPosition_doesNotUpdateLocalPositionWhenQueueRejectsPacket() = runTest {
+        everySuspend { packetHandler.sendToRadio(any<MeshPacket>()) } returns false
+
+        assertFailsWith<PacketQueueRejectedException> {
+            commandSender.setFixedPosition(DEST_NODE, Position(latitude = 1.0, longitude = 2.0, altitude = 3))
+        }
+
+        verify(exactly(0)) { nodeManager.handleReceivedPosition(any(), any(), any(), any()) }
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
@@ -19,6 +19,8 @@ package org.meshtastic.core.data.manager
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.service.LockdownState
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MeshConnectionManager
@@ -114,14 +116,14 @@ class LockdownCoordinatorImplTest {
             initFn: () -> AdminMessage,
         ) = Unit
 
-        override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) = Unit
-
-        override suspend fun sendAdminAwait(
+        override suspend fun sendAdminAwaitResult(
             destNum: Int,
             requestId: Int,
             wantResponse: Boolean,
             initFn: () -> AdminMessage,
-        ) = true
+        ) = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
+        override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) = Unit
 
         override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) =
             Unit

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
@@ -507,7 +507,7 @@ class MeshDataHandlerTest {
     // --- Routing/ACK-NAK handling ---
 
     @Test
-    fun `routing packet with successful ack broadcasts and removes response`() = testScope.runTest {
+    fun `routing ack completes dispatched response as accepted`() = testScope.runTest {
         val routing = Routing(error_reason = Routing.Error.NONE)
         val packet =
             MeshPacket(
@@ -528,7 +528,33 @@ class MeshDataHandlerTest {
         handler.handleReceivedData(packet, 123)
         advanceUntilIdle()
 
-        verifySuspend { packetHandler.removeResponse(99, complete = true) }
+        verifySuspend { packetHandler.completeDispatchedResponse(99, complete = true) }
+    }
+
+    @Test
+    fun `routing nak completes dispatched response as rejected`() = testScope.runTest {
+        // DUTY_CYCLE_LIMIT also exercises localized UI warnings; keep this response-ownership test independent.
+        val routing = Routing(error_reason = Routing.Error.NO_ROUTE)
+        val packet =
+            MeshPacket(
+                from = 456,
+                decoded =
+                Data(portnum = PortNum.ROUTING_APP, payload = routing.encode().toByteString(), request_id = 99),
+            )
+        val dataPacket =
+            DataPacket(
+                from = "!remote",
+                to = NodeAddress.ID_BROADCAST,
+                bytes = routing.encode().toByteString(),
+                dataType = PortNum.ROUTING_APP.value,
+            )
+        every { dataMapper.toDataPacket(packet) } returns dataPacket
+        every { nodeManager.toNodeID(456) } returns "!remote"
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend { packetHandler.completeDispatchedResponse(99, complete = false) }
     }
 
     @Test
@@ -556,7 +582,7 @@ class MeshDataHandlerTest {
 
         verifySuspend(exactly(0)) { packetRepository.getPacketByPacketId(any()) }
         verifySuspend(exactly(0)) { packetRepository.update(any(), any()) }
-        verifySuspend(exactly(0)) { packetHandler.removeResponse(any(), any()) }
+        verifySuspend(exactly(0)) { packetHandler.completeDispatchedResponse(any(), any()) }
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -20,6 +20,7 @@ import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
@@ -39,6 +40,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.common.di.asServiceScope
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketRepository
@@ -208,13 +211,15 @@ class PacketHandlerImplTest {
     fun `handleQueueStatus treats other nonzero res as failure`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
 
-        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 791)) }
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 791)) }
         testScheduler.runCurrent()
 
         handler.handleQueueStatus(QueueStatus(mesh_packet_id = 791, res = 33, free = 16))
         testScheduler.runCurrent()
 
-        assertFalse(result.await())
+        val rejected = result.await()
+        assertEquals(AwaitedSendStatus.RADIO_REJECTED, rejected.status)
+        assertTrue(rejected.dispatched)
     }
 
     @Test
@@ -245,6 +250,15 @@ class PacketHandlerImplTest {
     fun `stopping the queue completes an awaiting packet still behind the backlog`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         // Packet 803 owns the queue head, so 804 is stopped before the transport receives it.
+        val storedPacket =
+            DataPacket(
+                bytes = null,
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 804,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.getPacketById(804) } returns storedPacket
+        everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
         handler.sendToRadio(MeshPacket(id = 803))
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 804)) }
         testScheduler.runCurrent()
@@ -255,12 +269,22 @@ class PacketHandlerImplTest {
         val stopped = result.await()
         assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
         assertFalse(stopped.dispatched)
+        verifySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
     }
 
     @Test
     fun `stopping the queue reports an awaited packet that was already dispatched`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         // With no backlog, packet 807 reaches the transport before stopPacketQueue() drains its response.
+        val storedPacket =
+            DataPacket(
+                bytes = null,
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 807,
+                status = MessageStatus.ENROUTE,
+            )
+        everySuspend { packetRepository.getPacketById(807) } returns storedPacket
+        everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 807)) }
         testScheduler.runCurrent()
 
@@ -270,7 +294,37 @@ class PacketHandlerImplTest {
         val stopped = result.await()
         assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
         assertTrue(stopped.dispatched)
+        verifySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
     }
+
+    @Test
+    fun `queue stop does not overwrite an accepted packet while its reservation is still present`() =
+        runTest(testDispatcher) {
+            connectionStateFlow.value = ConnectionState.Connected
+            val storedPacket =
+                DataPacket(
+                    bytes = null,
+                    dataType = PortNum.TEXT_MESSAGE_APP.value,
+                    id = 817,
+                    status = MessageStatus.ENROUTE,
+                )
+            everySuspend { packetRepository.getPacketById(817) } returns storedPacket
+            everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
+            val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 817)) }
+            testScheduler.runCurrent()
+
+            // Queue the response callback first, then queue shutdown before either scheduled launch runs. The response
+            // completion resumes the worker behind the already-scheduled shutdown, reproducing the completed-but-still-
+            // reserved window that must not be reclassified as an error.
+            handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
+            handler.stopPacketQueue()
+            testScheduler.runCurrent()
+
+            val accepted = result.await()
+            assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+            assertTrue(accepted.dispatched)
+            verifySuspend(exactly(0)) { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
+        }
 
     @Test
     fun `disconnect drains queued responses without restarting the processor`() = runTest(testDispatcher) {
@@ -305,9 +359,29 @@ class PacketHandlerImplTest {
     }
 
     @Test
+    fun `disconnected queue admission reports transport stopped`() = runTest(testDispatcher) {
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 805)) }
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+        verify(exactly(0)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
     fun `transport refusing dispatch completes awaiting caller with failure`() = runTest(testDispatcher) {
         every { radioInterfaceService.trySendToRadio(any()) } returns false
         connectionStateFlow.value = ConnectionState.Connected
+        val storedPacket =
+            DataPacket(
+                bytes = null,
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 808,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.getPacketById(808) } returns storedPacket
+        everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
 
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 808)) }
         testScheduler.runCurrent()
@@ -315,6 +389,7 @@ class PacketHandlerImplTest {
         val failed = result.await()
         assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
         assertFalse(failed.dispatched)
+        verifySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) }
     }
 
     @Test
@@ -328,6 +403,42 @@ class PacketHandlerImplTest {
         val failed = result.await()
         assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
         assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `queue status without a packet id completes the oldest dispatched response`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val first = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 820)) }
+        val second = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 821)) }
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 0, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        val firstResult = first.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, firstResult.status)
+        assertTrue(firstResult.dispatched)
+        assertFalse(second.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 0, res = 0, free = 16))
+        testScheduler.runCurrent()
+        val secondResult = second.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, secondResult.status)
+        assertTrue(secondResult.dispatched)
+    }
+
+    @Test
+    fun `queue resumes after a stop and a later send`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        assertTrue(handler.sendToRadio(MeshPacket(id = 822)))
+        testScheduler.runCurrent()
+
+        verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 822, res = 0, free = 16))
+        testScheduler.runCurrent()
     }
 
     @Test
@@ -394,18 +505,17 @@ class PacketHandlerImplTest {
     }
 
     @Test
-    fun `early response completion retains the queued id and still transmits the packet`() = runTest(testDispatcher) {
+    fun `response received before dispatch is ignored and retains the queued id`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         handler.sendToRadio(MeshPacket(id = 816))
         val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 817)) }
         testScheduler.runCurrent()
 
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
         handler.removeResponse(dataRequestId = 817, complete = true)
         testScheduler.runCurrent()
 
-        val completed = queued.await()
-        assertEquals(AwaitedSendStatus.ACCEPTED, completed.status)
-        assertFalse(completed.dispatched)
+        assertFalse(queued.isCompleted)
 
         val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 817))
         assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
@@ -414,6 +524,16 @@ class PacketHandlerImplTest {
         testScheduler.runCurrent()
 
         verify(exactly(2)) { radioInterfaceService.trySendToRadio(any()) }
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        val accepted = queued.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+        assertTrue(accepted.dispatched)
+        assertTrue(handler.sendToRadio(MeshPacket(id = 817)))
+        testScheduler.runCurrent()
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
+        testScheduler.runCurrent()
     }
 
     @Test
@@ -449,6 +569,24 @@ class PacketHandlerImplTest {
             handler.stopPacketQueue()
             testScheduler.runCurrent()
         }
+
+    @Test
+    fun `completed packet id can be reused by a later retry`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        assertTrue(handler.sendToRadio(MeshPacket(id = 810)))
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 810, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertTrue(handler.sendToRadio(MeshPacket(id = 810)))
+        testScheduler.runCurrent()
+
+        verify(exactly(2)) { radioInterfaceService.trySendToRadio(any()) }
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+    }
 
     @Test
     fun `handleQueueStatus property test`() = runTest(testDispatcher) {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -73,19 +73,22 @@ class PacketHandlerImplTest {
 
     private lateinit var handler: PacketHandlerImpl
 
+    private val responseTimeoutCrossingMillis = PacketHandlerImpl.RESPONSE_TIMEOUT.inWholeMilliseconds + 1
+
+    private fun handlerWithScope(scope: TestScope) = PacketHandlerImpl(
+        lazy { packetRepository },
+        radioInterfaceService,
+        lazy { meshLogRepository },
+        serviceRepository,
+        scope.asServiceScope(),
+    )
+
     @BeforeTest
     fun setUp() {
         every { serviceRepository.connectionState } returns connectionStateFlow
         every { radioInterfaceService.trySendToRadio(any()) } returns true
 
-        handler =
-            PacketHandlerImpl(
-                lazy { packetRepository },
-                radioInterfaceService,
-                lazy { meshLogRepository },
-                serviceRepository,
-                testScope.asServiceScope(),
-            )
+        handler = handlerWithScope(testScope)
     }
 
     @Test
@@ -117,14 +120,7 @@ class PacketHandlerImplTest {
     fun `awaited send rejects when service scope is already stopped`() = runTest(testDispatcher) {
         val stoppedScope = TestScope(StandardTestDispatcher(testScheduler))
         stoppedScope.cancel()
-        val stoppedHandler =
-            PacketHandlerImpl(
-                lazy { packetRepository },
-                radioInterfaceService,
-                lazy { meshLogRepository },
-                serviceRepository,
-                stoppedScope.asServiceScope(),
-            )
+        val stoppedHandler = handlerWithScope(stoppedScope)
 
         val result = stoppedHandler.sendToRadioAndAwaitResult(MeshPacket(id = 457))
 
@@ -133,17 +129,22 @@ class PacketHandlerImplTest {
     }
 
     @Test
+    fun `plain send rejects when service scope is already stopped`() = runTest(testDispatcher) {
+        val stoppedScope = TestScope(StandardTestDispatcher(testScheduler))
+        stoppedScope.cancel()
+        val stoppedHandler = handlerWithScope(stoppedScope)
+
+        val accepted = stoppedHandler.sendToRadio(MeshPacket(id = 459))
+
+        assertFalse(accepted)
+        verify(exactly(0)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
     fun `awaited send is released when service scope stops before worker starts`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         val serviceScope = TestScope(StandardTestDispatcher(testScheduler))
-        val stoppedHandler =
-            PacketHandlerImpl(
-                lazy { packetRepository },
-                radioInterfaceService,
-                lazy { meshLogRepository },
-                serviceRepository,
-                serviceScope.asServiceScope(),
-            )
+        val stoppedHandler = handlerWithScope(serviceScope)
 
         val result =
             async(start = CoroutineStart.UNDISPATCHED) {
@@ -233,10 +234,10 @@ class PacketHandlerImplTest {
         // Let both earlier packets consume their full response windows. The awaited packet has not timed out
         // because
         // it has not reached the head of the queue yet.
-        testScheduler.advanceTimeBy(5_001)
+        testScheduler.advanceTimeBy(responseTimeoutCrossingMillis)
         testScheduler.runCurrent()
         assertFalse(result.isCompleted)
-        testScheduler.advanceTimeBy(5_001)
+        testScheduler.advanceTimeBy(responseTimeoutCrossingMillis)
         testScheduler.runCurrent()
         assertFalse(result.isCompleted)
 
@@ -257,7 +258,7 @@ class PacketHandlerImplTest {
                 id = 804,
                 status = MessageStatus.QUEUED,
             )
-        everySuspend { packetRepository.getPacketById(804) } returns storedPacket
+        everySuspend { packetRepository.getPacketByPacketId(804) } returns storedPacket
         everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
         handler.sendToRadio(MeshPacket(id = 803))
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 804)) }
@@ -273,6 +274,20 @@ class PacketHandlerImplTest {
     }
 
     @Test
+    fun `queue stop checks a missing persisted packet row only once`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 820))
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 821)) }
+        testScheduler.runCurrent()
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, queued.await().status)
+        verifySuspend(exactly(1)) { packetRepository.getPacketByPacketId(821) }
+    }
+
+    @Test
     fun `stopping the queue reports an awaited packet that was already dispatched`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
         // With no backlog, packet 807 reaches the transport before stopPacketQueue() drains its response.
@@ -283,7 +298,7 @@ class PacketHandlerImplTest {
                 id = 807,
                 status = MessageStatus.ENROUTE,
             )
-        everySuspend { packetRepository.getPacketById(807) } returns storedPacket
+        everySuspend { packetRepository.getPacketByPacketId(807) } returns storedPacket
         everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 807)) }
         testScheduler.runCurrent()
@@ -308,7 +323,7 @@ class PacketHandlerImplTest {
                     id = 817,
                     status = MessageStatus.ENROUTE,
                 )
-            everySuspend { packetRepository.getPacketById(817) } returns storedPacket
+            everySuspend { packetRepository.getPacketByPacketId(817) } returns storedPacket
             everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
             val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 817)) }
             testScheduler.runCurrent()
@@ -350,7 +365,7 @@ class PacketHandlerImplTest {
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 805)) }
         testScheduler.runCurrent()
 
-        testScheduler.advanceTimeBy(5_001)
+        testScheduler.advanceTimeBy(responseTimeoutCrossingMillis)
         testScheduler.runCurrent()
 
         val timedOut = result.await()
@@ -380,7 +395,7 @@ class PacketHandlerImplTest {
                 id = 808,
                 status = MessageStatus.QUEUED,
             )
-        everySuspend { packetRepository.getPacketById(808) } returns storedPacket
+        everySuspend { packetRepository.getPacketByPacketId(808) } returns storedPacket
         everySuspend { packetRepository.updateMessageStatus(storedPacket, MessageStatus.ERROR) } returns Unit
 
         val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 808)) }
@@ -512,7 +527,7 @@ class PacketHandlerImplTest {
         testScheduler.runCurrent()
 
         handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
-        handler.removeResponse(dataRequestId = 817, complete = true)
+        handler.completeDispatchedResponse(dataRequestId = 817, complete = true)
         testScheduler.runCurrent()
 
         assertFalse(queued.isCompleted)
@@ -534,6 +549,20 @@ class PacketHandlerImplTest {
         testScheduler.runCurrent()
         handler.handleQueueStatus(QueueStatus(mesh_packet_id = 817, res = 0, free = 16))
         testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `routing rejection after dispatch completes awaited response as radio rejected`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 818)) }
+        testScheduler.runCurrent()
+
+        handler.completeDispatchedResponse(dataRequestId = 818, complete = false)
+        testScheduler.runCurrent()
+
+        val rejected = result.await()
+        assertEquals(AwaitedSendStatus.RADIO_REJECTED, rejected.status)
+        assertTrue(rejected.dispatched)
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -17,22 +17,29 @@
 package org.meshtastic.core.data.manager
 
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.common.di.asServiceScope
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioInterfaceService
@@ -44,6 +51,7 @@ import org.meshtastic.proto.QueueStatus
 import org.meshtastic.proto.ToRadio
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -65,6 +73,7 @@ class PacketHandlerImplTest {
     @BeforeTest
     fun setUp() {
         every { serviceRepository.connectionState } returns connectionStateFlow
+        every { radioInterfaceService.trySendToRadio(any()) } returns true
 
         handler =
             PacketHandlerImpl(
@@ -87,7 +96,7 @@ class PacketHandlerImplTest {
 
         handler.sendToRadio(toRadio)
 
-        verify { radioInterfaceService.sendToRadio(any()) }
+        verify { radioInterfaceService.trySendToRadio(any()) }
     }
 
     @Test
@@ -98,7 +107,51 @@ class PacketHandlerImplTest {
         handler.sendToRadio(packet)
         testScheduler.runCurrent()
 
-        verify { radioInterfaceService.sendToRadio(any()) }
+        verify { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `awaited send rejects when service scope is already stopped`() = runTest(testDispatcher) {
+        val stoppedScope = TestScope(StandardTestDispatcher(testScheduler))
+        stoppedScope.cancel()
+        val stoppedHandler =
+            PacketHandlerImpl(
+                lazy { packetRepository },
+                radioInterfaceService,
+                lazy { meshLogRepository },
+                serviceRepository,
+                stoppedScope.asServiceScope(),
+            )
+
+        val result = stoppedHandler.sendToRadioAndAwaitResult(MeshPacket(id = 457))
+
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, result.status)
+        assertFalse(result.dispatched)
+    }
+
+    @Test
+    fun `awaited send is released when service scope stops before worker starts`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val serviceScope = TestScope(StandardTestDispatcher(testScheduler))
+        val stoppedHandler =
+            PacketHandlerImpl(
+                lazy { packetRepository },
+                radioInterfaceService,
+                lazy { meshLogRepository },
+                serviceRepository,
+                serviceScope.asServiceScope(),
+            )
+
+        val result =
+            async(start = CoroutineStart.UNDISPATCHED) {
+                stoppedHandler.sendToRadioAndAwaitResult(MeshPacket(id = 458))
+            }
+        serviceScope.cancel()
+        testScheduler.runCurrent()
+        val completed = result.await()
+
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, completed.status)
+        assertFalse(completed.dispatched)
     }
 
     @Test
@@ -163,6 +216,239 @@ class PacketHandlerImplTest {
 
         assertFalse(result.await())
     }
+
+    @Test
+    fun `await response timeout starts after earlier queued packets`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 800))
+        handler.sendToRadio(MeshPacket(id = 801))
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 802)) }
+        testScheduler.runCurrent()
+
+        // Let both earlier packets consume their full response windows. The awaited packet has not timed out
+        // because
+        // it has not reached the head of the queue yet.
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+        assertFalse(result.isCompleted)
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+        assertFalse(result.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 802, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertEquals(AwaitedSendStatus.ACCEPTED, result.await().status)
+    }
+
+    @Test
+    fun `stopping the queue completes an awaiting packet still behind the backlog`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        // Packet 803 owns the queue head, so 804 is stopped before the transport receives it.
+        handler.sendToRadio(MeshPacket(id = 803))
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 804)) }
+        testScheduler.runCurrent()
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+    }
+
+    @Test
+    fun `stopping the queue reports an awaited packet that was already dispatched`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        // With no backlog, packet 807 reaches the transport before stopPacketQueue() drains its response.
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 807)) }
+        testScheduler.runCurrent()
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+
+        val stopped = result.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertTrue(stopped.dispatched)
+    }
+
+    @Test
+    fun `disconnect drains queued responses without restarting the processor`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val first = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 813)) }
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 814)) }
+        testScheduler.runCurrent()
+
+        connectionStateFlow.value = ConnectionState.Disconnected
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 813, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertEquals(AwaitedSendStatus.ACCEPTED, first.await().status)
+        val stopped = queued.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+        verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `queue response timeout completes awaiting caller with failure`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 805)) }
+        testScheduler.runCurrent()
+
+        testScheduler.advanceTimeBy(5_001)
+        testScheduler.runCurrent()
+
+        val timedOut = result.await()
+        assertEquals(AwaitedSendStatus.TIMED_OUT, timedOut.status)
+        assertTrue(timedOut.dispatched)
+    }
+
+    @Test
+    fun `transport refusing dispatch completes awaiting caller with failure`() = runTest(testDispatcher) {
+        every { radioInterfaceService.trySendToRadio(any()) } returns false
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 808)) }
+        testScheduler.runCurrent()
+
+        val failed = result.await()
+        assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
+        assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `queue send failure completes awaiting caller with failure`() = runTest(testDispatcher) {
+        every { radioInterfaceService.trySendToRadio(any()) } calls { error("test send failure") }
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 806)) }
+        testScheduler.runCurrent()
+
+        val failed = result.await()
+        assertEquals(AwaitedSendStatus.SEND_FAILED, failed.status)
+        assertFalse(failed.dispatched)
+    }
+
+    @Test
+    fun `cancelled queue handoff releases its reservation before restarting queued work`() = runTest(testDispatcher) {
+        var sendAttempts = 0
+        every { radioInterfaceService.trySendToRadio(any()) } calls
+            {
+                sendAttempts++
+                if (sendAttempts == 1) throw CancellationException("transport stopped")
+                true
+            }
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val interrupted = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 815)) }
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 816)) }
+        testScheduler.runCurrent()
+
+        val stopped = interrupted.await()
+        assertEquals(AwaitedSendStatus.TRANSPORT_STOPPED, stopped.status)
+        assertFalse(stopped.dispatched)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 816, res = 0, free = 16))
+        testScheduler.runCurrent()
+        val accepted = queued.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+        assertTrue(accepted.dispatched)
+
+        assertTrue(handler.sendToRadio(MeshPacket(id = 815)))
+        testScheduler.runCurrent()
+        verify(exactly(3)) { radioInterfaceService.trySendToRadio(any()) }
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 815, res = 0, free = 16))
+        testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `awaited packet without an id is rejected before dispatch`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = handler.sendToRadioAndAwaitResult(MeshPacket())
+
+        assertEquals(AwaitedSendStatus.REJECTED, result.status)
+        assertFalse(result.dispatched)
+        verify(exactly(0)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `duplicate awaited packet id is rejected without replacing the original waiter`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        val original = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 809)) }
+        testScheduler.runCurrent()
+
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 809))
+
+        assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
+        assertFalse(duplicate.dispatched)
+        assertFalse(original.isCompleted)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 809, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        val accepted = original.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, accepted.status)
+        assertTrue(accepted.dispatched)
+    }
+
+    @Test
+    fun `early response completion retains the queued id and still transmits the packet`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 816))
+        val queued = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 817)) }
+        testScheduler.runCurrent()
+
+        handler.removeResponse(dataRequestId = 817, complete = true)
+        testScheduler.runCurrent()
+
+        val completed = queued.await()
+        assertEquals(AwaitedSendStatus.ACCEPTED, completed.status)
+        assertFalse(completed.dispatched)
+
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 817))
+        assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 816, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        verify(exactly(2)) { radioInterfaceService.trySendToRadio(any()) }
+    }
+
+    @Test
+    fun `cancelling an awaiting caller does not release its queued packet id`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        handler.sendToRadio(MeshPacket(id = 811))
+        val awaiting = async { handler.sendToRadioAndAwaitResult(MeshPacket(id = 812)) }
+        testScheduler.runCurrent()
+
+        awaiting.cancelAndJoin()
+        val duplicate = handler.sendToRadioAndAwaitResult(MeshPacket(id = 812))
+
+        assertEquals(AwaitedSendStatus.REJECTED, duplicate.status)
+        assertFalse(duplicate.dispatched)
+
+        handler.stopPacketQueue()
+        testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `fire and forget rejects invalid packet ids without throwing or replacing queued work`() =
+        runTest(testDispatcher) {
+            connectionStateFlow.value = ConnectionState.Connected
+            assertTrue(handler.sendToRadio(MeshPacket(id = 810)))
+            testScheduler.runCurrent()
+
+            assertFalse(handler.sendToRadio(MeshPacket(id = 810)))
+            assertFalse(handler.sendToRadio(MeshPacket()))
+            testScheduler.runCurrent()
+
+            verify(exactly(1)) { radioInterfaceService.trySendToRadio(any()) }
+
+            handler.stopPacketQueue()
+            testScheduler.runCurrent()
+        }
 
     @Test
     fun `handleQueueStatus property test`() = runTest(testDispatcher) {

--- a/core/domain/README.md
+++ b/core/domain/README.md
@@ -50,7 +50,7 @@ Ensures a per-node remote-admin passkey session exists before entering the remot
 sealed interface EnsureSessionResult {
     data object AlreadyActive   : EnsureSessionResult  // passkey already fresh
     data object Refreshed       : EnsureSessionResult  // metadata response arrived
-    data object Timeout         : EnsureSessionResult  // no response within 10 s
+    data object Timeout         : EnsureSessionResult  // no response within 30 s
     data object Disconnected    : EnsureSessionResult  // radio not connected
 }
 ```

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/session/EnsureRemoteAdminSessionUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/session/EnsureRemoteAdminSessionUseCase.kt
@@ -103,9 +103,10 @@ open class EnsureRemoteAdminSessionUseCase(
 
     companion object {
         /**
-         * UX deadline for surfacing a result to the user. The metadata request keeps flying after this — late responses
-         * still update the durable `SessionStatus` flow.
+         * UX deadline for surfacing a result to the user. Multi-hop remote-admin responses can legitimately take well
+         * over ten seconds; the metadata request keeps flying after this, and late responses still update the durable
+         * `SessionStatus` flow.
          */
-        val UX_TIMEOUT = 10.seconds
+        val UX_TIMEOUT = 30.seconds
     }
 }

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/session/EnsureRemoteAdminSessionUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/session/EnsureRemoteAdminSessionUseCaseTest.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okio.ByteString
 import org.meshtastic.core.common.di.asServiceScope
@@ -42,6 +43,7 @@ import org.meshtastic.core.repository.SessionManager
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EnsureRemoteAdminSessionUseCaseTest {
@@ -113,6 +115,27 @@ class EnsureRemoteAdminSessionUseCaseTest {
         val result = useCase(destNum)
 
         assertEquals(EnsureSessionResult.Refreshed, result)
+        verifySuspend { controller.refreshMetadata(destNum) }
+    }
+
+    @Test
+    fun `accepts a valid refresh arriving after the former ten second deadline`() = runTest {
+        val refresh = MutableSharedFlow<Int>(extraBufferCapacity = 8)
+        val sessionManager = stubSessionManager(refreshFlow = refresh)
+        val controller = mock<RadioController>(MockMode.autofill)
+        everySuspend { controller.refreshMetadata(any()) } returns Unit
+        val useCase =
+            EnsureRemoteAdminSessionUseCase(sessionManager, controller, connectedRepo(), this.asServiceScope())
+
+        var observed: EnsureSessionResult? = null
+        val job = launch { observed = useCase(destNum) }
+        runCurrent()
+        advanceTimeBy(13.seconds.inWholeMilliseconds)
+        refresh.emit(destNum)
+        advanceUntilIdle()
+        job.join()
+
+        assertEquals(EnsureSessionResult.Refreshed, observed)
         verifySuspend { controller.refreshMetadata(destNum) }
     }
 

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ConnectionState.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ConnectionState.kt
@@ -29,3 +29,49 @@ sealed interface ConnectionState {
     /** The device is in a light sleep state, and we are waiting for it to wake up and reconnect to us. */
     data object DeviceSleep : ConnectionState
 }
+
+/**
+ * One atomically published view of canonical connection state and its lifecycle evidence.
+ *
+ * Consumers that need to correlate a state with departure or handshake counters must observe this snapshot instead of
+ * reading [ConnectionState] and [ConnectionEpochs] flows independently.
+ */
+data class ConnectionLifecycle(
+    val version: Long = 0,
+    val state: ConnectionState = ConnectionState.Disconnected,
+    val epochs: ConnectionEpochs = ConnectionEpochs(),
+)
+
+/**
+ * Monotonic counters for connection lifecycle events that cannot be inferred reliably from transient [ConnectionState]
+ * values. A fast disconnect/reconnect may be observed only as the final state, while these counters retain both
+ * lifecycle boundaries.
+ *
+ * @property departures Number of transitions away from [ConnectionState.Connected].
+ * @property completedHandshakes Number of transitions into [ConnectionState.Connected].
+ * @property handshakesAtLastDeparture Completed-handshake count captured at the most recent departure. This preserves
+ *   event ordering when a fast departure/reconnect pair is conflated into one observed state-flow value.
+ * @property lastDepartureState State entered by the most recent departure. Consumers that react after a fast reconnect
+ *   can use this event evidence instead of rereading the already-advanced live connection state.
+ */
+data class ConnectionEpochs(
+    val departures: Long = 0,
+    val completedHandshakes: Long = 0,
+    val handshakesAtLastDeparture: Long = 0,
+    val lastDepartureState: ConnectionState? = null,
+) {
+    /** Returns the counters after applying one canonical connection-state transition. */
+    fun advance(previous: ConnectionState, current: ConnectionState): ConnectionEpochs = when {
+        previous is ConnectionState.Connected && current !is ConnectionState.Connected ->
+            copy(
+                departures = departures + 1,
+                handshakesAtLastDeparture = completedHandshakes,
+                lastDepartureState = current,
+            )
+
+        previous !is ConnectionState.Connected && current is ConnectionState.Connected ->
+            copy(completedHandshakes = completedHandshakes + 1)
+
+        else -> this
+    }
+}

--- a/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
+++ b/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
@@ -74,11 +74,12 @@ class SerialRadioTransportTest {
         val address = "serial-device"
         val connectEntered = CountDownLatch(1)
         val releaseConnect = CountDownLatch(1)
-        every { serialConnection.connect() } calls {
-            connectEntered.countDown()
-            check(releaseConnect.await(5, TimeUnit.SECONDS))
-            serialConnectionListener.onConnected()
-        }
+        every { serialConnection.connect() } calls
+            {
+                connectEntered.countDown()
+                check(releaseConnect.await(5, TimeUnit.SECONDS))
+                serialConnectionListener.onConnected()
+            }
         val transport = createTransport(address, this)
         val executor = Executors.newFixedThreadPool(2)
 

--- a/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
+++ b/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
@@ -23,6 +23,7 @@ import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -97,6 +98,46 @@ class SerialRadioTransportTest {
             releaseConnect.countDown()
             executor.shutdownNow()
         }
+    }
+
+    @Test
+    fun `stale terminal callbacks do not tear down a replacement connection`() = runTest {
+        val address = "serial-device"
+        val firstConnection = mock<SerialConnection>(MockMode.autofill)
+        val secondConnection = mock<SerialConnection>(MockMode.autofill)
+        val listeners = mutableListOf<SerialConnectionListener>()
+        var nextConnection = 0
+        val transport =
+            SerialRadioTransport(
+                callback = callback,
+                scope = this,
+                serialDevices = MutableStateFlow(mapOf(address to serialDriver)),
+                createSerialConnection = { driver, listener ->
+                    assertSame(serialDriver, driver)
+                    listeners += listener
+                    if (nextConnection++ == 0) firstConnection else secondConnection
+                },
+                address = address,
+            )
+        every { firstConnection.connect() } calls { listeners[0].onConnected() }
+        every { secondConnection.connect() } calls { listeners[1].onConnected() }
+
+        transport.start()
+        assertTrue(transport.handleSendToRadio(byteArrayOf(1)))
+        listeners[0].onDisconnected(null)
+        assertFalse(transport.handleSendToRadio(byteArrayOf(2)))
+
+        transport.start()
+        assertTrue(transport.handleSendToRadio(byteArrayOf(3)))
+        listeners[0].onDisconnected(IllegalStateException("late disconnect"))
+        assertTrue(transport.handleSendToRadio(byteArrayOf(4)))
+        listeners[0].onMissingPermission()
+        assertTrue(transport.handleSendToRadio(byteArrayOf(5)))
+
+        verify(exactly(1)) { callback.onDisconnect(isPermanent = false, errorMessage = null, reason = null) }
+        verify { firstConnection.close(waitForStopped = false) }
+        transport.close()
+        verify { secondConnection.close(waitForStopped = true) }
     }
 
     @Test

--- a/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
+++ b/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.radio
+
+import com.hoho.android.usbserial.driver.UsbSerialDriver
+import dev.mokkery.MockMode
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.network.repository.SerialConnection
+import org.meshtastic.core.repository.RadioTransportCallback
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+
+class SerialRadioTransportTest {
+
+    private val callback: RadioTransportCallback = mock(MockMode.autofill)
+    private val serialDriver: UsbSerialDriver = mock(MockMode.autofill)
+    private val serialConnection: SerialConnection = mock(MockMode.autofill)
+
+    private fun createTransport(address: String, scope: CoroutineScope): SerialRadioTransport = SerialRadioTransport(
+        callback = callback,
+        scope = scope,
+        serialDevices = MutableStateFlow(mapOf(address to serialDriver)),
+        createSerialConnection = { driver, _ ->
+            assertSame(serialDriver, driver)
+            serialConnection
+        },
+        address = address,
+    )
+
+    @Test
+    fun `failed connection is not left admitted`() = runTest {
+        val address = "serial-device"
+        every { serialConnection.connect() } throws IllegalStateException("connect failed")
+        val transport = createTransport(address, this)
+
+        assertFailsWith<IllegalStateException> { transport.start() }
+
+        verify { serialConnection.close(waitForStopped = false) }
+        assertFalse(transport.handleSendToRadio(byteArrayOf(1)))
+    }
+
+    @Test
+    fun `send is rejected before connection and after disconnect`() = runTest {
+        val address = "serial-device"
+        val transport = createTransport(address, this)
+
+        assertFalse(transport.handleSendToRadio(byteArrayOf(1)))
+
+        transport.start()
+        transport.close()
+
+        verify { serialConnection.close(waitForStopped = true) }
+        assertFalse(transport.handleSendToRadio(byteArrayOf(2)))
+    }
+}

--- a/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
+++ b/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.network.radio
 
 import com.hoho.android.usbserial.driver.UsbSerialDriver
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.mock
@@ -26,24 +27,31 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.network.repository.SerialConnection
+import org.meshtastic.core.network.repository.SerialConnectionListener
 import org.meshtastic.core.repository.RadioTransportCallback
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class SerialRadioTransportTest {
 
     private val callback: RadioTransportCallback = mock(MockMode.autofill)
     private val serialDriver: UsbSerialDriver = mock(MockMode.autofill)
     private val serialConnection: SerialConnection = mock(MockMode.autofill)
+    private lateinit var serialConnectionListener: SerialConnectionListener
 
     private fun createTransport(address: String, scope: CoroutineScope): SerialRadioTransport = SerialRadioTransport(
         callback = callback,
         scope = scope,
         serialDevices = MutableStateFlow(mapOf(address to serialDriver)),
-        createSerialConnection = { driver, _ ->
+        createSerialConnection = { driver, listener ->
             assertSame(serialDriver, driver)
+            serialConnectionListener = listener
             serialConnection
         },
         address = address,
@@ -62,16 +70,47 @@ class SerialRadioTransportTest {
     }
 
     @Test
+    fun `send is rejected promptly while connection is still opening`() = runTest {
+        val address = "serial-device"
+        val connectEntered = CountDownLatch(1)
+        val releaseConnect = CountDownLatch(1)
+        every { serialConnection.connect() } calls {
+            connectEntered.countDown()
+            check(releaseConnect.await(5, TimeUnit.SECONDS))
+            serialConnectionListener.onConnected()
+        }
+        val transport = createTransport(address, this)
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val startFuture = executor.submit { transport.start() }
+            assertTrue(connectEntered.await(1, TimeUnit.SECONDS), "connect should enter the blocking open")
+
+            val sendFuture = executor.submit<Boolean> { transport.handleSendToRadio(byteArrayOf(1)) }
+            assertFalse(sendFuture.get(1, TimeUnit.SECONDS), "an opening transport must reject promptly")
+
+            releaseConnect.countDown()
+            startFuture.get(1, TimeUnit.SECONDS)
+            transport.close()
+        } finally {
+            releaseConnect.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `send is rejected before connection and after disconnect`() = runTest {
         val address = "serial-device"
         val transport = createTransport(address, this)
 
         assertFalse(transport.handleSendToRadio(byteArrayOf(1)))
 
+        every { serialConnection.connect() } calls { serialConnectionListener.onConnected() }
         transport.start()
+        assertTrue(transport.handleSendToRadio(byteArrayOf(2)), "an established connection must accept the handoff")
         transport.close()
 
         verify { serialConnection.close(waitForStopped = true) }
-        assertFalse(transport.handleSendToRadio(byteArrayOf(2)))
+        assertFalse(transport.handleSendToRadio(byteArrayOf(3)))
     }
 }

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/AndroidRadioTransportFactory.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/AndroidRadioTransportFactory.kt
@@ -96,7 +96,8 @@ class AndroidRadioTransportFactory(
                 SerialRadioTransport(
                     callback = service,
                     scope = service.serviceScope,
-                    usbRepository = usbRepository,
+                    serialDevices = usbRepository.serialDevices,
+                    createSerialConnection = usbRepository::createSerialConnection,
                     address = rest,
                 )
 

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
@@ -40,6 +40,8 @@ class SerialRadioTransport(
 ) : StreamTransport(callback, scope) {
     private var connRef = AtomicReference<SerialConnection?>()
     private val connectionAdmissionLock = Any()
+    private var activeConnectionToken: Any? = null
+    private val connectionReady = AtomicBoolean(false)
 
     private val heartbeatSender = HeartbeatSender(sendToRadio = { handleSendToRadio(it) }, logTag = "Serial[$address]")
 
@@ -80,7 +82,12 @@ class SerialRadioTransport(
     }
 
     private fun closeConnection(waitForStopped: Boolean): Boolean {
-        val connection = synchronized(connectionAdmissionLock) { connRef.getAndSet(null) } ?: return false
+        val connection =
+            synchronized(connectionAdmissionLock) {
+                connectionReady.set(false)
+                activeConnectionToken = null
+                connRef.getAndSet(null)
+            } ?: return false
         connection.close(waitForStopped)
         return true
     }
@@ -99,6 +106,7 @@ class SerialRadioTransport(
             var bytesReceived = 0L
             var connectionStartTime = 0L
 
+            val connectionToken = Any()
             val onConnect: () -> Unit = {
                 connectionStartTime = nowMillis
                 val connectionTime = connectionStartTime - connectStart
@@ -124,7 +132,11 @@ class SerialRadioTransport(
                     }
 
                     override fun onConnected() {
-                        onConnect.invoke()
+                        synchronized(connectionAdmissionLock) {
+                            if (activeConnectionToken !== connectionToken || connRef.get() == null) return
+                            connectionReady.set(true)
+                            onConnect.invoke()
+                        }
                     }
 
                     override fun onDataReceived(bytes: ByteArray) {
@@ -174,15 +186,25 @@ class SerialRadioTransport(
                 .also { conn ->
                     synchronized(connectionAdmissionLock) {
                         connRef.set(conn)
-                        try {
-                            conn.connect()
-                        } catch (e: Exception) {
-                            // A synchronous listener callback can already have cleared and closed this connection.
-                            if (connRef.compareAndSet(conn, null)) {
-                                conn.close(waitForStopped = false)
+                        activeConnectionToken = connectionToken
+                        connectionReady.set(false)
+                    }
+                    try {
+                        conn.connect()
+                    } catch (e: Exception) {
+                        // A synchronous listener callback can already have cleared and closed this connection.
+                        val shouldClose =
+                            synchronized(connectionAdmissionLock) {
+                                if (activeConnectionToken !== connectionToken || !connRef.compareAndSet(conn, null)) {
+                                    false
+                                } else {
+                                    connectionReady.set(false)
+                                    activeConnectionToken = null
+                                    true
+                                }
                             }
-                            throw e
-                        }
+                        if (shouldClose) conn.close(waitForStopped = false)
+                        throw e
                     }
                 }
         }
@@ -190,13 +212,12 @@ class SerialRadioTransport(
 
     // The result reports synchronous admission against the current connection, not eventual delivery: framing and
     // sendBytes run later on the transport scope, where teardown may legitimately make the connection unavailable.
-    override fun handleSendToRadio(p: ByteArray): Boolean = synchronized(connectionAdmissionLock) {
-        if (connRef.get() == null) {
+    override fun handleSendToRadio(p: ByteArray): Boolean {
+        if (!connectionReady.get() || connRef.get() == null) {
             Logger.w { "[$address] Serial connection not available, cannot send ${p.size} bytes" }
-            false
-        } else {
-            super.handleSendToRadio(p)
+            return false
         }
+        return super.handleSendToRadio(p)
     }
 
     override fun keepAlive() {

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
@@ -81,14 +81,30 @@ class SerialRadioTransport(
         }
     }
 
+    private fun claimConnection(connectionToken: Any? = null): SerialConnection? =
+        synchronized(connectionAdmissionLock) {
+            if (connectionToken != null && activeConnectionToken !== connectionToken) return@synchronized null
+            connectionReady.set(false)
+            activeConnectionToken = null
+            connRef.getAndSet(null)
+        }
+
     private fun closeConnection(waitForStopped: Boolean): Boolean {
-        val connection =
-            synchronized(connectionAdmissionLock) {
-                connectionReady.set(false)
-                activeConnectionToken = null
-                connRef.getAndSet(null)
-            } ?: return false
+        val connection = claimConnection() ?: return false
         connection.close(waitForStopped)
+        return true
+    }
+
+    private fun disconnectOwnedConnection(
+        connectionToken: Any,
+        waitForStopped: Boolean,
+        isPermanent: Boolean,
+        errorMessage: String? = null,
+        reason: TransportDisconnectReason? = null,
+    ): Boolean {
+        val connection = claimConnection(connectionToken) ?: return false
+        connection.close(waitForStopped)
+        super.onDeviceDisconnect(waitForStopped, isPermanent, errorMessage, reason)
         return true
     }
 
@@ -118,17 +134,19 @@ class SerialRadioTransport(
                 device,
                 object : SerialConnectionListener {
                     override fun onMissingPermission() {
+                        if (
+                            !disconnectOwnedConnection(
+                                connectionToken = connectionToken,
+                                waitForStopped = false,
+                                isPermanent = true,
+                                reason = TransportDisconnectReason.UsbPermissionDenied,
+                            )
+                        ) {
+                            return
+                        }
                         Logger.e {
                             "[$address] Serial connection failed - missing USB permissions for device: $device"
                         }
-                        // Permission denial is terminal for this connection attempt: stop the reconnect loop
-                        // and let the service/UI layer choose the user-facing copy for the structured reason.
-                        onDeviceDisconnect(
-                            waitForStopped = false,
-                            isPermanent = true,
-                            errorMessage = null,
-                            reason = TransportDisconnectReason.UsbPermissionDenied,
-                        )
                     }
 
                     override fun onConnected() {
@@ -158,6 +176,15 @@ class SerialRadioTransport(
                         if (explicitCloseInProgress.get()) {
                             return
                         }
+                        if (
+                            !disconnectOwnedConnection(
+                                connectionToken = connectionToken,
+                                waitForStopped = false,
+                                isPermanent = false,
+                            )
+                        ) {
+                            return
+                        }
 
                         val uptime =
                             if (connectionStartTime > 0) {
@@ -175,11 +202,6 @@ class SerialRadioTransport(
                                 "Uptime: ${uptime}ms, " +
                                 "Packets RX: $packetsReceived ($bytesReceived bytes)"
                         }
-                        // USB unplug / cable error is transient — the transport will reconnect when
-                        // the device is replugged or the OS re-enumerates the port. Only close()
-                        // (user disconnects) and missing-permission (see onMissingPermission) signal
-                        // a permanent disconnect; cable unplug / I/O errors are transient.
-                        onDeviceDisconnect(waitForStopped = false, isPermanent = false)
                     }
                 },
             )

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
@@ -17,12 +17,13 @@
 package org.meshtastic.core.network.radio
 
 import co.touchlab.kermit.Logger
+import com.hoho.android.usbserial.driver.UsbSerialDriver
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.network.repository.SerialConnection
 import org.meshtastic.core.network.repository.SerialConnectionListener
-import org.meshtastic.core.network.repository.UsbRepository
 import org.meshtastic.core.network.transport.HeartbeatSender
 import org.meshtastic.core.repository.RadioTransportCallback
 import org.meshtastic.core.repository.TransportDisconnectReason
@@ -33,12 +34,14 @@ import java.util.concurrent.atomic.AtomicReference
 class SerialRadioTransport(
     callback: RadioTransportCallback,
     scope: CoroutineScope,
-    private val usbRepository: UsbRepository,
+    private val serialDevices: StateFlow<Map<String, UsbSerialDriver>>,
+    private val createSerialConnection: (UsbSerialDriver, SerialConnectionListener) -> SerialConnection,
     private val address: String,
 ) : StreamTransport(callback, scope) {
     private var connRef = AtomicReference<SerialConnection?>()
+    private val connectionAdmissionLock = Any()
 
-    private val heartbeatSender = HeartbeatSender(sendToRadio = ::handleSendToRadio, logTag = "Serial[$address]")
+    private val heartbeatSender = HeartbeatSender(sendToRadio = { handleSendToRadio(it) }, logTag = "Serial[$address]")
 
     /**
      * Set while an explicit [close] is tearing down the connection so the reader thread's
@@ -77,13 +80,14 @@ class SerialRadioTransport(
     }
 
     private fun closeConnection(waitForStopped: Boolean): Boolean {
-        val connection = connRef.getAndSet(null) ?: return false
+        val connection = synchronized(connectionAdmissionLock) { connRef.getAndSet(null) } ?: return false
         connection.close(waitForStopped)
         return true
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun connect() {
-        val deviceMap = usbRepository.serialDevices.value
+        val deviceMap = serialDevices.value
         val device = deviceMap[address] ?: deviceMap.values.firstOrNull()
         if (device == null) {
             Logger.e { "[$address] Serial device not found at address" }
@@ -102,76 +106,96 @@ class SerialRadioTransport(
                 super.connect()
             }
 
-            usbRepository
-                .createSerialConnection(
-                    device,
-                    object : SerialConnectionListener {
-                        override fun onMissingPermission() {
-                            Logger.e {
-                                "[$address] Serial connection failed - missing USB permissions for device: $device"
-                            }
-                            // Permission denial is terminal for this connection attempt: stop the reconnect loop
-                            // and let the service/UI layer choose the user-facing copy for the structured reason.
-                            onDeviceDisconnect(
-                                waitForStopped = false,
-                                isPermanent = true,
-                                errorMessage = null,
-                                reason = TransportDisconnectReason.UsbPermissionDenied,
-                            )
+            createSerialConnection(
+                device,
+                object : SerialConnectionListener {
+                    override fun onMissingPermission() {
+                        Logger.e {
+                            "[$address] Serial connection failed - missing USB permissions for device: $device"
+                        }
+                        // Permission denial is terminal for this connection attempt: stop the reconnect loop
+                        // and let the service/UI layer choose the user-facing copy for the structured reason.
+                        onDeviceDisconnect(
+                            waitForStopped = false,
+                            isPermanent = true,
+                            errorMessage = null,
+                            reason = TransportDisconnectReason.UsbPermissionDenied,
+                        )
+                    }
+
+                    override fun onConnected() {
+                        onConnect.invoke()
+                    }
+
+                    override fun onDataReceived(bytes: ByteArray) {
+                        packetsReceived++
+                        bytesReceived += bytes.size
+                        Logger.d {
+                            "[$address] Serial received packet #$packetsReceived - " +
+                                "${bytes.size} byte(s) (Total RX: $bytesReceived bytes)"
+                        }
+                        bytes.forEach(::readChar)
+                    }
+
+                    override fun onDisconnected(thrown: Exception?) {
+                        // Skip the disconnect callback when the reader-thread termination is the
+                        // direct result of an explicit close() — the caller owns the post-close
+                        // notification, and the expected close must not emit warning-log noise.
+                        // USB unplug / cable error is the only path that should log + forward a
+                        // transient disconnect here.
+                        if (explicitCloseInProgress.get()) {
+                            return
                         }
 
-                        override fun onConnected() {
-                            onConnect.invoke()
+                        val uptime =
+                            if (connectionStartTime > 0) {
+                                nowMillis - connectionStartTime
+                            } else {
+                                0
+                            }
+                        thrown?.let { e ->
+                            // USB errors are common when unplugging; log as warning to avoid Crashlytics noise
+                            Logger.w(e) { "[$address] Serial error after ${uptime}ms: ${e.message}" }
                         }
-
-                        override fun onDataReceived(bytes: ByteArray) {
-                            packetsReceived++
-                            bytesReceived += bytes.size
-                            Logger.d {
-                                "[$address] Serial received packet #$packetsReceived - " +
-                                    "${bytes.size} byte(s) (Total RX: $bytesReceived bytes)"
-                            }
-                            bytes.forEach(::readChar)
+                        Logger.w {
+                            "[$address] Serial device disconnected - " +
+                                "Device: $device, " +
+                                "Uptime: ${uptime}ms, " +
+                                "Packets RX: $packetsReceived ($bytesReceived bytes)"
                         }
-
-                        override fun onDisconnected(thrown: Exception?) {
-                            // Skip the disconnect callback when the reader-thread termination is the
-                            // direct result of an explicit close() — the caller owns the post-close
-                            // notification, and the expected close must not emit warning-log noise.
-                            // USB unplug / cable error is the only path that should log + forward a
-                            // transient disconnect here.
-                            if (explicitCloseInProgress.get()) {
-                                return
-                            }
-
-                            val uptime =
-                                if (connectionStartTime > 0) {
-                                    nowMillis - connectionStartTime
-                                } else {
-                                    0
-                                }
-                            thrown?.let { e ->
-                                // USB errors are common when unplugging; log as warning to avoid Crashlytics noise
-                                Logger.w(e) { "[$address] Serial error after ${uptime}ms: ${e.message}" }
-                            }
-                            Logger.w {
-                                "[$address] Serial device disconnected - " +
-                                    "Device: $device, " +
-                                    "Uptime: ${uptime}ms, " +
-                                    "Packets RX: $packetsReceived ($bytesReceived bytes)"
-                            }
-                            // USB unplug / cable error is transient — the transport will reconnect when
-                            // the device is replugged or the OS re-enumerates the port. Only close()
-                            // (user disconnects) and missing-permission (see onMissingPermission) signal
-                            // a permanent disconnect; cable unplug / I/O errors are transient.
-                            onDeviceDisconnect(waitForStopped = false, isPermanent = false)
-                        }
-                    },
-                )
+                        // USB unplug / cable error is transient — the transport will reconnect when
+                        // the device is replugged or the OS re-enumerates the port. Only close()
+                        // (user disconnects) and missing-permission (see onMissingPermission) signal
+                        // a permanent disconnect; cable unplug / I/O errors are transient.
+                        onDeviceDisconnect(waitForStopped = false, isPermanent = false)
+                    }
+                },
+            )
                 .also { conn ->
-                    connRef.set(conn)
-                    conn.connect()
+                    synchronized(connectionAdmissionLock) {
+                        connRef.set(conn)
+                        try {
+                            conn.connect()
+                        } catch (e: Exception) {
+                            // A synchronous listener callback can already have cleared and closed this connection.
+                            if (connRef.compareAndSet(conn, null)) {
+                                conn.close(waitForStopped = false)
+                            }
+                            throw e
+                        }
+                    }
                 }
+        }
+    }
+
+    // The result reports synchronous admission against the current connection, not eventual delivery: framing and
+    // sendBytes run later on the transport scope, where teardown may legitimately make the connection unavailable.
+    override fun handleSendToRadio(p: ByteArray): Boolean = synchronized(connectionAdmissionLock) {
+        if (connRef.get() == null) {
+            Logger.w { "[$address] Serial connection not available, cannot send ${p.size} bytes" }
+            false
+        } else {
+            super.handleSendToRadio(p)
         }
     }
 

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -220,7 +220,7 @@ class BleRadioTransport(
 
     private val heartbeatSender =
         HeartbeatSender(
-            sendToRadio = ::handleSendToRadio,
+            sendToRadio = { handleSendToRadio(it) },
             afterHeartbeat = {
                 delay(HEARTBEAT_DRAIN_DELAY)
                 radioService?.requestDrain()
@@ -683,50 +683,52 @@ class BleRadioTransport(
      *
      * @param p The packet to send.
      */
-    override fun handleSendToRadio(p: ByteArray) {
+    override fun handleSendToRadio(p: ByteArray): Boolean {
         // Fast-path check: skip coroutine launch entirely if no transport is active.
         if (radioService == null) {
             Logger.w { "[$address] toRadio characteristic unavailable, can't send data" }
-            return
+            return false
         }
-        connectionScope.launch {
-            writeMutex.withLock {
-                // Re-read radioService UNDER the lock — handleFailure may have nulled it
-                // between the outer check and lock acquisition. Without this, a queued send
-                // can retry writes against a stale/dead profile.
-                val currentService =
-                    radioService
-                        ?: run {
-                            Logger.w { "[$address] toRadio characteristic cleared during write queue" }
-                            return@withLock
+        val sendJob =
+            connectionScope.launch {
+                writeMutex.withLock {
+                    // Re-read radioService UNDER the lock — handleFailure may have nulled it
+                    // between the outer check and lock acquisition. Without this, a queued send
+                    // can retry writes against a stale/dead profile.
+                    val currentService =
+                        radioService
+                            ?: run {
+                                Logger.w { "[$address] toRadio characteristic cleared during write queue" }
+                                return@withLock
+                            }
+                    try {
+                        retryBleOperation(tag = address, retryWhile = { currentService === radioService }) {
+                            currentService.sendToRadio(p)
                         }
-                try {
-                    retryBleOperation(tag = address, retryWhile = { currentService === radioService }) {
-                        currentService.sendToRadio(p)
-                    }
-                    val sent = packetsSent.incrementAndGet()
-                    val txBytes = bytesSent.addAndGet(p.size.toLong())
-                    Logger.v {
-                        "[$address] Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $txBytes bytes)"
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Guard: only call handleFailure if this write was against the CURRENT session.
-                    // If radioService was replaced (new reconnect cycle) or cleared (handleFailure
-                    // already ran), this is a stale write from the old session — silently discard.
-                    if (currentService === radioService) {
-                        Logger.w(e) {
-                            "[$address] Failed to write packet to toRadioCharacteristic after " +
-                                "${packetsSent.value} successful writes"
+                        val sent = packetsSent.incrementAndGet()
+                        val txBytes = bytesSent.addAndGet(p.size.toLong())
+                        Logger.v {
+                            "[$address] Wrote packet #$sent " + "to toRadio (${p.size} bytes, total TX: $txBytes bytes)"
                         }
-                        handleFailure(e)
-                    } else {
-                        Logger.d(e) { "[$address] Stale write failure ignored because the session was replaced" }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // Guard: only call handleFailure if this write was against the CURRENT session.
+                        // If radioService was replaced (new reconnect cycle) or cleared (handleFailure
+                        // already ran), this is a stale write from the old session — silently discard.
+                        if (currentService === radioService) {
+                            Logger.w(e) {
+                                "[$address] Failed to write packet to toRadioCharacteristic after " +
+                                    "${packetsSent.value} successful writes"
+                            }
+                            handleFailure(e)
+                        } else {
+                            Logger.d(e) { "[$address] Stale write failure ignored because the session was replaced" }
+                        }
                     }
                 }
             }
-        }
+        return !sendJob.isCancelled
     }
 
     override fun keepAlive() {

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/MockRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/MockRadioTransport.kt
@@ -82,7 +82,7 @@ class MockRadioTransport(
         callback.onConnect() // Tell clients they can use the API
     }
 
-    override fun handleSendToRadio(p: ByteArray) {
+    override fun handleSendToRadio(p: ByteArray): Boolean {
         val pr = ToRadio.ADAPTER.decode(p)
 
         // Intercept want_config handshake — send config response only when requested,
@@ -90,7 +90,7 @@ class MockRadioTransport(
         val wantConfigId = pr.want_config_id ?: 0
         if (wantConfigId != 0) {
             sendConfigResponse(wantConfigId)
-            return
+            return true
         }
 
         val packet = pr.packet
@@ -108,6 +108,7 @@ class MockRadioTransport(
 
             else -> Logger.i { "Ignoring data sent to mock transport $pr" }
         }
+        return true
     }
 
     private fun handleAdminPacket(pr: ToRadio, d: AdminMessage) {

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/NopRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/NopRadioTransport.kt
@@ -26,9 +26,7 @@ import org.meshtastic.core.repository.RadioTransport
  * the service layer.
  */
 class NopRadioTransport(val address: String) : RadioTransport {
-    override fun handleSendToRadio(p: ByteArray) {
-        // No-op
-    }
+    override fun handleSendToRadio(p: ByteArray): Boolean = false
 
     override suspend fun close() {
         // No-op

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransport.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.core.network.radio
 
 import co.touchlab.kermit.Logger
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import okio.Buffer
@@ -104,7 +105,7 @@ class ReplayRadioTransport(
         packetFrames = buffer.readSection(counted = false, label = "packet")
     }
 
-    private var packetsStarted = false
+    private val packetsStarted = atomic(false)
 
     override fun start() {
         Logger.i {
@@ -130,10 +131,7 @@ class ReplayRadioTransport(
                     scope.handledLaunch {
                         emit(nodeFrames)
                         complete(HandshakeConstants.NODE_INFO_NONCE)
-                        if (!packetsStarted) {
-                            packetsStarted = true
-                            streamPackets()
-                        }
+                        if (packetsStarted.compareAndSet(expect = false, update = true)) streamPackets()
                     }
 
                 // All other ToRadio traffic (heartbeats, outbound packets) is ignored — this is a read-only replay.

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransport.kt
@@ -114,28 +114,32 @@ class ReplayRadioTransport(
         callback.onConnect()
     }
 
-    override fun handleSendToRadio(p: ByteArray) {
+    override fun handleSendToRadio(p: ByteArray): Boolean {
         // Undecodable ToRadio is ignored rather than thrown: the replay must tolerate any bytes the app — or a fuzz
         // harness — hands it, exactly as it tolerates a malformed asset.
         val wantConfigId = runCatching { ToRadio.ADAPTER.decode(p).want_config_id }.getOrNull()
-        when (wantConfigId) {
-            HandshakeConstants.CONFIG_NONCE ->
-                scope.handledLaunch {
-                    emit(configFrames)
-                    complete(HandshakeConstants.CONFIG_NONCE)
-                }
-
-            HandshakeConstants.NODE_INFO_NONCE ->
-                scope.handledLaunch {
-                    emit(nodeFrames)
-                    complete(HandshakeConstants.NODE_INFO_NONCE)
-                    if (!packetsStarted) {
-                        packetsStarted = true
-                        streamPackets()
+        val sendJob =
+            when (wantConfigId) {
+                HandshakeConstants.CONFIG_NONCE ->
+                    scope.handledLaunch {
+                        emit(configFrames)
+                        complete(HandshakeConstants.CONFIG_NONCE)
                     }
-                }
-            // All other ToRadio traffic (heartbeats, outbound packets) is ignored — this is a read-only replay.
-        }
+
+                HandshakeConstants.NODE_INFO_NONCE ->
+                    scope.handledLaunch {
+                        emit(nodeFrames)
+                        complete(HandshakeConstants.NODE_INFO_NONCE)
+                        if (!packetsStarted) {
+                            packetsStarted = true
+                            streamPackets()
+                        }
+                    }
+
+                // All other ToRadio traffic (heartbeats, outbound packets) is ignored — this is a read-only replay.
+                else -> null
+            }
+        return sendJob?.isCancelled == false
     }
 
     private fun emit(frames: List<ByteArray>) = frames.forEach { callback.handleFromRadio(it) }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/StreamTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/StreamTransport.kt
@@ -77,10 +77,14 @@ abstract class StreamTransport(protected val callback: RadioTransportCallback, p
     /** Flushes buffered bytes to the underlying stream. No-op by default. */
     open fun flushBytes() {}
 
-    override fun handleSendToRadio(p: ByteArray) {
-        // This method is called from a continuation and it might show up late, so check for uart being null
-        scope.handledLaunch { codec.frameAndSend(p, ::sendBytes, ::flushBytes) }
-    }
+    /**
+     * Queues the framed packet onto [scope].
+     *
+     * @return true when the write coroutine was launched on a live scope. Delivery through [sendBytes] happens later
+     *   and is not confirmed by this result.
+     */
+    override fun handleSendToRadio(p: ByteArray): Boolean =
+        !scope.handledLaunch { codec.frameAndSend(p, ::sendBytes, ::flushBytes) }.isCancelled
 
     /** Process a single incoming byte through the stream framing state machine. */
     protected fun readChar(c: Byte) {

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/TcpRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/TcpRadioTransport.kt
@@ -91,7 +91,7 @@ open class TcpRadioTransport(
     }
 
     override fun handleSendToRadio(p: ByteArray): Boolean {
-        if (closing) return false
+        if (closing || !transport.isConnected) return false
         return !scope.handledLaunch { transport.sendPacket(p) }.isCancelled
     }
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/TcpRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/TcpRadioTransport.kt
@@ -90,7 +90,8 @@ open class TcpRadioTransport(
         scope.handledLaunch { transport.sendHeartbeat() }
     }
 
-    override fun handleSendToRadio(p: ByteArray) {
-        scope.handledLaunch { transport.sendPacket(p) }
+    override fun handleSendToRadio(p: ByteArray): Boolean {
+        if (closing) return false
+        return !scope.handledLaunch { transport.sendPacket(p) }.isCancelled
     }
 }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -104,6 +104,25 @@ class BleRadioTransportTest {
         assertEquals(address, bleTransport.address)
     }
 
+    @Test
+    fun `send is rejected before the BLE profile is available`() = runTest {
+        val bleTransport =
+            BleRadioTransport(
+                scope = testScope,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+
+        try {
+            assertFalse(bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3)))
+        } finally {
+            bleTransport.close()
+        }
+    }
+
     /**
      * After [BleReconnectPolicy.DEFAULT_FAILURE_THRESHOLD] consecutive connection failures,
      * [RadioInterfaceService.onDisconnect] must be called so the higher layers can react (e.g. start the device-sleep

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransportTest.kt
@@ -29,6 +29,7 @@ import org.meshtastic.proto.ToRadio
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ReplayRadioTransportTest {
@@ -91,10 +92,22 @@ class ReplayRadioTransportTest {
         val callback = RecordingCallback()
         val transport = ReplayRadioTransport(callback, this, address = "", frames = asset(), packetDelayMs = 0)
 
-        transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.CONFIG_NONCE).encode())
+        val accepted = transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.CONFIG_NONCE).encode())
         testScheduler.advanceUntilIdle()
 
+        assertTrue(accepted)
         assertEquals(configFrames + FromRadio(config_complete_id = HandshakeConstants.CONFIG_NONCE), callback.received)
+    }
+
+    @Test
+    fun `read-only replay rejects outbound mesh traffic`() = runTest {
+        val callback = RecordingCallback()
+        val transport = ReplayRadioTransport(callback, this, address = "", frames = asset(), packetDelayMs = 0)
+
+        val accepted = transport.handleSendToRadio(ToRadio(packet = MeshPacket(id = 1)).encode())
+
+        assertFalse(accepted)
+        assertTrue(callback.received.isEmpty())
     }
 
     @Test

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/StreamTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/StreamTransportTest.kt
@@ -78,6 +78,7 @@ class StreamTransportTest {
         stoppedScope.cancel()
 
         assertFalse(transport.handleSendToRadio(byteArrayOf(1, 2, 3)))
+        assertTrue(transport.sentBytes.isEmpty())
     }
 
     @Test

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/StreamTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/StreamTransportTest.kt
@@ -26,11 +26,13 @@ import io.kotest.property.arbitrary.byte
 import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.network.transport.StreamFrameCodec
 import org.meshtastic.core.repository.RadioTransportCallback
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class StreamTransportTest {
@@ -64,7 +66,18 @@ class StreamTransportTest {
     fun `handleSendToRadio property test`() = runTest {
         fakeStream = FakeStreamTransport(callback, testScope)
 
-        checkAll(Arb.byteArray(Arb.int(0, 512), Arb.byte())) { payload -> fakeStream.handleSendToRadio(payload) }
+        checkAll(Arb.byteArray(Arb.int(0, 512), Arb.byte())) { payload ->
+            assertTrue(fakeStream.handleSendToRadio(payload))
+        }
+    }
+
+    @Test
+    fun `send is rejected after the transport scope stops`() {
+        val stoppedScope = TestScope()
+        val transport = FakeStreamTransport(callback, stoppedScope)
+        stoppedScope.cancel()
+
+        assertFalse(transport.handleSendToRadio(byteArrayOf(1, 2, 3)))
     }
 
     @Test

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/TcpRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/TcpRadioTransportTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.radio
+
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.repository.RadioTransportCallback
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class TcpRadioTransportTest {
+
+    private val callback: RadioTransportCallback = mock(MockMode.autofill)
+
+    @Test
+    fun `send is rejected after close starts`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val dispatchers = CoroutineDispatchers(io = dispatcher, main = dispatcher, default = dispatcher)
+        val transport = TcpRadioTransport(callback, this, dispatchers, address = "127.0.0.1")
+
+        transport.close()
+
+        assertFalse(transport.handleSendToRadio(byteArrayOf(1, 2, 3)))
+    }
+}

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/TcpRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/TcpRadioTransportTest.kt
@@ -30,13 +30,15 @@ class TcpRadioTransportTest {
     private val callback: RadioTransportCallback = mock(MockMode.autofill)
 
     @Test
-    fun `send is rejected after close starts`() = runTest {
+    fun `send is rejected while disconnected and after close starts`() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val dispatchers = CoroutineDispatchers(io = dispatcher, main = dispatcher, default = dispatcher)
         val transport = TcpRadioTransport(callback, this, dispatchers, address = "127.0.0.1")
 
+        assertFalse(transport.handleSendToRadio(byteArrayOf(1, 2, 3)))
+
         transport.close()
 
-        assertFalse(transport.handleSendToRadio(byteArrayOf(1, 2, 3)))
+        assertFalse(transport.handleSendToRadio(byteArrayOf(4, 5, 6)))
     }
 }

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/SerialTransport.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/SerialTransport.kt
@@ -48,7 +48,7 @@ private constructor(
     private var serialPort: SerialPort? = null
     private var readJob: Job? = null
 
-    private val heartbeatSender = HeartbeatSender(sendToRadio = ::handleSendToRadio, logTag = "Serial[$portName]")
+    private val heartbeatSender = HeartbeatSender(sendToRadio = { handleSendToRadio(it) }, logTag = "Serial[$portName]")
 
     /** Attempts to open the serial port and starts the read loop. Returns true if successful, false otherwise. */
     private fun startConnection(): Boolean {

--- a/core/repository/README.md
+++ b/core/repository/README.md
@@ -78,12 +78,16 @@ Raw hardware I/O contract for all physical transports (BLE, USB, TCP, Mock).
 
 ```kotlin
 interface RadioTransport {
-    fun handleSendToRadio(p: ByteArray)
+    fun handleSendToRadio(p: ByteArray): Boolean
     fun start()
     fun keepAlive()
     suspend fun close()
 }
 ```
+
+`handleSendToRadio` reports synchronous admission only: `true` means the transport accepted the bytes for asynchronous
+handoff, not that the device received them. `false` means the transport is unavailable, closed, or unable to schedule
+the handoff; delivery confirmation is a separate protocol concern.
 
 ### `ServiceRepository`
 
@@ -92,7 +96,9 @@ Decomposed into focused sub-interfaces via Interface Segregation Principle:
 
 ```kotlin
 interface ConnectionStateProvider {
+    val connectionLifecycle: StateFlow<ConnectionLifecycle>
     val connectionState: StateFlow<ConnectionState>
+    val connectionEpochs: StateFlow<ConnectionEpochs>
 }
 
 interface TracerouteResponseProvider {

--- a/core/repository/README.md
+++ b/core/repository/README.md
@@ -89,6 +89,16 @@ interface RadioTransport {
 handoff, not that the device received them. `false` means the transport is unavailable, closed, or unable to schedule
 the handoff; delivery confirmation is a separate protocol concern.
 
+`RadioTransportWriter` is the service-facing half of the same admission contract. `trySendToRadio` must likewise return
+promptly and reports only whether the active transport accepted the bytes for asynchronous delivery.
+
+```kotlin
+interface RadioTransportWriter {
+    fun sendToRadio(bytes: ByteArray)
+    fun trySendToRadio(bytes: ByteArray): Boolean
+}
+```
+
 ### `ServiceRepository`
 
 The primary reactive bridge between the long-running mesh service and all feature/UI layers.

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.repository
 
+import kotlinx.coroutines.NonCancellable
 import org.meshtastic.core.model.Position
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.Config
@@ -145,7 +146,16 @@ interface AdminController {
      * SDK's `AdminApi.editSettings { }`.
      *
      * All admin packets for the session — begin, the [block]'s writes, and commit — are issued from the calling
-     * coroutine, which is required for the firmware to associate them with one transaction.
+     * coroutine, which is required for the firmware to associate them with one transaction. The implementation waits
+     * for radio queue acceptance at both boundaries, so callers cannot start a later rebooting stage while this
+     * transaction is still queued or uncommitted.
+     *
+     * For the locally connected node, a commit dispatched immediately before the expected transport departure is
+     * treated as accepted because the reboot can prevent an acknowledgement from returning.
+     *
+     * Firmware exposes no abort boundary, so commit is attempted in [NonCancellable] context even when [block] throws
+     * or the caller is cancelled. The original block failure is rethrown, with a distinct commit failure attached as a
+     * suppressed exception.
      */
     suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit)
 
@@ -167,7 +177,10 @@ interface AdminEditScope {
     /** Updates a module configuration on the session's node. */
     suspend fun setModuleConfig(config: ModuleConfig)
 
-    /** Updates a channel configuration on the session's node. */
+    /**
+     * Updates a channel configuration on the session's node. The batch operation that owns the complete target set is
+     * responsible for authoritative local-cache reconciliation after [AdminController.editSettings] returns.
+     */
     suspend fun setChannel(channel: Channel)
 
     /** Sets a fixed position on the session's node. */

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
@@ -18,16 +18,29 @@ package org.meshtastic.core.repository
 
 /** Outcome of a packet whose caller waited for radio acceptance. */
 enum class AwaitedSendStatus {
+    /** An active transport dispatched the packet and the radio acknowledged it. */
     ACCEPTED,
+
+    /** The app rejected the packet before it reached a transport, such as an invalid or duplicate packet ID. */
     REJECTED,
+
+    /** The transport dispatched the packet, but the radio rejected it. */
+    RADIO_REJECTED,
+
+    /** No radio response arrived within the response window after the packet reached the queue head. */
     TIMED_OUT,
+
+    /** The queue or owning service scope stopped before the radio answered; retry after the next connection. */
     TRANSPORT_STOPPED,
+
+    /** No transport accepted the bytes, or the send attempt raised an error. */
     SEND_FAILED,
 }
 
 /**
  * Detailed result for an awaited send. [dispatched] is true only when an active transport accepted the outbound bytes
- * for asynchronous delivery.
+ * for asynchronous delivery. Correlated responses received before dispatch are ignored, so an accepted result always
+ * belongs to an admitted transport send.
  */
 data class AwaitedSendResult(val status: AwaitedSendStatus, val dispatched: Boolean) {
     val accepted: Boolean

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AwaitedSendResult.kt
@@ -14,27 +14,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+package org.meshtastic.core.repository
 
-plugins {
-    alias(libs.plugins.meshtastic.kmp.library)
-    alias(libs.plugins.meshtastic.koin)
+/** Outcome of a packet whose caller waited for radio acceptance. */
+enum class AwaitedSendStatus {
+    ACCEPTED,
+    REJECTED,
+    TIMED_OUT,
+    TRANSPORT_STOPPED,
+    SEND_FAILED,
 }
 
-kotlin {
-    android { withHostTest {} }
-
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.core.model)
-            api(libs.meshtastic.protobufs)
-            implementation(projects.core.common)
-            implementation(projects.core.database)
-
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.atomicfu)
-            implementation(libs.kermit)
-            implementation(libs.androidx.paging.common)
-        }
-        commonTest.dependencies { implementation(projects.core.testing) }
-    }
+/**
+ * Detailed result for an awaited send. [dispatched] is true only when an active transport accepted the outbound bytes
+ * for asynchronous delivery.
+ */
+data class AwaitedSendResult(val status: AwaitedSendStatus, val dispatched: Boolean) {
+    val accepted: Boolean
+        get() = status == AwaitedSendStatus.ACCEPTED
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -37,10 +37,12 @@ interface CommandSender {
     /** Generates a new unique packet ID. */
     fun generatePacketId(): Int
 
-    /** Sends a data packet to the mesh. */
+    /**
+     * Sends a data packet to the mesh, recording [org.meshtastic.core.model.MessageStatus.ERROR] if admission fails.
+     */
     suspend fun sendData(p: DataPacket)
 
-    /** Sends an admin message to a specific node. */
+    /** Sends an admin message to a specific node, or throws if the outbound queue rejects it. */
     suspend fun sendAdmin(
         destNum: Int,
         requestId: Int = generatePacketId(),
@@ -79,25 +81,25 @@ interface CommandSender {
         initFn: () -> AdminMessage,
     ): AwaitedSendResult
 
-    /** Sends our current position to the mesh. */
+    /** Sends our current position to the mesh, or throws if the outbound queue rejects it. */
     suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int? = null, wantResponse: Boolean = false)
 
-    /** Requests the position of a specific node. */
+    /** Requests the position of a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestPosition(destNum: Int, currentPosition: Position)
 
-    /** Sets a fixed position for a node. */
+    /** Sets a fixed position for a node, or throws if the outbound queue rejects the admin command. */
     suspend fun setFixedPosition(destNum: Int, pos: Position)
 
-    /** Requests user info from a specific node. */
+    /** Requests user info from a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestUserInfo(destNum: Int)
 
-    /** Requests a traceroute to a specific node. */
+    /** Requests a traceroute to a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestTraceroute(requestId: Int, destNum: Int)
 
-    /** Requests telemetry from a specific node. */
+    /** Requests telemetry from a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestTelemetry(requestId: Int, destNum: Int, typeValue: Int)
 
-    /** Requests neighbor info from a specific node. */
+    /** Requests neighbor info from a specific node, or throws if the outbound queue rejects it. */
     suspend fun requestNeighborInfo(requestId: Int, destNum: Int)
 
     /**

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -59,7 +59,8 @@ interface CommandSender {
      * Sends an admin message and suspends until the radio acknowledges it.
      *
      * This is used when the caller needs to guarantee a packet has been accepted by the radio before proceeding, such
-     * as sending a shared contact before the first DM to a node.
+     * as sending a shared contact before the first DM to a node. Time spent behind existing FIFO entries does not count
+     * against the radio-response timeout.
      *
      * @return `true` if the radio accepted the packet, `false` on timeout or failure.
      */
@@ -68,7 +69,15 @@ interface CommandSender {
         requestId: Int = generatePacketId(),
         wantResponse: Boolean = false,
         initFn: () -> AdminMessage,
-    ): Boolean
+    ): Boolean = sendAdminAwaitResult(destNum, requestId, wantResponse, initFn).accepted
+
+    /** Detailed form of [sendAdminAwait], including whether an active transport admitted the packet. */
+    suspend fun sendAdminAwaitResult(
+        destNum: Int,
+        requestId: Int = generatePacketId(),
+        wantResponse: Boolean = false,
+        initFn: () -> AdminMessage,
+    ): AwaitedSendResult
 
     /** Sends our current position to the mesh. */
     suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int? = null, wantResponse: Boolean = false)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -38,7 +38,9 @@ interface CommandSender {
     fun generatePacketId(): Int
 
     /**
-     * Sends a data packet to the mesh, recording [org.meshtastic.core.model.MessageStatus.ERROR] if admission fails.
+     * Sends a data packet to the mesh. If the outbound queue refuses admission, the packet is marked
+     * [org.meshtastic.core.model.MessageStatus.ERROR] and [PacketQueueRejectedException] is thrown so the persistence
+     * owner can requeue or fail its durable record instead of treating a normal return as successful admission.
      */
     suspend fun sendData(p: DataPacket)
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
+import org.meshtastic.core.model.ConnectionState
+
+/**
+ * Owns canonical connection state and its lifecycle epochs as one lock-free transition.
+ *
+ * The canonical [ConnectionLifecycle] flow is updated with compare-and-set, so concurrent writers cannot lose or
+ * double-count lifecycle edges. One publisher then mirrors its newest value to the legacy state and epoch convenience
+ * flows. Lifecycle-sensitive consumers therefore never have to correlate separate publications.
+ */
+class ConnectionStateHolder(
+    initialState: ConnectionState = ConnectionState.Disconnected,
+    initialEpochs: ConnectionEpochs = ConnectionEpochs(),
+) : ConnectionStateProvider {
+    private val publicationInProgress = atomic(false)
+    private val publishedVersion = atomic(0L)
+
+    private val mutableConnectionLifecycle =
+        MutableStateFlow(ConnectionLifecycle(version = 0, state = initialState, epochs = initialEpochs))
+    private val mutableConnectionState = MutableStateFlow(initialState)
+    private val mutableConnectionEpochs = MutableStateFlow(initialEpochs)
+
+    override val connectionLifecycle: StateFlow<ConnectionLifecycle> = mutableConnectionLifecycle.asStateFlow()
+    override val connectionState: StateFlow<ConnectionState> = mutableConnectionState.asStateFlow()
+    override val connectionEpochs: StateFlow<ConnectionEpochs> = mutableConnectionEpochs.asStateFlow()
+
+    /** Applies [newState] and advances epochs exactly once when the state changes. */
+    fun setConnectionState(newState: ConnectionState) {
+        while (true) {
+            val current = mutableConnectionLifecycle.value
+            if (current.state == newState) return
+
+            val next =
+                ConnectionLifecycle(
+                    version = current.version + 1,
+                    state = newState,
+                    epochs = current.epochs.advance(current.state, newState),
+                )
+            if (mutableConnectionLifecycle.compareAndSet(current, next)) {
+                publishCompatibilityViews()
+                return
+            }
+        }
+    }
+
+    /** Restores a known baseline, primarily for reusable test fakes. */
+    fun reset(state: ConnectionState = ConnectionState.Disconnected, epochs: ConnectionEpochs = ConnectionEpochs()) {
+        while (true) {
+            val current = mutableConnectionLifecycle.value
+            val next = ConnectionLifecycle(version = current.version + 1, state = state, epochs = epochs)
+            if (mutableConnectionLifecycle.compareAndSet(current, next)) {
+                publishCompatibilityViews()
+                return
+            }
+        }
+    }
+
+    private fun publishCompatibilityViews() {
+        while (true) {
+            if (!publicationInProgress.compareAndSet(expect = false, update = true)) return
+            try {
+                do {
+                    val snapshot = mutableConnectionLifecycle.value
+                    mutableConnectionEpochs.value = snapshot.epochs
+                    mutableConnectionState.value = snapshot.state
+                    publishedVersion.value = snapshot.version
+                } while (publishedVersion.value != mutableConnectionLifecycle.value.version)
+            } finally {
+                publicationInProgress.value = false
+            }
+
+            // An updater can publish a new lifecycle after the final loop check but before the publisher flag is
+            // released. AtomicFU's sequentially-consistent lifecycle CAS, failed flag CAS, and flag release order
+            // that update before this post-release comparison. Recheck so its compatibility projection cannot be
+            // stranded; do not weaken the flag or reorder publication without replacing that handoff guarantee.
+            if (publishedVersion.value == mutableConnectionLifecycle.value.version) return
+        }
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
@@ -47,7 +47,13 @@ class ConnectionStateHolder(
     override val connectionState: StateFlow<ConnectionState> = mutableConnectionState.asStateFlow()
     override val connectionEpochs: StateFlow<ConnectionEpochs> = mutableConnectionEpochs.asStateFlow()
 
-    /** Applies [newState] and advances epochs exactly once when the state changes. */
+    /**
+     * Applies [newState] and advances epochs exactly once when the state changes.
+     *
+     * [connectionLifecycle] is authoritative on return. A concurrent publisher may update the compatibility
+     * [connectionState] and [connectionEpochs] mirrors immediately afterward, so they are not read-after-write
+     * consistent for the caller under contention.
+     */
     fun setConnectionState(newState: ConnectionState) {
         while (true) {
             val current = mutableConnectionLifecycle.value
@@ -66,7 +72,10 @@ class ConnectionStateHolder(
         }
     }
 
-    /** Restores a known baseline, primarily for reusable test fakes. */
+    /**
+     * Restores a known baseline, primarily for reusable test fakes. The version remains monotonic even when state and
+     * epochs return to earlier values, so a reader cannot mistake a reset snapshot for an older publication.
+     */
     fun reset(state: ConnectionState = ConnectionState.Disconnected, epochs: ConnectionEpochs = ConnectionEpochs()) {
         while (true) {
             val current = mutableConnectionLifecycle.value
@@ -92,10 +101,9 @@ class ConnectionStateHolder(
                 publicationInProgress.value = false
             }
 
-            // An updater can publish a new lifecycle after the final loop check but before the publisher flag is
-            // released. AtomicFU's sequentially-consistent lifecycle CAS, failed flag CAS, and flag release order
-            // that update before this post-release comparison. Recheck so its compatibility projection cannot be
-            // stranded; do not weaken the flag or reorder publication without replacing that handoff guarantee.
+            // An updater can commit after the final loop check, lose the publisher race, and return before this owner
+            // releases the flag. Sequentially consistent atomics make that lifecycle write visible here. The
+            // post-release recheck ensures its compatibility projection cannot be stranded.
             if (publishedVersion.value == mutableConnectionLifecycle.value.version) return
         }
     }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateHolder.kt
@@ -93,6 +93,7 @@ class ConnectionStateHolder(
             try {
                 do {
                     val snapshot = mutableConnectionLifecycle.value
+                    // Epochs first: state collectors that then read connectionEpochs must not observe lagging counters.
                     mutableConnectionEpochs.value = snapshot.epochs
                     mutableConnectionState.value = snapshot.state
                     publishedVersion.value = snapshot.version

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateProvider.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ConnectionStateProvider.kt
@@ -17,6 +17,8 @@
 package org.meshtastic.core.repository
 
 import kotlinx.coroutines.flow.StateFlow
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
 import org.meshtastic.core.model.ConnectionState
 
 /**
@@ -30,6 +32,14 @@ import org.meshtastic.core.model.ConnectionState
  */
 interface ConnectionStateProvider {
     /**
+     * Atomically correlated canonical state and lifecycle evidence.
+     *
+     * Lifecycle-sensitive code must observe this flow rather than combining independent reads from [connectionState]
+     * and [connectionEpochs].
+     */
+    val connectionLifecycle: StateFlow<ConnectionLifecycle>
+
+    /**
      * Canonical app-level connection state.
      *
      * This is the **single source of truth** for connection status across the entire application.
@@ -37,4 +47,11 @@ interface ConnectionStateProvider {
      * @see ServiceRepository.connectionState
      */
     val connectionState: StateFlow<ConnectionState>
+
+    /**
+     * Convenience view of monotonic departures and completed handshakes. Use [connectionLifecycle] when the counters
+     * must be correlated with a specific state, because independent StateFlow collections can observe different
+     * versions.
+     */
+    val connectionEpochs: StateFlow<ConnectionEpochs>
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -25,8 +25,13 @@ interface PacketHandler {
     /** Sends a command/packet directly to the radio. */
     fun sendToRadio(p: ToRadio)
 
-    /** Adds a mesh packet to the queue for sending. */
-    suspend fun sendToRadio(packet: MeshPacket)
+    /**
+     * Adds a mesh packet to the queue for sending.
+     *
+     * @return `true` when the packet's non-zero ID was reserved and queued, or `false` when the packet was invalid or
+     *   its ID was already queued/in flight.
+     */
+    suspend fun sendToRadio(packet: MeshPacket): Boolean
 
     /**
      * Adds a mesh packet to the queue and suspends until the radio acknowledges it via [QueueStatus].
@@ -35,9 +40,15 @@ interface PacketHandler {
      * packet has been accepted by the radio before proceeding. This is critical for operations where ordering matters
      * (e.g., sending a shared contact before the first DM).
      *
+     * Time spent behind packets already in the FIFO is not part of the response timeout. The timeout begins when this
+     * packet reaches the head of the queue and is transmitted.
+     *
      * @return `true` if the radio accepted the packet, `false` on timeout or failure.
      */
-    suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean
+    suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean = sendToRadioAndAwaitResult(packet).accepted
+
+    /** Detailed form of [sendToRadioAndAwait], including whether an active transport admitted the packet. */
+    suspend fun sendToRadioAndAwaitResult(packet: MeshPacket): AwaitedSendResult
 
     /** Processes queue status updates from the radio. */
     fun handleQueueStatus(queueStatus: QueueStatus)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -28,8 +28,11 @@ interface PacketHandler {
     /**
      * Adds a mesh packet to the queue for sending.
      *
-     * @return `true` when the packet's non-zero ID was reserved and queued, or `false` when the packet was invalid or
-     *   its ID was already queued/in flight.
+     * A completed packet ID may be reused by a later retry. A duplicate is rejected only while that ID is still queued
+     * or in flight, preserving single ownership of its response.
+     *
+     * @return `true` when the packet's non-zero ID was reserved and queued, or `false` when the packet was invalid, its
+     *   ID was already reserved, or the owning service scope has shut down.
      */
     suspend fun sendToRadio(packet: MeshPacket): Boolean
 
@@ -53,7 +56,9 @@ interface PacketHandler {
     /** Processes queue status updates from the radio. */
     fun handleQueueStatus(queueStatus: QueueStatus)
 
-    /** Removes and completes a pending response for a request before the caller's lifecycle lease is released. */
+    /**
+     * Completes a dispatched request before the caller's lifecycle lease is released; pre-dispatch replies are stale.
+     */
     suspend fun removeResponse(dataRequestId: Int, complete: Boolean)
 
     /** Stops the packet queue. */

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -57,9 +57,11 @@ interface PacketHandler {
     fun handleQueueStatus(queueStatus: QueueStatus)
 
     /**
-     * Completes a dispatched request before the caller's lifecycle lease is released; pre-dispatch replies are stale.
+     * Completes the pending response for [dataRequestId] when an active transport already dispatched that packet.
+     * Replies that arrive before dispatch are stale and are ignored. This method does not release the packet ID
+     * reservation; the queue worker owns that removal.
      */
-    suspend fun removeResponse(dataRequestId: Int, complete: Boolean)
+    suspend fun completeDispatchedResponse(dataRequestId: Int, complete: Boolean)
 
     /** Stops the packet queue. */
     fun stopPacketQueue()

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketQueueRejectedException.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketQueueRejectedException.kt
@@ -14,30 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.meshtastic.core.testing
+package org.meshtastic.core.repository
 
-import org.meshtastic.core.repository.RadioTransport
-
-/** A test double for [RadioTransport] that tracks sent data. */
-class FakeRadioTransport : RadioTransport {
-    val sentData = mutableListOf<ByteArray>()
-    var closeCalled = false
-    var closeCount = 0
-        private set
-
-    var keepAliveCalled = false
-
-    override fun handleSendToRadio(p: ByteArray): Boolean {
-        sentData.add(p)
-        return true
-    }
-
-    override fun keepAlive() {
-        keepAliveCalled = true
-    }
-
-    override suspend fun close() {
-        closeCalled = true
-        closeCount++
-    }
-}
+/** Thrown when the outbound packet queue refuses admission for an operation. */
+class PacketQueueRejectedException(operation: String) :
+    IllegalStateException("$operation was rejected by the outbound packet queue")

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -82,6 +82,8 @@ interface RadioTransportWriter {
     /**
      * Attempts to dispatch [bytes] to the active transport.
      *
+     * Implementations must return promptly: enqueue transport work internally instead of blocking for I/O or delivery.
+     *
      * @return `true` when an active transport accepted the bytes for asynchronous delivery, or `false` when no send
      *   could be scheduled or confirmed.
      */

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -72,6 +72,22 @@ interface RadioSessionAuthority {
         runWithSessionLease(session) { block() }
 }
 
+/** Writes raw protocol frames to the currently admitted transport. */
+interface RadioTransportWriter {
+    /** Sends [bytes] when a transport is available; callers that need admission evidence use [trySendToRadio]. */
+    fun sendToRadio(bytes: ByteArray) {
+        trySendToRadio(bytes)
+    }
+
+    /**
+     * Attempts to dispatch [bytes] to the active transport.
+     *
+     * @return `true` when an active transport accepted the bytes for asynchronous delivery, or `false` when no send
+     *   could be scheduled or confirmed.
+     */
+    fun trySendToRadio(bytes: ByteArray): Boolean
+}
+
 /**
  * Interface for the low-level radio interface that handles raw byte communication.
  *
@@ -89,7 +105,8 @@ interface RadioSessionAuthority {
  */
 interface RadioInterfaceService :
     RadioTransportCallback,
-    RadioSessionAuthority {
+    RadioSessionAuthority,
+    RadioTransportWriter {
     /** The device types supported by this platform's radio interface. */
     val supportedDeviceTypes: List<DeviceType>
 
@@ -144,9 +161,6 @@ interface RadioInterfaceService :
      * collector was attached do not get replayed ahead of the next session's handshake.
      */
     fun resetReceivedBuffer()
-
-    /** Sends a raw byte array to the radio. */
-    fun sendToRadio(bytes: ByteArray)
 
     /** Initiates the connection to the radio. */
     fun connect()

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioTransport.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioTransport.kt
@@ -21,8 +21,13 @@ package org.meshtastic.core.repository
  * KMP-compatible replacement for the legacy Android-specific IRadioInterface.
  */
 interface RadioTransport {
-    /** Sends a raw byte array to the radio hardware. */
-    fun handleSendToRadio(p: ByteArray)
+    /**
+     * Attempts to hand [p] to this transport for delivery. Implementations must return promptly after any required
+     * synchronous admission checks and enqueue asynchronous I/O internally.
+     *
+     * @return `true` when the transport accepted the bytes for delivery, or `false` when no send was scheduled.
+     */
+    fun handleSendToRadio(p: ByteArray): Boolean
 
     /**
      * Initializes the transport after construction. Called by the factory once the transport has been fully created.

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
+import org.meshtastic.core.model.ConnectionState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConnectionStateHolderTest {
+    @Test
+    fun `transitions advance matching epochs exactly once`() {
+        val holder = ConnectionStateHolder()
+
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connecting)
+        holder.setConnectionState(ConnectionState.Disconnected)
+        holder.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            holder.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `lifecycle flow publishes state and epochs as one correlated snapshot`() {
+        val holder = ConnectionStateHolder()
+
+        holder.setConnectionState(ConnectionState.Connected)
+        holder.setConnectionState(ConnectionState.Connecting)
+
+        assertEquals(
+            ConnectionLifecycle(
+                version = 2,
+                state = ConnectionState.Connecting,
+                epochs =
+                ConnectionEpochs(
+                    departures = 1,
+                    completedHandshakes = 1,
+                    handshakesAtLastDeparture = 1,
+                    lastDepartureState = ConnectionState.Connecting,
+                ),
+            ),
+            holder.connectionLifecycle.value,
+        )
+    }
+
+    @Test
+    fun `concurrent duplicate transitions advance each lifecycle edge once`() = runTest {
+        val holder = ConnectionStateHolder()
+
+        suspend fun fanOut(state: ConnectionState) = coroutineScope {
+            List(100) { async(Dispatchers.Default) { holder.setConnectionState(state) } }.awaitAll()
+        }
+
+        fanOut(ConnectionState.Connected)
+        fanOut(ConnectionState.Connecting)
+        fanOut(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            holder.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `reset restores an explicit state and epoch baseline`() {
+        val holder = ConnectionStateHolder()
+        holder.setConnectionState(ConnectionState.Connected)
+        val versionBeforeReset = holder.connectionLifecycle.value.version
+
+        holder.reset(
+            state = ConnectionState.DeviceSleep,
+            epochs = ConnectionEpochs(departures = 7, completedHandshakes = 11, handshakesAtLastDeparture = 10),
+        )
+
+        assertEquals(versionBeforeReset + 1, holder.connectionLifecycle.value.version)
+        assertEquals(ConnectionState.DeviceSleep, holder.connectionState.value)
+        assertEquals(
+            ConnectionEpochs(departures = 7, completedHandshakes = 11, handshakesAtLastDeparture = 10),
+            holder.connectionEpochs.value,
+        )
+    }
+}

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
@@ -16,16 +16,21 @@
  */
 package org.meshtastic.core.repository
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionLifecycle
 import org.meshtastic.core.model.ConnectionState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ConnectionStateHolderTest {
     @Test
@@ -99,9 +104,30 @@ class ConnectionStateHolderTest {
     }
 
     @Test
-    fun `concurrent mixed transitions leave compatibility views on one committed lifecycle`() = runTest {
+    fun `concurrent mixed transitions publish correlated lifecycle snapshots while active`() = runTest {
         repeat(25) {
             val holder = ConnectionStateHolder()
+            val collectorReady = CompletableDeferred<Unit>()
+            val transitionObserved = CompletableDeferred<Unit>()
+            val collector =
+                backgroundScope.launch(Dispatchers.Default) {
+                    holder.connectionLifecycle.collect { lifecycle ->
+                        collectorReady.complete(Unit)
+                        if (lifecycle.version > 0) transitionObserved.complete(Unit)
+
+                        val connectedOffset = if (lifecycle.state is ConnectionState.Connected) 1 else 0
+                        assertEquals(
+                            lifecycle.epochs.departures + connectedOffset,
+                            lifecycle.epochs.completedHandshakes,
+                        )
+                        assertTrue(
+                            lifecycle.epochs.handshakesAtLastDeparture <= lifecycle.epochs.completedHandshakes,
+                            "departure handshake evidence must come from the same lifecycle commit",
+                        )
+                    }
+                }
+            collectorReady.await()
+
             val states =
                 List(25) {
                     listOf(
@@ -112,10 +138,11 @@ class ConnectionStateHolderTest {
                     )
                 }
                     .flatten()
-
             coroutineScope {
                 states.map { state -> async(Dispatchers.Default) { holder.setConnectionState(state) } }.awaitAll()
             }
+            transitionObserved.await()
+            collector.cancelAndJoin()
 
             val lifecycle = holder.connectionLifecycle.value
             assertEquals(lifecycle.state, holder.connectionState.value)

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ConnectionStateHolderTest.kt
@@ -39,6 +39,7 @@ class ConnectionStateHolderTest {
         holder.setConnectionState(ConnectionState.Connected)
 
         assertEquals(ConnectionState.Connected, holder.connectionState.value)
+        assertEquals(4L, holder.connectionLifecycle.value.version)
         assertEquals(
             ConnectionEpochs(
                 departures = 1,
@@ -95,6 +96,31 @@ class ConnectionStateHolderTest {
             ),
             holder.connectionEpochs.value,
         )
+    }
+
+    @Test
+    fun `concurrent mixed transitions leave compatibility views on one committed lifecycle`() = runTest {
+        repeat(25) {
+            val holder = ConnectionStateHolder()
+            val states =
+                List(25) {
+                    listOf(
+                        ConnectionState.Connected,
+                        ConnectionState.Connecting,
+                        ConnectionState.DeviceSleep,
+                        ConnectionState.Disconnected,
+                    )
+                }
+                    .flatten()
+
+            coroutineScope {
+                states.map { state -> async(Dispatchers.Default) { holder.setConnectionState(state) } }.awaitAll()
+            }
+
+            val lifecycle = holder.connectionLifecycle.value
+            assertEquals(lifecycle.state, holder.connectionState.value)
+            assertEquals(lifecycle.epochs, holder.connectionEpochs.value)
+        }
     }
 
     @Test

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/RadioTransportTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/RadioTransportTest.kt
@@ -30,8 +30,9 @@ class RadioTransportTest {
 
         val transport =
             object : RadioTransport {
-                override fun handleSendToRadio(p: ByteArray) {
+                override fun handleSendToRadio(p: ByteArray): Boolean {
                     sentData = p
+                    return true
                 }
 
                 override fun keepAlive() {
@@ -44,10 +45,11 @@ class RadioTransportTest {
             }
 
         val testData = byteArrayOf(1, 2, 3)
-        transport.handleSendToRadio(testData)
+        val accepted = transport.handleSendToRadio(testData)
         transport.keepAlive()
         transport.close()
 
+        assertTrue(accepted)
         assertTrue(sentData!!.contentEquals(testData))
         assertTrue(keepAliveCalled)
         assertTrue(closed)

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
@@ -18,15 +18,22 @@ package org.meshtastic.core.service
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowSeconds
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
+import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.proto.AdminMessage
@@ -36,6 +43,7 @@ import org.meshtastic.proto.HamParameters
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.OTAMode
 import org.meshtastic.proto.User
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [AdminController] implementation: local/remote configuration, channels, owner, device lifecycle, and the
@@ -51,6 +59,7 @@ internal class AdminControllerImpl(
     private val commandSender: CommandSender,
     private val nodeManager: NodeManager,
     private val radioConfigRepository: RadioConfigRepository,
+    private val connectionStateProvider: ConnectionStateProvider,
     private val scope: CoroutineScope,
 ) : AdminController {
 
@@ -219,9 +228,18 @@ internal class AdminControllerImpl(
     // ── Edit Settings (transactional) ───────────────────────────────────────
 
     override suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit) {
-        commandSender.sendAdmin(destNum) { AdminMessage(begin_edit_settings = true) }
-        EditSettingsSession(destNum).block()
-        commandSender.sendAdmin(destNum) { AdminMessage(commit_edit_settings = true) }
+        requireEditBoundaryAccepted(destNum, "begin") { AdminMessage(begin_edit_settings = true) }
+
+        // Firmware has no abort boundary. Preserve any block failure, including cancellation, only long enough to
+        // attempt the commit that closes the accepted session; the original failure is restored below.
+        val blockResult = runCatching { EditSettingsSession(destNum).block() }
+        val commitResult = runCatching { withContext(NonCancellable) { requireCommitBoundaryAccepted(destNum) } }
+
+        blockResult.exceptionOrNull()?.let { blockFailure ->
+            commitResult.exceptionOrNull()?.takeUnless { it === blockFailure }?.let(blockFailure::addSuppressed)
+            throw blockFailure
+        }
+        commitResult.getOrThrow()
     }
 
     override suspend fun editLocalSettings(block: suspend AdminEditScope.() -> Unit) = editSettings(myNodeNum, block)
@@ -235,10 +253,9 @@ internal class AdminControllerImpl(
         override suspend fun setModuleConfig(config: ModuleConfig) =
             setModuleConfig(destNum, config, commandSender.generatePacketId())
 
-        // Unlike the one-shot setRemoteChannel, a transactional channel write does NOT mirror to the local cache per
-        // slot: importChannelSet owns the cache and writes it once after commit (replaceAllSettings), so an import
-        // interrupted before commit leaves the local channel cache untouched. (Firmware still writes each set_channel
-        // into its in-memory channel table on arrival; only disk persist/reload/reboot is deferred to commit.)
+        // Unlike one-shot writes, a transaction can replace several slots. This scope cannot infer the complete target
+        // set, so the operation adding channel writes must reconcile that set after the transaction; mirroring slots
+        // here could expose a partial cache if a later write or commit fails.
         override suspend fun setChannel(channel: Channel) =
             commandSender.sendAdmin(destNum) { AdminMessage(set_channel = channel) }
 
@@ -246,7 +263,45 @@ internal class AdminControllerImpl(
             this@AdminControllerImpl.setFixedPosition(destNum, position)
     }
 
+    /**
+     * Applies back-pressure at transaction boundaries. Ordinary writes are already queued FIFO by [CommandSender], so
+     * waiting for the commit's queue acceptance keeps the caller suspended until the sender has processed every
+     * preceding write. This prevents a rebooting transport write from overtaking an uncommitted settings transaction.
+     */
+    private suspend fun requireEditBoundaryAccepted(destNum: Int, boundary: String, message: () -> AdminMessage) {
+        check(commandSender.sendAdminAwait(destNum, initFn = message)) {
+            "Device rejected or timed out while sending edit-settings $boundary"
+        }
+    }
+
+    private suspend fun requireCommitBoundaryAccepted(destNum: Int) {
+        val isLocalDestination = destNum == nodeManager.myNodeNum.value
+        val departureBaseline = connectionStateProvider.connectionLifecycle.value.epochs.departures
+        val result = commandSender.sendAdminAwaitResult(destNum) { AdminMessage(commit_edit_settings = true) }
+        val stoppedAfterDispatch =
+            isLocalDestination && result.dispatched && result.status == AwaitedSendStatus.TRANSPORT_STOPPED
+        val departedLifecycle =
+            if (stoppedAfterDispatch) {
+                withTimeoutOrNull(COMMIT_DEPARTURE_TIMEOUT) {
+                    connectionStateProvider.connectionLifecycle.first { it.epochs.departures > departureBaseline }
+                }
+            } else {
+                null
+            }
+        val committedBeforeLocalDeparture =
+            stoppedAfterDispatch && departedLifecycle?.epochs?.lastDepartureState is ConnectionState.Disconnected
+
+        check(result.accepted || committedBeforeLocalDeparture) {
+            "Device rejected or timed out while sending edit-settings commit " +
+                "(status=${result.status}, dispatched=${result.dispatched})"
+        }
+        if (committedBeforeLocalDeparture) {
+            Logger.i { "Edit-settings commit dispatched before expected local transport departure" }
+        }
+    }
+
     private companion object {
         private const val DEFAULT_DELAY_SECONDS = 5
+        private val COMMIT_DEPARTURE_TIMEOUT = 2.seconds
     }
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
@@ -44,6 +44,16 @@ import org.meshtastic.proto.OTAMode
 import org.meshtastic.proto.User
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Additional window for observing local transport departure after a dispatched commit loses its response. The
+ * surrounding NonCancellable finalization can take longer because [CommandSender.sendAdminAwaitResult] first waits
+ * behind older FIFO entries and then owns its radio-response window.
+ */
+internal val COMMIT_DEPARTURE_TIMEOUT = 5.seconds
+
+internal fun editSettingsBoundaryFailureMessage(boundary: String): String =
+    "Device rejected or timed out while sending edit-settings $boundary"
+
 internal fun editSettingsCommitFailureMessage(status: AwaitedSendStatus, dispatched: Boolean): String =
     "Device rejected or timed out while sending edit-settings commit (status=$status, dispatched=$dispatched)"
 
@@ -265,17 +275,16 @@ internal class AdminControllerImpl(
             this@AdminControllerImpl.setFixedPosition(destNum, position)
     }
 
-    /**
-     * Applies back-pressure at transaction boundaries. Ordinary writes are already queued FIFO by [CommandSender], so
-     * waiting for the commit's queue acceptance keeps the caller suspended until the sender has processed every
-     * preceding write. This prevents a rebooting transport write from overtaking an uncommitted settings transaction.
-     */
+    /** Requires the begin boundary to be admitted before any transactional settings writes are issued. */
     private suspend fun requireEditBoundaryAccepted(destNum: Int, boundary: String, message: () -> AdminMessage) {
-        check(commandSender.sendAdminAwait(destNum, initFn = message)) {
-            "Device rejected or timed out while sending edit-settings $boundary"
-        }
+        check(commandSender.sendAdminAwait(destNum, initFn = message)) { editSettingsBoundaryFailureMessage(boundary) }
     }
 
+    /**
+     * Applies commit back-pressure. Ordinary writes are already queued FIFO by [CommandSender], so waiting for the
+     * commit's queue acceptance keeps the caller suspended until the sender has processed every preceding write. This
+     * prevents a rebooting transport write from overtaking an uncommitted settings transaction.
+     */
     private suspend fun requireCommitBoundaryAccepted(destNum: Int) {
         val isLocalDestination = destNum == nodeManager.myNodeNum.value
         val departureBaseline = connectionStateProvider.connectionLifecycle.value.epochs.departures
@@ -292,8 +301,7 @@ internal class AdminControllerImpl(
             }
         // A dispatched local commit is durable once any post-baseline departure is observed. Firmware may move the
         // connection through Disconnected, Connecting, or DeviceSleep while rebooting.
-        val committedBeforeLocalDeparture =
-            stoppedAfterDispatch && departedLifecycle?.epochs?.lastDepartureState != null
+        val committedBeforeLocalDeparture = stoppedAfterDispatch && departedLifecycle != null
 
         check(result.accepted || committedBeforeLocalDeparture) {
             editSettingsCommitFailureMessage(result.status, result.dispatched)
@@ -305,6 +313,5 @@ internal class AdminControllerImpl(
 
     private companion object {
         private const val DEFAULT_DELAY_SECONDS = 5
-        private val COMMIT_DEPARTURE_TIMEOUT = 5.seconds
     }
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
@@ -27,7 +27,6 @@ import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowSeconds
-import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.AdminEditScope
@@ -44,6 +43,9 @@ import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.OTAMode
 import org.meshtastic.proto.User
 import kotlin.time.Duration.Companion.seconds
+
+internal fun editSettingsCommitFailureMessage(status: AwaitedSendStatus, dispatched: Boolean): String =
+    "Device rejected or timed out while sending edit-settings commit (status=$status, dispatched=$dispatched)"
 
 /**
  * [AdminController] implementation: local/remote configuration, channels, owner, device lifecycle, and the
@@ -288,12 +290,13 @@ internal class AdminControllerImpl(
             } else {
                 null
             }
+        // A dispatched local commit is durable once any post-baseline departure is observed. Firmware may move the
+        // connection through Disconnected, Connecting, or DeviceSleep while rebooting.
         val committedBeforeLocalDeparture =
-            stoppedAfterDispatch && departedLifecycle?.epochs?.lastDepartureState is ConnectionState.Disconnected
+            stoppedAfterDispatch && departedLifecycle?.epochs?.lastDepartureState != null
 
         check(result.accepted || committedBeforeLocalDeparture) {
-            "Device rejected or timed out while sending edit-settings commit " +
-                "(status=${result.status}, dispatched=${result.dispatched})"
+            editSettingsCommitFailureMessage(result.status, result.dispatched)
         }
         if (committedBeforeLocalDeparture) {
             Logger.i { "Edit-settings commit dispatched before expected local transport departure" }
@@ -302,6 +305,6 @@ internal class AdminControllerImpl(
 
     private companion object {
         private const val DEFAULT_DELAY_SECONDS = 5
-        private val COMMIT_DEPARTURE_TIMEOUT = 2.seconds
+        private val COMMIT_DEPARTURE_TIMEOUT = 5.seconds
     }
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
@@ -93,7 +93,7 @@ internal class MessagingControllerImpl(
                 rssi = null,
                 hopsAway = 0,
                 packetId = dataPacket.id,
-                status = MessageStatus.QUEUED,
+                status = dataPacket.status ?: MessageStatus.ERROR,
                 to = destId,
                 channel = channel,
             ),

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
@@ -93,7 +93,7 @@ internal class MessagingControllerImpl(
                 rssi = null,
                 hopsAway = 0,
                 packetId = dataPacket.id,
-                status = dataPacket.status ?: MessageStatus.ERROR,
+                status = dataPacket.status ?: MessageStatus.QUEUED,
                 to = destId,
                 channel = channel,
             ),

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.common.database.DatabaseManager
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionLifecycle
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.CommandSender
@@ -95,7 +97,13 @@ class RadioControllerImpl(
     scope: CoroutineScope,
     private val onDeviceAddressChanged: (() -> Unit)? = null,
 ) : RadioController,
-    AdminController by AdminControllerImpl(commandSender, nodeManager, radioConfigRepository, scope),
+    AdminController by AdminControllerImpl(
+        commandSender = commandSender,
+        nodeManager = nodeManager,
+        radioConfigRepository = radioConfigRepository,
+        connectionStateProvider = serviceRepository,
+        scope = scope,
+    ),
     MessagingController by MessagingControllerImpl(
         commandSender,
         nodeManager,
@@ -195,8 +203,14 @@ class RadioControllerImpl(
 
     // ── Connection State ────────────────────────────────────────────────────
 
+    override val connectionLifecycle: StateFlow<ConnectionLifecycle>
+        get() = serviceRepository.connectionLifecycle
+
     override val connectionState: StateFlow<ConnectionState>
         get() = serviceRepository.connectionState
+
+    override val connectionEpochs: StateFlow<ConnectionEpochs>
+        get() = serviceRepository.connectionEpochs
 
     override val clientNotification: StateFlow<ClientNotification?>
         get() = serviceRepository.clientNotification

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/ServiceRepositoryImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/ServiceRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.service.LockdownTokenInfo
 import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.MeshPacket
@@ -42,13 +43,13 @@ import org.meshtastic.proto.MeshPacket
 open class ServiceRepositoryImpl : ServiceRepository {
 
     // Canonical app-level connection state — written exclusively by MeshConnectionManager.
-    private val _connectionState: MutableStateFlow<ConnectionState> = MutableStateFlow(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState>
-        get() = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionLifecycle = connectionStateHolder.connectionLifecycle
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
-    override fun setConnectionState(connectionState: ConnectionState) {
-        _connectionState.value = connectionState
-    }
+    override fun setConnectionState(connectionState: ConnectionState) =
+        connectionStateHolder.setConnectionState(connectionState)
 
     private val _clientNotification = MutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?>

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -60,9 +60,9 @@ import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.ble.BluetoothRepository
 import org.meshtastic.core.common.di.PROCESS_LIFECYCLE
-import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.ignoreExceptionSuspend
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
@@ -212,7 +212,7 @@ class SharedRadioInterfaceService(
     /** Guarded by [sessionCallbackLock]. New work is rejected immediately when teardown closes this gate. */
     private var sessionAdmissionOpen = false
 
-    /** Number of suspend operations admitted for [activeTransportSession], guarded by [sessionCallbackLock]. */
+    /** Number of operations admitted for [activeTransportSession], guarded by [sessionCallbackLock]. */
     private var admittedSessionOperations = 0
 
     /** Completed by the last admitted operation after teardown closes admission. Guarded by [sessionCallbackLock]. */
@@ -258,20 +258,7 @@ class SharedRadioInterfaceService(
             block(lease)
             return true
         } finally {
-            val drainWaiter =
-                synchronized(sessionCallbackLock) {
-                    check(activeTransportSession === admittedSession) {
-                        "Session changed before an admitted operation released its lease"
-                    }
-                    check(admittedSessionOperations > 0) { "Session operation count underflow" }
-                    admittedSessionOperations--
-                    if (admittedSessionOperations == 0) {
-                        sessionDrainWaiter.also { sessionDrainWaiter = null }
-                    } else {
-                        null
-                    }
-                }
-            drainWaiter?.complete(Unit)
+            releaseSessionOperation(admittedSession)
         }
     }
 
@@ -293,6 +280,35 @@ class SharedRadioInterfaceService(
                 }
             }
         }
+
+    private fun releaseSessionOperation(admittedSession: RadioTransportSession) {
+        val drainWaiter =
+            synchronized(sessionCallbackLock) {
+                check(activeTransportSession === admittedSession) {
+                    "Session changed before an admitted operation released its lease"
+                }
+                check(admittedSessionOperations > 0) { "Session operation count underflow" }
+                admittedSessionOperations--
+                if (admittedSessionOperations == 0) {
+                    sessionDrainWaiter.also { sessionDrainWaiter = null }
+                } else {
+                    null
+                }
+            }
+        drainWaiter?.complete(Unit)
+    }
+
+    private data class AdmittedTransportSend(val session: RadioTransportSession, val transport: RadioTransport)
+
+    /** Admits one synchronous transport handoff under the same gate drained by [revokeTransportSession]. */
+    private fun admitTransportSend(): AdmittedTransportSend? = synchronized(sessionCallbackLock) admission@{
+        if (!sessionAdmissionOpen || isStopping) return@admission null
+        val session = activeTransportSession ?: return@admission null
+        val transport = radioTransport ?: return@admission null
+
+        admittedSessionOperations++
+        AdmittedTransportSend(session = session, transport = transport)
+    }
 
     /** Runs a callback only while [session] still owns admission, atomically with session teardown. */
     private inline fun runIfTransportSessionActive(session: RadioTransportSession, block: () -> Unit): Boolean =
@@ -372,12 +388,13 @@ class SharedRadioInterfaceService(
         get() = _serviceScope
 
     private var _serviceScope = CoroutineScope(dispatchers.io + SupervisorJob())
-    private var radioTransport: RadioTransport? = null
+
+    @Volatile private var radioTransport: RadioTransport? = null
     private var runningTransportId: InterfaceId? = null
     private var isStarted = false
 
     /**
-     * Set while [stopTransportLocked] is draining the polite disconnect frame. [sendToRadio] checks this so any late
+     * Set while [stopTransportLocked] is draining the polite disconnect frame. [trySendToRadio] checks this so any late
      * traffic submitted after we've announced disconnection is dropped rather than racing in front of the firmware-side
      * link teardown.
      */
@@ -828,7 +845,27 @@ class SharedRadioInterfaceService(
                 _connectionState.value = connectionStateBeforeStart
                 throw failure
             }
-        radioTransport = newTransport
+        val published =
+            synchronized(sessionCallbackLock) {
+                if (activeTransportSession !== session || !sessionAdmissionOpen) {
+                    false
+                } else {
+                    radioTransport = newTransport
+                    true
+                }
+            }
+        if (!published) {
+            // Revocation already closed this session's admission and owns the canonical lifecycle rollback. Do not
+            // restore connectionStateBeforeStart here; that would overwrite the newer teardown state.
+            val publicationFailure =
+                IllegalStateException("Transport session was revoked before its transport could be published")
+            try {
+                withContext(NonCancellable) { newTransport.close() }
+            } catch (closeFailure: Exception) {
+                publicationFailure.addSuppressed(closeFailure)
+            }
+            throw publicationFailure
+        }
         runningTransportId = address.firstOrNull()?.let { InterfaceId.forIdChar(it) }
         isStarted = true
         startHeartbeat()
@@ -988,25 +1025,24 @@ class SharedRadioInterfaceService(
         }
     }
 
-    override fun sendToRadio(bytes: ByteArray) {
-        if (isStopping) {
-            Logger.d { "sendToRadio: transport stopping, dropping ${bytes.size} bytes" }
-            return
-        }
-        // Snapshot the transport to avoid calling handleSendToRadio on a null reference.
-        // There is still a benign race: stopTransportLocked() may cancel _serviceScope
-        // between the null-check and the launch, causing the coroutine to be silently
-        // dropped. This is acceptable — if the transport is shutting down, dropping the
-        // send is the correct behavior.
-        val currentTransport =
-            radioTransport
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
+        // Admission and teardown share one session gate. Once accepted, teardown drains the synchronous handoff before
+        // revoking the session; transport implementations still own their asynchronous delivery outcome.
+        val admitted =
+            admitTransportSend()
                 ?: run {
-                    Logger.w { "sendToRadio: no active radio transport, dropping ${bytes.size} bytes" }
-                    return
+                    Logger.w { "sendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
+                    return false
                 }
-        _serviceScope.handledLaunch {
-            currentTransport.handleSendToRadio(bytes)
-            _meshActivity.tryEmit(MeshActivity.Send)
+        return try {
+            safeCatching {
+                admitted.transport.handleSendToRadio(bytes)
+                _meshActivity.tryEmit(MeshActivity.Send)
+            }
+                .onFailure { Logger.w(it) { "sendToRadio: active transport rejected ${bytes.size} bytes" } }
+                .isSuccess
+        } finally {
+            releaseSessionOperation(admitted.session)
         }
     }
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -1074,7 +1074,7 @@ class SharedRadioInterfaceService(
 
     private fun keepAliveThroughAdmittedTransport(admission: TransportSendAdmission.Admitted): Boolean = try {
         safeCatching { admission.transport.keepAlive() }
-            .onFailure { Logger.w { "keepAlive: active transport rejected heartbeat" } }
+            .onFailure { Logger.w(it) { "keepAlive: active transport rejected heartbeat" } }
             .isSuccess
     } finally {
         releaseSessionOperation(admission.session)

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -158,7 +158,7 @@ private fun TransportDisconnectReason.toConnectionErrorMessage(): String = when 
  * hardware state observability (BLE/Network toggles). Delegates the actual raw byte transport mapping to a
  * platform-specific [RadioTransportFactory].
  */
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LargeClass", "LongParameterList", "TooManyFunctions")
 @Single
 class SharedRadioInterfaceService(
     private val dispatchers: CoroutineDispatchers,
@@ -284,30 +284,64 @@ class SharedRadioInterfaceService(
     private fun releaseSessionOperation(admittedSession: RadioTransportSession) {
         val drainWaiter =
             synchronized(sessionCallbackLock) {
-                check(activeTransportSession === admittedSession) {
-                    "Session changed before an admitted operation released its lease"
-                }
-                check(admittedSessionOperations > 0) { "Session operation count underflow" }
-                admittedSessionOperations--
-                if (admittedSessionOperations == 0) {
-                    sessionDrainWaiter.also { sessionDrainWaiter = null }
-                } else {
-                    null
+                when {
+                    activeTransportSession !== admittedSession -> {
+                        Logger.e { "Session changed before an admitted operation released its lease" }
+                        null
+                    }
+
+                    admittedSessionOperations <= 0 -> {
+                        Logger.e { "Session operation count underflow" }
+                        null
+                    }
+
+                    else -> {
+                        admittedSessionOperations--
+                        if (admittedSessionOperations == 0) {
+                            sessionDrainWaiter.also { sessionDrainWaiter = null }
+                        } else {
+                            null
+                        }
+                    }
                 }
             }
         drainWaiter?.complete(Unit)
     }
 
-    private data class AdmittedTransportSend(val session: RadioTransportSession, val transport: RadioTransport)
+    private sealed interface TransportSendAdmission {
+        data class Admitted(val session: RadioTransportSession, val transport: RadioTransport) : TransportSendAdmission
 
-    /** Admits one synchronous transport handoff under the same gate drained by [revokeTransportSession]. */
-    private fun admitTransportSend(): AdmittedTransportSend? = synchronized(sessionCallbackLock) admission@{
-        if (!sessionAdmissionOpen || isStopping) return@admission null
-        val session = activeTransportSession ?: return@admission null
-        val transport = radioTransport ?: return@admission null
+        data object AdmissionClosed : TransportSendAdmission
 
-        admittedSessionOperations++
-        AdmittedTransportSend(session = session, transport = transport)
+        data object Stopping : TransportSendAdmission
+
+        data object NoActiveSession : TransportSendAdmission
+
+        data object NoTransport : TransportSendAdmission
+    }
+
+    /**
+     * Admits one synchronous transport handoff under the same gate drained by [revokeTransportSession]. [Stopping]
+     * covers only a pre-revocation stopping window; once teardown revokes admission, [AdmissionClosed] is
+     * authoritative.
+     */
+    private fun admitTransportSend(): TransportSendAdmission = synchronized(sessionCallbackLock) {
+        val session = activeTransportSession
+        val transport = radioTransport
+        when {
+            isStopping -> TransportSendAdmission.Stopping
+
+            !sessionAdmissionOpen -> TransportSendAdmission.AdmissionClosed
+
+            session == null -> TransportSendAdmission.NoActiveSession
+
+            transport == null -> TransportSendAdmission.NoTransport
+
+            else -> {
+                admittedSessionOperations++
+                TransportSendAdmission.Admitted(session = session, transport = transport)
+            }
+        }
     }
 
     /** Runs a callback only while [session] still owns admission, atomically with session teardown. */
@@ -1019,32 +1053,71 @@ class SharedRadioInterfaceService(
     }
 
     fun keepAlive(now: Long = now()) {
-        if (now - lastHeartbeatMillis > HEARTBEAT_INTERVAL_MILLIS) {
-            radioTransport?.keepAlive()
-            lastHeartbeatMillis = now
+        if (now - lastHeartbeatMillis <= HEARTBEAT_INTERVAL_MILLIS) return
+
+        when (val admission = admitTransportSend()) {
+            is TransportSendAdmission.Admitted -> {
+                if (keepAliveThroughAdmittedTransport(admission)) lastHeartbeatMillis = now
+            }
+
+            TransportSendAdmission.Stopping -> Logger.d { "keepAlive: transport stopping, dropping heartbeat" }
+
+            TransportSendAdmission.AdmissionClosed,
+            TransportSendAdmission.NoActiveSession,
+            ->
+                Logger.d { "keepAlive: no admitted transport session, dropping heartbeat" }
+
+            TransportSendAdmission.NoTransport ->
+                Logger.w { "keepAlive: admitted session has no radio transport, dropping heartbeat" }
         }
     }
 
-    override fun trySendToRadio(bytes: ByteArray): Boolean {
+    private fun keepAliveThroughAdmittedTransport(admission: TransportSendAdmission.Admitted): Boolean = try {
+        safeCatching { admission.transport.keepAlive() }
+            .onFailure { Logger.w { "keepAlive: active transport rejected heartbeat" } }
+            .isSuccess
+    } finally {
+        releaseSessionOperation(admission.session)
+    }
+
+    override fun trySendToRadio(bytes: ByteArray): Boolean =
         // Admission and teardown share one session gate. Once accepted, teardown drains the synchronous handoff before
         // revoking the session; transport implementations still own their asynchronous delivery outcome.
-        val admitted =
-            admitTransportSend()
-                ?: run {
-                    Logger.w { "trySendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
-                    return false
-                }
-        return try {
-            safeCatching {
-                admitted.transport.handleSendToRadio(bytes)
-                _meshActivity.tryEmit(MeshActivity.Send)
+        when (val admission = admitTransportSend()) {
+            is TransportSendAdmission.Admitted -> sendThroughAdmittedTransport(admission, bytes)
+
+            TransportSendAdmission.Stopping -> {
+                Logger.d { "trySendToRadio: transport stopping, dropping ${bytes.size} bytes" }
+                false
             }
-                .onFailure { Logger.w(it) { "trySendToRadio: active transport rejected ${bytes.size} bytes" } }
-                .isSuccess
-        } finally {
-            releaseSessionOperation(admitted.session)
+
+            TransportSendAdmission.AdmissionClosed,
+            TransportSendAdmission.NoActiveSession,
+            -> {
+                Logger.d { "trySendToRadio: no admitted transport session, dropping ${bytes.size} bytes" }
+                false
+            }
+
+            TransportSendAdmission.NoTransport -> {
+                Logger.w { "trySendToRadio: admitted session has no radio transport, dropping ${bytes.size} bytes" }
+                false
+            }
         }
-    }
+
+    private fun sendThroughAdmittedTransport(admission: TransportSendAdmission.Admitted, bytes: ByteArray): Boolean =
+        try {
+            val sent =
+                safeCatching { admission.transport.handleSendToRadio(bytes) }
+                    .onFailure { Logger.w(it) { "trySendToRadio: active transport rejected ${bytes.size} bytes" } }
+                    .getOrDefault(false)
+            if (sent) {
+                safeCatching { _meshActivity.tryEmit(MeshActivity.Send) }
+                    .onFailure { Logger.w(it) { "trySendToRadio: failed to publish mesh activity" } }
+            }
+            sent
+        } finally {
+            releaseSessionOperation(admission.session)
+        }
 
     @Suppress("TooGenericExceptionCaught")
     override fun handleFromRadio(bytes: ByteArray) {

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -1031,7 +1031,7 @@ class SharedRadioInterfaceService(
         val admitted =
             admitTransportSend()
                 ?: run {
-                    Logger.w { "sendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
+                    Logger.w { "trySendToRadio: no admitted radio transport, dropping ${bytes.size} bytes" }
                     return false
                 }
         return try {
@@ -1039,7 +1039,7 @@ class SharedRadioInterfaceService(
                 admitted.transport.handleSendToRadio(bytes)
                 _meshActivity.tryEmit(MeshActivity.Send)
             }
-                .onFailure { Logger.w(it) { "sendToRadio: active transport rejected ${bytes.size} bytes" } }
+                .onFailure { Logger.w(it) { "trySendToRadio: active transport rejected ${bytes.size} bytes" } }
                 .isSuccess
         } finally {
             releaseSessionOperation(admitted.session)

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -653,14 +653,14 @@ class RadioControllerImplTest {
         val node = Node(num = 1234, user = user)
         every { nodeManager.nodeDBbyNodeNum } returns mapOf(1234 to node)
         every { nodeManager.getMyId() } returns "!abcd1234"
-        // Production CommandSenderImpl.sendData stamps QUEUED on successful queue admission. DataPacket.status
-        // defaults to UNKNOWN (not null), so the controller's `dataPacket.status ?: QUEUED` fallback never fires
-        // in practice — the happy-path reaction inherits QUEUED from the stamp. Mirror the stamp here so the
-        // persistence assertion exercises the realistic contract; the explicit ERROR-stamping path is covered by
-        // sendReactionPersistsStatusStampedByCommandSender.
-        everySuspend { commandSender.sendData(any()) } calls {
-            (it.args[0] as DataPacket).status = MessageStatus.QUEUED
-        }
+        // Production CommandSenderImpl.sendData stamps QUEUED on successful queue admission. DataPacket.status is
+        // nullable but defaults to UNKNOWN, so the default value does not exercise the controller's null fallback.
+        // Mirror the production stamp here so this assertion exercises the realistic happy-path contract; the explicit
+        // ERROR-stamping path is covered by sendReactionPersistsStatusStampedByCommandSender.
+        everySuspend { commandSender.sendData(any()) } calls
+            {
+                (it.args[0] as DataPacket).status = MessageStatus.QUEUED
+            }
 
         val reactions = mutableListOf<Reaction>()
         everySuspend { packetRepository.insertReaction(capture(reactions), any()) } returns Unit

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -31,6 +31,7 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -187,9 +188,6 @@ class RadioControllerImplTest {
             }
         return CommitBoundaryFixture(controller, serviceRepository)
     }
-
-    private fun commitFailureMessage(status: AwaitedSendStatus, dispatched: Boolean): String =
-        "Device rejected or timed out while sending edit-settings commit (status=$status, dispatched=$dispatched)"
 
     @Test
     fun staleAddressIdentityCannotAssociateSelectedTransport() = runTest {
@@ -848,7 +846,7 @@ class RadioControllerImplTest {
         val controller = createController(scope = backgroundScope, myNodeNum = 1234)
         everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
         everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
-            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+            AwaitedSendResult(AwaitedSendStatus.RADIO_REJECTED, dispatched = true)
 
         val failure =
             assertFailsWith<IllegalStateException> {
@@ -860,7 +858,7 @@ class RadioControllerImplTest {
             }
 
         assertEquals(
-            "Device rejected or timed out while sending edit-settings commit (status=REJECTED, dispatched=true)",
+            editSettingsCommitFailureMessage(AwaitedSendStatus.RADIO_REJECTED, dispatched = true),
             failure.message,
         )
         verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
@@ -895,17 +893,14 @@ class RadioControllerImplTest {
         val controller = createController(scope = backgroundScope, myNodeNum = 1234)
         everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
         everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
-            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+            AwaitedSendResult(AwaitedSendStatus.RADIO_REJECTED, dispatched = true)
         val blockFailure = IllegalArgumentException("settings write failed")
 
         val failure = assertFailsWith<IllegalArgumentException> { controller.editLocalSettings { throw blockFailure } }
 
         assertSame(blockFailure, failure)
         assertEquals(
-            listOf(
-                "Device rejected or timed out while sending edit-settings commit " +
-                    "(status=REJECTED, dispatched=true)",
-            ),
+            listOf(editSettingsCommitFailureMessage(AwaitedSendStatus.RADIO_REJECTED, dispatched = true)),
             failure.suppressedExceptions.map(Throwable::message),
         )
         verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
@@ -927,14 +922,17 @@ class RadioControllerImplTest {
 
     @Test
     fun editSettingsWaitsForCanonicalDepartureAfterTransportStops() = runTest {
+        var stateAtCommitReturn: ConnectionState? = null
         val (controller, serviceRepository) =
             createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
                 backgroundScope.launch { serviceRepository.setConnectionState(ConnectionState.Disconnected) }
+                stateAtCommitReturn = serviceRepository.connectionState.value
                 AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
             }
 
         controller.editLocalSettings {}
 
+        assertEquals(ConnectionState.Connected, stateAtCommitReturn)
         verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
         assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
     }
@@ -965,7 +963,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false),
+            failure.message,
+        )
     }
 
     @Test
@@ -977,7 +978,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true),
+            failure.message,
+        )
     }
 
     @Test
@@ -990,20 +994,56 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TIMED_OUT, dispatched = true), failure.message)
+        assertEquals(editSettingsCommitFailureMessage(AwaitedSendStatus.TIMED_OUT, dispatched = true), failure.message)
     }
 
     @Test
-    fun editSettingsRejectsDeviceSleepAsCommitAcceptance() = runTest {
+    fun editSettingsAcceptsDeviceSleepAsPostDispatchDeparture() = runTest {
+        var departuresAtCommit = 0L
+        var departuresAfterSleep = 0L
         val (controller, _) =
             createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                departuresAtCommit = serviceRepository.connectionLifecycle.value.epochs.departures
                 serviceRepository.setConnectionState(ConnectionState.DeviceSleep)
+                departuresAfterSleep = serviceRepository.connectionLifecycle.value.epochs.departures
                 AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
             }
 
-        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+        controller.editLocalSettings {}
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertTrue(
+            departuresAfterSleep > departuresAtCommit,
+            "DeviceSleep must publish a departure before the commit result is evaluated",
+        )
+    }
+
+    @Test
+    fun editSettingsAcceptsConnectingAsPostDispatchDeparture() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { repository ->
+                repository.setConnectionState(ConnectionState.Connecting)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        assertEquals(ConnectionState.Connecting, serviceRepository.connectionState.value)
+    }
+
+    @Test
+    fun editSettingsAcceptsDepartureThatArrivesAfterTwoSeconds() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { repository ->
+                backgroundScope.launch {
+                    delay(3_000)
+                    repository.setConnectionState(ConnectionState.Disconnected)
+                }
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
     }
 
     @Test
@@ -1016,7 +1056,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 5678) {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true),
+            failure.message,
+        )
     }
 
     @Test
@@ -1029,7 +1072,10 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 0) {} }
 
-        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+        assertEquals(
+            editSettingsCommitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true),
+            failure.message,
+        )
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -653,16 +653,21 @@ class RadioControllerImplTest {
         val node = Node(num = 1234, user = user)
         every { nodeManager.nodeDBbyNodeNum } returns mapOf(1234 to node)
         every { nodeManager.getMyId() } returns "!abcd1234"
-        // This class reuses its mocks; isolate the fallback-status case from status-stamping tests.
-        everySuspend { commandSender.sendData(any()) } returns Unit
+        // Production CommandSenderImpl.sendData stamps QUEUED on successful queue admission. DataPacket.status
+        // defaults to UNKNOWN (not null), so the controller's `dataPacket.status ?: QUEUED` fallback never fires
+        // in practice — the happy-path reaction inherits QUEUED from the stamp. Mirror the stamp here so the
+        // persistence assertion exercises the realistic contract; the explicit ERROR-stamping path is covered by
+        // sendReactionPersistsStatusStampedByCommandSender.
+        everySuspend { commandSender.sendData(any()) } calls {
+            (it.args[0] as DataPacket).status = MessageStatus.QUEUED
+        }
 
         val reactions = mutableListOf<Reaction>()
         everySuspend { packetRepository.insertReaction(capture(reactions), any()) } returns Unit
 
         controller.sendReaction(emoji = "👍", replyId = 42, contactKey = "0!dest5678")
 
-        // Reaction must be persisted (not fire-and-forget). An accepted send is QUEUED even if a test double does not
-        // stamp the mutable DataPacket the way CommandSenderImpl does in production.
+        // Reaction must be persisted (not fire-and-forget) with the queue-admission QUEUED status.
         verifySuspend { commandSender.sendData(any()) }
         assertEquals(MessageStatus.QUEUED, reactions.single().status)
     }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -23,6 +23,7 @@ import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.capture.capture
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.atLeast
@@ -40,8 +41,11 @@ import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.common.database.DatabaseManager
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.model.Position
+import org.meshtastic.core.model.Reaction
 import org.meshtastic.core.repository.AwaitedSendResult
 import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
@@ -53,6 +57,7 @@ import org.meshtastic.core.repository.MeshPrefs
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.NotificationManager
+import org.meshtastic.core.repository.PacketQueueRejectedException
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -379,6 +384,44 @@ class RadioControllerImplTest {
     }
 
     @Test
+    fun sendMessageDoesNotPersistWhenQueueRejects() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 456)
+        val packet = DataPacket(to = NodeAddress.ID_BROADCAST, channel = 1, text = "ping")
+        val rejection = PacketQueueRejectedException("Data packet")
+        everySuspend { commandSender.sendData(packet) } throws rejection
+
+        val failure = assertFailsWith<PacketQueueRejectedException> { controller.sendMessage(packet) }
+
+        assertSame(rejection, failure)
+        verifySuspend(exactly(0)) { dataHandler.rememberDataPacket(any(), any(), any()) }
+    }
+
+    @Test
+    fun localChannelDoesNotPersistWhenQueueRejects() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 456)
+        val channel = Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "Primary"))
+        val rejection = PacketQueueRejectedException("Admin command")
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } throws rejection
+
+        val failure = assertFailsWith<PacketQueueRejectedException> { controller.setLocalChannel(channel) }
+
+        assertSame(rejection, failure)
+        verifySuspend(exactly(0)) { radioConfigRepository.updateChannelSettings(any()) }
+    }
+
+    @Test
+    fun fixedPositionPropagatesQueueRejection() = runTest {
+        val controller = createController(scope = backgroundScope)
+        val position = Position(latitude = 1.0, longitude = 2.0, altitude = 3)
+        val rejection = PacketQueueRejectedException("Fixed position")
+        everySuspend { commandSender.setFixedPosition(123, position) } throws rejection
+
+        val failure = assertFailsWith<PacketQueueRejectedException> { controller.setFixedPosition(123, position) }
+
+        assertSame(rejection, failure)
+    }
+
+    @Test
     fun sendSharedContactCallsCommandSenderAdminAwait() = runTest {
         val controller = createController(scope = backgroundScope)
         val nodeNum = 321
@@ -610,12 +653,33 @@ class RadioControllerImplTest {
         val node = Node(num = 1234, user = user)
         every { nodeManager.nodeDBbyNodeNum } returns mapOf(1234 to node)
         every { nodeManager.getMyId() } returns "!abcd1234"
+        // This class reuses its mocks; isolate the fallback-status case from status-stamping tests.
+        everySuspend { commandSender.sendData(any()) } returns Unit
+
+        val reactions = mutableListOf<Reaction>()
+        everySuspend { packetRepository.insertReaction(capture(reactions), any()) } returns Unit
 
         controller.sendReaction(emoji = "👍", replyId = 42, contactKey = "0!dest5678")
 
-        // Reaction must be persisted (not fire-and-forget)
+        // Reaction must be persisted (not fire-and-forget). An accepted send is QUEUED even if a test double does not
+        // stamp the mutable DataPacket the way CommandSenderImpl does in production.
         verifySuspend { commandSender.sendData(any()) }
-        verifySuspend { packetRepository.insertReaction(any(), any()) }
+        assertEquals(MessageStatus.QUEUED, reactions.single().status)
+    }
+
+    @Test
+    fun sendReactionPersistsStatusStampedByCommandSender() = runTest {
+        val controller = createController(scope = backgroundScope)
+        val user = User(id = "!abcd1234", long_name = "Test", short_name = "T")
+        every { nodeManager.nodeDBbyNodeNum } returns mapOf(1234 to Node(num = 1234, user = user))
+        every { nodeManager.getMyId() } returns "!abcd1234"
+        everySuspend { commandSender.sendData(any()) } calls { (it.args[0] as DataPacket).status = MessageStatus.ERROR }
+        val reactions = mutableListOf<Reaction>()
+        everySuspend { packetRepository.insertReaction(capture(reactions), any()) } returns Unit
+
+        controller.sendReaction(emoji = "👍", replyId = 42, contactKey = "0!dest5678")
+
+        assertEquals(MessageStatus.ERROR, reactions.single().status)
     }
 
     @Test
@@ -783,10 +847,9 @@ class RadioControllerImplTest {
         verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
         verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
         verifySuspend(exactly(2)) { commandSender.sendAdmin(any(), any(), any(), any()) }
-        // A transactional channel write must NOT eagerly mirror to the local cache the way one-shot
-        // setRemoteChannel does for the local node. importChannelSet owns the cache and writes it once after commit
-        // (replaceAllSettings), so an interrupted import can't leave partial channels cached. A regression to
-        // per-slot mirroring inside the session would make this call count non-zero.
+        // A transactional channel write must not eagerly mirror to the local cache like a one-shot setRemoteChannel.
+        // The batch operation knows the complete target set and must reconcile it after the transaction; per-slot
+        // mirroring here could expose a partial cache when a later write or commit fails.
         verifySuspend(exactly(0)) { radioConfigRepository.updateChannelSettings(any()) }
     }
 
@@ -834,7 +897,7 @@ class RadioControllerImplTest {
 
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { blockRan = true } }
 
-        assertEquals("Device rejected or timed out while sending edit-settings begin", failure.message)
+        assertEquals(editSettingsBoundaryFailureMessage("begin"), failure.message)
         assertFalse(blockRan)
         verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
         verifySuspend(exactly(0)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
@@ -1031,11 +1094,11 @@ class RadioControllerImplTest {
     }
 
     @Test
-    fun editSettingsAcceptsDepartureThatArrivesAfterTwoSeconds() = runTest {
+    fun editSettingsAcceptsDepartureThatArrivesWithinCommitDepartureTimeout() = runTest {
         val (controller, serviceRepository) =
             createCommitBoundaryFixture(backgroundScope) { repository ->
                 backgroundScope.launch {
-                    delay(3_000)
+                    delay(COMMIT_DEPARTURE_TIMEOUT.inWholeMilliseconds / 2)
                     repository.setConnectionState(ConnectionState.Disconnected)
                 }
                 AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
@@ -1044,6 +1107,7 @@ class RadioControllerImplTest {
         controller.editLocalSettings {}
 
         assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -41,6 +41,8 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.ConnectionIdentity
 import org.meshtastic.core.repository.MeshDataHandler
@@ -70,6 +72,7 @@ import org.meshtastic.proto.User
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -163,6 +166,30 @@ class RadioControllerImplTest {
             onDeviceAddressChanged = onDeviceAddressChanged,
         )
     }
+
+    private data class CommitBoundaryFixture(
+        val controller: RadioControllerImpl,
+        val serviceRepository: ServiceRepositoryImpl,
+    )
+
+    private fun createCommitBoundaryFixture(
+        scope: CoroutineScope,
+        myNodeNum: Int? = 1234,
+        commitResult: (ServiceRepositoryImpl) -> AwaitedSendResult,
+    ): CommitBoundaryFixture {
+        val serviceRepository = ServiceRepositoryImpl()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        val controller = createController(scope = scope, myNodeNum = myNodeNum, serviceRepository = serviceRepository)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                commitResult(serviceRepository)
+            }
+        return CommitBoundaryFixture(controller, serviceRepository)
+    }
+
+    private fun commitFailureMessage(status: AwaitedSendStatus, dispatched: Boolean): String =
+        "Device rejected or timed out while sending edit-settings commit (status=$status, dispatched=$dispatched)"
 
     @Test
     fun staleAddressIdentityCannotAssociateSelectedTransport() = runTest {
@@ -739,9 +766,13 @@ class RadioControllerImplTest {
         verifySuspend { commandSender.sendAdmin(any(), any(), any(), any()) }
     }
 
+    private fun acceptedSendResult() = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
+
     @Test
     fun editLocalSettingsChannelWritesDoNotMirrorToLocalCache() = runTest {
         val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
 
         controller.editLocalSettings {
             setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "A")))
@@ -749,14 +780,279 @@ class RadioControllerImplTest {
         }
         advanceUntilIdle()
 
-        // Exactly 4 admin packets: begin + 2 channel writes + commit. The tight count also catches a duplicated
-        // begin/commit or an accidental double-write per channel.
-        verifySuspend(exactly(4)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+        // Exactly four packets: awaited begin + 2 channel writes + awaited commit. The tight count also catches a
+        // duplicated boundary or an accidental double-write per channel.
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(2)) { commandSender.sendAdmin(any(), any(), any(), any()) }
         // A transactional channel write must NOT eagerly mirror to the local cache the way one-shot
         // setRemoteChannel does for the local node. importChannelSet owns the cache and writes it once after commit
         // (replaceAllSettings), so an interrupted import can't leave partial channels cached. A regression to
         // per-slot mirroring inside the session would make this call count non-zero.
         verifySuspend(exactly(0)) { radioConfigRepository.updateChannelSettings(any()) }
+    }
+
+    @Test
+    fun editSettingsAwaitsBoundariesAroundOrderedWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        val sentMessages = mutableListOf<AdminMessage>()
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+                true
+            }
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+                acceptedSendResult()
+            }
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessages += (it.args[3] as () -> AdminMessage)()
+            }
+
+        controller.editLocalSettings {
+            setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "Primary")))
+            setChannel(
+                Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "Secondary")),
+            )
+        }
+
+        assertEquals(4, sentMessages.size)
+        assertEquals(true, sentMessages[0].begin_edit_settings)
+        assertEquals(0, sentMessages[1].set_channel?.index)
+        assertEquals(1, sentMessages[2].set_channel?.index)
+        assertEquals(true, sentMessages[3].commit_edit_settings)
+    }
+
+    @Test
+    fun editSettingsRejectsFailedBeginBeforeRunningWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns false
+        var blockRan = false
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { blockRan = true } }
+
+        assertEquals("Device rejected or timed out while sending edit-settings begin", failure.message)
+        assertFalse(blockRan)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(0)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(0)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsReportsFailedCommitAfterOrderedWrites() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
+            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                controller.editLocalSettings {
+                    setChannel(
+                        Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "Primary")),
+                    )
+                }
+            }
+
+        assertEquals(
+            "Device rejected or timed out while sending edit-settings commit (status=REJECTED, dispatched=true)",
+            failure.message,
+        )
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsCommitsAfterWriteFailureAndRethrowsOriginal() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        val writeFailure = IllegalArgumentException("settings write failed")
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } throws writeFailure
+
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                controller.editLocalSettings {
+                    setChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = ChannelSettings(name = "A")))
+                }
+            }
+
+        assertSame(writeFailure, failure)
+        assertTrue(failure.suppressedExceptions.isEmpty())
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdmin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsSuppressesCommitFailureOnBlockFailure() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns
+            AwaitedSendResult(AwaitedSendStatus.REJECTED, dispatched = true)
+        val blockFailure = IllegalArgumentException("settings write failed")
+
+        val failure = assertFailsWith<IllegalArgumentException> { controller.editLocalSettings { throw blockFailure } }
+
+        assertSame(blockFailure, failure)
+        assertEquals(
+            listOf(
+                "Device rejected or timed out while sending edit-settings commit " +
+                    "(status=REJECTED, dispatched=true)",
+            ),
+            failure.suppressedExceptions.map(Throwable::message),
+        )
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsAcceptsDispatchedCommitWhenLocalTransportDeparts() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsWaitsForCanonicalDepartureAfterTransportStops() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                backgroundScope.launch { serviceRepository.setConnectionState(ConnectionState.Disconnected) }
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+        assertEquals(ConnectionState.Disconnected, serviceRepository.connectionState.value)
+    }
+
+    @Test
+    fun editSettingsAcceptsCapturedDisconnectAfterFastReconnect() = runTest {
+        val (controller, serviceRepository) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                serviceRepository.setConnectionState(ConnectionState.Connecting)
+                serviceRepository.setConnectionState(ConnectionState.Connected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        controller.editLocalSettings {}
+
+        assertEquals(ConnectionState.Connected, serviceRepository.connectionState.value)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun editSettingsRejectsTransportStopBeforeCommitTransmission() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = false), failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsTransportStopWithoutObservedDeparture() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) {
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsTimeoutEvenWhenLocalTransportDeparts() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TIMED_OUT, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TIMED_OUT, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsRejectsDeviceSleepAsCommitAcceptance() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.DeviceSleep)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsDoesNotTreatLocalDepartureAsRemoteCommitAcceptance() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 5678) {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsDoesNotTreatDestinationZeroAsLocalWhenNodeIdentityIsUnknown() = runTest {
+        val (controller, _) =
+            createCommitBoundaryFixture(backgroundScope, myNodeNum = null) { serviceRepository ->
+                serviceRepository.setConnectionState(ConnectionState.Disconnected)
+                AwaitedSendResult(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true)
+            }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editSettings(destNum = 0) {} }
+
+        assertEquals(commitFailureMessage(AwaitedSendStatus.TRANSPORT_STOPPED, dispatched = true), failure.message)
+    }
+
+    @Test
+    fun editSettingsCommitsWhenCallerIsCancelled() = runTest {
+        val controller = createController(scope = backgroundScope, myNodeNum = 1234)
+        everySuspend { commandSender.sendAdminAwait(any(), any(), any(), any()) } returns true
+        everySuspend { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) } returns acceptedSendResult()
+        val blockStarted = CompletableDeferred<Unit>()
+        val keepBlockOpen = CompletableDeferred<Unit>()
+
+        val job = launch {
+            controller.editLocalSettings {
+                blockStarted.complete(Unit)
+                keepBlockOpen.await()
+            }
+        }
+        blockStarted.await()
+        job.cancel(CancellationException("cancel settings transaction"))
+        job.join()
+
+        assertTrue(job.isCancelled)
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwait(any(), any(), any(), any()) }
+        verifySuspend(exactly(1)) { commandSender.sendAdminAwaitResult(any(), any(), any(), any()) }
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
+import org.meshtastic.core.model.ConnectionEpochs
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.TracerouteResponse
 import kotlin.test.Test
@@ -39,6 +40,7 @@ class ServiceRepositoryImplTest {
         val repository = ServiceRepositoryImpl()
 
         assertEquals(ConnectionState.Disconnected, repository.connectionState.value)
+        assertEquals(ConnectionEpochs(), repository.connectionEpochs.value)
         assertNull(repository.clientNotification.value)
         assertNull(repository.errorMessage.value)
         assertNull(repository.connectionProgress.value)
@@ -63,6 +65,33 @@ class ServiceRepositoryImplTest {
 
         assertEquals(ConnectionState.Connecting, emittedState.await())
         assertEquals(ConnectionState.Connecting, repository.connectionState.value)
+    }
+
+    @Test
+    fun connectionEpochsPreserveRapidDepartureAndHandshakeTransitions() = runTest {
+        val repository = ServiceRepositoryImpl()
+        repository.setConnectionState(ConnectionState.Connected)
+        val baseline = repository.connectionEpochs.value
+
+        repository.setConnectionState(ConnectionState.Disconnected)
+        repository.setConnectionState(ConnectionState.Connecting)
+        repository.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionState.Connected, repository.connectionState.value)
+        assertEquals(baseline.departures + 1, repository.connectionEpochs.value.departures)
+        assertEquals(baseline.completedHandshakes + 1, repository.connectionEpochs.value.completedHandshakes)
+    }
+
+    @Test
+    fun duplicateConnectionStatesDoNotAdvanceEpochs() = runTest {
+        val repository = ServiceRepositoryImpl()
+        repository.setConnectionState(ConnectionState.Connected)
+        val afterHandshake = repository.connectionEpochs.value
+
+        repository.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), afterHandshake)
+        assertEquals(afterHandshake, repository.connectionEpochs.value)
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/ServiceRepositoryImplTest.kt
@@ -80,6 +80,8 @@ class ServiceRepositoryImplTest {
         assertEquals(ConnectionState.Connected, repository.connectionState.value)
         assertEquals(baseline.departures + 1, repository.connectionEpochs.value.departures)
         assertEquals(baseline.completedHandshakes + 1, repository.connectionEpochs.value.completedHandshakes)
+        assertEquals(baseline.completedHandshakes, repository.connectionEpochs.value.handshakesAtLastDeparture)
+        assertEquals(ConnectionState.Disconnected, repository.connectionEpochs.value.lastDepartureState)
     }
 
     @Test

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -220,6 +220,33 @@ class SharedRadioInterfaceServiceLivenessTest {
         }
     }
 
+    /** Triggers a liveness restart from inside one synchronous send handoff. */
+    private class ReentrantRestartTransport(private val requestRestart: () -> Unit) : RadioTransport {
+        var handoffCompleted = false
+            private set
+
+        var closeCalled = false
+            private set
+
+        var closeObservedBeforeHandoff = false
+            private set
+
+        private var restartRequested = false
+
+        override fun handleSendToRadio(p: ByteArray) {
+            if (!restartRequested) {
+                restartRequested = true
+                requestRestart()
+            }
+            handoffCompleted = true
+        }
+
+        override suspend fun close() {
+            closeCalled = true
+            closeObservedBeforeHandoff = !handoffCompleted
+        }
+    }
+
     /** Controllable clock — tests advance this manually so all time comparisons are deterministic. */
     private var clock: Long = 0L
 
@@ -656,6 +683,46 @@ class SharedRadioInterfaceServiceLivenessTest {
 
             val firstTransportCloses = createdTransports.firstOrNull()?.closeCount ?: 0
             assertEquals(1, firstTransportCloses, "First transport should be closed exactly once (no stacking)")
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    @Test
+    fun `transport teardown drains a synchronously admitted send before close`() = runTest(testDispatcher) {
+        val transports = mutableListOf<RadioTransport>()
+        lateinit var service: SharedRadioInterfaceService
+        lateinit var initialTransport: ReentrantRestartTransport
+        val transportProvider: () -> RadioTransport = {
+            if (transports.isEmpty()) {
+                ReentrantRestartTransport {
+                    clock = 65_000L
+                    service.checkLiveness()
+                }
+                    .also {
+                        initialTransport = it
+                        transports += it
+                    }
+            } else {
+                FakeRadioTransport().also { transports += it }
+            }
+        }
+
+        clock = 0L
+        service = createConnectedService("xAA:BB:CC:DD:EE:FF", transportProvider)
+        try {
+            val accepted = service.trySendToRadio(byteArrayOf(1, 2, 3))
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(accepted)
+            assertTrue(initialTransport.handoffCompleted)
+            assertTrue(initialTransport.closeCalled)
+            assertFalse(
+                initialTransport.closeObservedBeforeHandoff,
+                "teardown must wait until the admitted handoff releases its session lease",
+            )
+            assertEquals(2, transports.size, "the liveness restart should publish one replacement transport")
         } finally {
             service.disconnect()
             advanceTimeBy(1_000L)

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -207,9 +207,8 @@ class SharedRadioInterfaceServiceLivenessTest {
         var closeCompletedCount = 0
             private set
 
-        // Liveness restart skips the polite-disconnect frame (sendPoliteDisconnect = false), so no
-        // outbound data is expected; satisfy the contract with a no-op.
-        override fun handleSendToRadio(p: ByteArray) = Unit
+        // Liveness restart skips the polite-disconnect frame, so reject any unexpected outbound handoff.
+        override fun handleSendToRadio(p: ByteArray): Boolean = false
 
         override suspend fun close() {
             closeCalled = true
@@ -233,12 +232,13 @@ class SharedRadioInterfaceServiceLivenessTest {
 
         private var restartRequested = false
 
-        override fun handleSendToRadio(p: ByteArray) {
+        override fun handleSendToRadio(p: ByteArray): Boolean {
             if (!restartRequested) {
                 restartRequested = true
                 requestRestart()
             }
             handoffCompleted = true
+            return true
         }
 
         override suspend fun close() {
@@ -516,6 +516,43 @@ class SharedRadioInterfaceServiceLivenessTest {
             assertTrue(createdTransports.single().closeCalled, "cancellation must not strand the revoked transport")
         }
 
+    @Test
+    fun `heartbeat cannot bypass transport admission while teardown drains a session lease`() =
+        runTest(testDispatcher) {
+            val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+            val transport = createdTransports.single()
+            service.keepAlive(now = 31_000L)
+            assertTrue(transport.keepAliveCalled, "an admitted session must receive its heartbeat")
+            transport.keepAliveCalled = false
+
+            val session = requireNotNull(service.activeSession.value)
+            val workStarted = CompletableDeferred<Unit>()
+            val releaseWork = CompletableDeferred<Unit>()
+            val workJob = launch {
+                service.runWithSessionLease(session) {
+                    workStarted.complete(Unit)
+                    releaseWork.await()
+                }
+            }
+            workStarted.await()
+
+            val disconnectJob = launch { service.disconnect() }
+            try {
+                testDispatcher.scheduler.runCurrent()
+                assertFalse(disconnectJob.isCompleted, "disconnect must wait for the admitted lease")
+
+                service.keepAlive(now = 62_000L)
+
+                assertFalse(transport.keepAliveCalled, "teardown must reject a late heartbeat")
+            } finally {
+                releaseWork.complete(Unit)
+                workJob.join()
+                testDispatcher.scheduler.runCurrent()
+                advanceTimeBy(1_000L)
+                disconnectJob.join()
+            }
+        }
+
     // ─── BLE: Liveness timeout triggers recovery ───────────────────────────────────────────────
 
     @Test
@@ -694,11 +731,17 @@ class SharedRadioInterfaceServiceLivenessTest {
         val transports = mutableListOf<RadioTransport>()
         lateinit var service: SharedRadioInterfaceService
         lateinit var initialTransport: ReentrantRestartTransport
+        // The provider runs before `service` is assigned; keep the callback disarmed until construction completes
+        // so
+        // the captured lateinit reference cannot be touched from the transport factory.
+        var restartArmed = false
         val transportProvider: () -> RadioTransport = {
             if (transports.isEmpty()) {
                 ReentrantRestartTransport {
-                    clock = 65_000L
-                    service.checkLiveness()
+                    if (restartArmed) {
+                        clock = 65_000L
+                        service.checkLiveness()
+                    }
                 }
                     .also {
                         initialTransport = it
@@ -712,6 +755,7 @@ class SharedRadioInterfaceServiceLivenessTest {
         clock = 0L
         service = createConnectedService("xAA:BB:CC:DD:EE:FF", transportProvider)
         try {
+            restartArmed = true
             val accepted = service.trySendToRadio(byteArrayOf(1, 2, 3))
             testDispatcher.scheduler.runCurrent()
 
@@ -727,6 +771,35 @@ class SharedRadioInterfaceServiceLivenessTest {
             service.disconnect()
             advanceTimeBy(1_000L)
         }
+    }
+
+    @Test
+    fun `transport rejection is reported to the caller`() = runTest(testDispatcher) {
+        val rejectingTransport =
+            object : RadioTransport {
+                override fun handleSendToRadio(p: ByteArray): Boolean = false
+
+                override suspend fun close() = Unit
+            }
+        val service =
+            createConnectedService(address = "xAA:BB:CC:DD:EE:FF", transportProvider = { rejectingTransport })
+
+        try {
+            assertFalse(service.trySendToRadio(byteArrayOf(1, 2, 3)))
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
+
+    @Test
+    fun `transport admission is closed after disconnect`() = runTest(testDispatcher) {
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+
+        service.disconnect()
+        testDispatcher.scheduler.runCurrent()
+
+        assertFalse(service.trySendToRadio(byteArrayOf(1, 2, 3)))
     }
 
     @Test

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -16,34 +16,29 @@
  */
 package org.meshtastic.core.takserver
 
-import co.touchlab.kermit.Severity
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.di.CoroutineDispatchers
-import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeSortOption
 import org.meshtastic.core.model.Position
-import org.meshtastic.core.model.service.LockdownState
-import org.meshtastic.core.model.service.LockdownTokenInfo
-import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.AwaitedSendResult
+import org.meshtastic.core.repository.AwaitedSendStatus
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.MeshConfigHandler
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioSessionContext
-import org.meshtastic.core.repository.ServiceRepository
+import org.meshtastic.core.testing.FakeServiceRepository
 import org.meshtastic.core.testing.FakeTakPrefs
 import org.meshtastic.proto.AdminMessage
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
-import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Data
 import org.meshtastic.proto.DeviceMetadata
@@ -99,12 +94,12 @@ class TAKMeshIntegrationTest {
 
         override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {}
 
-        override suspend fun sendAdminAwait(
+        override suspend fun sendAdminAwaitResult(
             destNum: Int,
             requestId: Int,
             wantResponse: Boolean,
             initFn: () -> AdminMessage,
-        ): Boolean = true
+        ) = AwaitedSendResult(AwaitedSendStatus.ACCEPTED, dispatched = true)
 
         override suspend fun sendPosition(pos: org.meshtastic.proto.Position, destNum: Int?, wantResponse: Boolean) {}
 
@@ -129,61 +124,6 @@ class TAKMeshIntegrationTest {
         ) {}
 
         override fun sendLockNow() {}
-    }
-
-    private class FakeServiceRepository : ServiceRepository {
-        private val _meshPacketFlow = MutableSharedFlow<MeshPacket>(replay = 1, extraBufferCapacity = 64)
-        override val meshPacketFlow: Flow<MeshPacket> = _meshPacketFlow
-
-        override val connectionState: StateFlow<ConnectionState> = MutableStateFlow(ConnectionState.Disconnected)
-
-        override fun setConnectionState(connectionState: ConnectionState) {}
-
-        override val clientNotification: StateFlow<ClientNotification?> = MutableStateFlow(null)
-
-        override fun setClientNotification(notification: ClientNotification?) {}
-
-        override fun clearClientNotification() {}
-
-        override val errorMessage: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setErrorMessage(text: String, severity: Severity) {}
-
-        override fun clearErrorMessage() {}
-
-        override val connectionProgress: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setConnectionProgress(text: String) {}
-
-        override suspend fun emitMeshPacket(packet: MeshPacket) {
-            _meshPacketFlow.emit(packet)
-        }
-
-        override val tracerouteResponse: StateFlow<TracerouteResponse?> = MutableStateFlow(null)
-
-        override fun setTracerouteResponse(value: TracerouteResponse?) {}
-
-        override fun clearTracerouteResponse() {}
-
-        override val neighborInfoResponse: StateFlow<String?> = MutableStateFlow(null)
-
-        override fun setNeighborInfoResponse(value: String?) {}
-
-        override fun clearNeighborInfoResponse() {}
-
-        override val lockdownState: StateFlow<LockdownState> = MutableStateFlow(LockdownState.None)
-
-        override fun setLockdownState(state: LockdownState) {}
-
-        override fun clearLockdownState() {}
-
-        override val lockdownTokenInfo: StateFlow<LockdownTokenInfo?> = MutableStateFlow(null)
-
-        override fun setLockdownTokenInfo(info: LockdownTokenInfo?) {}
-
-        override val sessionAuthorized: StateFlow<Boolean> = MutableStateFlow(false)
-
-        override fun setSessionAuthorized(authorized: Boolean) {}
     }
 
     private class FakeMeshConfigHandler : MeshConfigHandler {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -16,11 +16,14 @@
  */
 package org.meshtastic.core.testing
 
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminEditScope
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ClientNotification
@@ -38,8 +41,10 @@ class FakeRadioController :
     RadioController {
 
     /** Canonical app-level connection state, mirroring [ServiceRepository][connectionState] semantics. */
-    private val _connectionState = mutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState> = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionLifecycle = connectionStateHolder.connectionLifecycle
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
     private val _clientNotification = mutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?> = _clientNotification
@@ -48,13 +53,56 @@ class FakeRadioController :
     val favoritedNodes = mutableListOf<Int>()
     val sentSharedContacts = mutableListOf<Int>()
 
-    /** Every [setLocalConfig] call, in order — lets tests assert e.g. that a scan restored the home LoRa preset. */
-    val localConfigs = mutableListOf<Config>()
-    val lastLocalConfig: Config?
-        get() = localConfigs.lastOrNull()
+    /** One local or admin configuration write. Local writes have no destination. */
+    data class ConfigWrite(val destination: Int?, val config: Config)
 
-    /** Every [setLocalChannel] call, in order. */
+    /** One module configuration write, preserving its destination and payload as a single observation. */
+    data class ModuleConfigWrite(val destination: Int, val config: ModuleConfig)
+
+    /** Every local or admin configuration write, preserving destination and call order together. */
+    val configWrites = mutableListOf<ConfigWrite>()
+
+    /** Local configuration payloads in call order. Prefer [configWrites] when destination identity matters. */
+    val localConfigs: List<Config>
+        get() = configWrites.filter { it.destination == null }.map(ConfigWrite::config)
+
+    val lastLocalConfig: Config?
+        get() = configWrites.lastOrNull { it.destination == null }?.config
+
+    /** Every local or admin channel write, in call order. */
     val localChannels = mutableListOf<Channel>()
+
+    /** Every [setFixedPosition] call, in order. */
+    val fixedPositions = mutableListOf<Position>()
+
+    /** Every module configuration write, preserving destination and call order together. */
+    val moduleConfigWrites = mutableListOf<ModuleConfigWrite>()
+
+    /** Module configuration payloads in call order. Prefer [moduleConfigWrites] when destination identity matters. */
+    val moduleConfigs: List<ModuleConfig>
+        get() = moduleConfigWrites.map(ModuleConfigWrite::config)
+
+    /** Destination node for every module configuration write, in order. */
+    val moduleConfigDestinations: List<Int>
+        get() = moduleConfigWrites.map(ModuleConfigWrite::destination)
+
+    /** Destination node for every edit transaction, in order. Local edits use the fake's sentinel value of zero. */
+    val editSettingsDestinations = mutableListOf<Int>()
+
+    /** High-level admin operation order, including edit transaction boundaries. */
+    val adminOperations = mutableListOf<String>()
+
+    /** When true, an edit transaction fails before the begin boundary is recorded. */
+    var failEditSettingsBegin: Boolean = false
+
+    /** Test hook invoked after an edit transaction commits. */
+    var onEditSettingsCommitted: suspend () -> Unit = {}
+
+    /** Test hook invoked after a standalone module-config write. */
+    var onStandaloneModuleConfig: suspend (ModuleConfig) -> Unit = {}
+
+    /** Test hook invoked after a standalone general-config write. */
+    var onStandaloneConfig: suspend (Config) -> Unit = {}
 
     var throwOnSend: Boolean = false
 
@@ -81,11 +129,20 @@ class FakeRadioController :
 
     init {
         registerResetAction {
+            connectionStateHolder.reset()
             sentPackets.clear()
             favoritedNodes.clear()
             sentSharedContacts.clear()
-            localConfigs.clear()
+            configWrites.clear()
             localChannels.clear()
+            fixedPositions.clear()
+            moduleConfigWrites.clear()
+            editSettingsDestinations.clear()
+            adminOperations.clear()
+            failEditSettingsBegin = false
+            onEditSettingsCommitted = {}
+            onStandaloneModuleConfig = {}
+            onStandaloneConfig = {}
             throwOnSend = false
             throwOnSetLocalConfig = false
             failChannelWriteAfter = null
@@ -129,7 +186,7 @@ class FakeRadioController :
 
     override suspend fun setLocalConfig(config: Config) {
         if (throwOnSetLocalConfig) error("Fake local config write failure")
-        localConfigs.add(config)
+        configWrites.add(ConfigWrite(destination = null, config = config))
     }
 
     override suspend fun setLocalChannel(channel: Channel) {
@@ -138,22 +195,41 @@ class FakeRadioController :
 
     override suspend fun setOwner(destNum: Int, user: User, packetId: Int) {
         lastSetOwnerUser = user
+        adminOperations.add("owner")
     }
 
     override suspend fun setHamMode(destNum: Int, hamParameters: HamParameters, packetId: Int) {}
 
     override suspend fun setConfig(destNum: Int, config: Config, packetId: Int) {
-        localConfigs.add(config)
+        recordConfigWrite(destNum, config, invokeStandaloneHook = true)
     }
 
-    override suspend fun setModuleConfig(destNum: Int, config: ModuleConfig, packetId: Int) {}
+    override suspend fun setModuleConfig(destNum: Int, config: ModuleConfig, packetId: Int) {
+        recordModuleConfigWrite(destNum, config, invokeStandaloneHook = true)
+    }
+
+    private suspend fun recordConfigWrite(destNum: Int, config: Config, invokeStandaloneHook: Boolean) {
+        configWrites.add(ConfigWrite(destination = destNum, config = config))
+        adminOperations.add("config:update")
+        if (invokeStandaloneHook) onStandaloneConfig(config)
+    }
+
+    private suspend fun recordModuleConfigWrite(destNum: Int, config: ModuleConfig, invokeStandaloneHook: Boolean) {
+        moduleConfigWrites.add(ModuleConfigWrite(destination = destNum, config = config))
+        adminOperations.add("module:update")
+        if (invokeStandaloneHook) onStandaloneModuleConfig(config)
+    }
 
     override suspend fun setRemoteChannel(destNum: Int, channel: Channel, packetId: Int) {
         failChannelWriteAfter?.let { if (localChannels.size >= it) error("Fake channel write failure") }
         localChannels.add(channel)
+        adminOperations.add("channel:${channel.index}")
     }
 
-    override suspend fun setFixedPosition(destNum: Int, position: Position) {}
+    override suspend fun setFixedPosition(destNum: Int, position: Position) {
+        fixedPositions.add(position)
+        adminOperations.add("fixed-position")
+    }
 
     override suspend fun setRingtone(destNum: Int, ringtone: String) {}
 
@@ -202,15 +278,19 @@ class FakeRadioController :
     override suspend fun requestNeighborInfo(requestId: Int, destNum: Int) {}
 
     override suspend fun editSettings(destNum: Int, block: suspend AdminEditScope.() -> Unit) {
+        editSettingsDestinations.add(destNum)
         editSettingsCalled = true
+        if (failEditSettingsBegin) error("Fake edit-settings begin failure")
+        adminOperations.add("begin")
         val scope =
             object : AdminEditScope {
                 override suspend fun setOwner(user: User) = setOwner(destNum, user, generatePacketId())
 
-                override suspend fun setConfig(config: Config) = setConfig(destNum, config, generatePacketId())
+                override suspend fun setConfig(config: Config) =
+                    recordConfigWrite(destNum, config, invokeStandaloneHook = false)
 
                 override suspend fun setModuleConfig(config: ModuleConfig) =
-                    setModuleConfig(destNum, config, generatePacketId())
+                    recordModuleConfigWrite(destNum, config, invokeStandaloneHook = false)
 
                 override suspend fun setChannel(channel: Channel) =
                     setRemoteChannel(destNum, channel, generatePacketId())
@@ -218,7 +298,19 @@ class FakeRadioController :
                 override suspend fun setFixedPosition(position: Position) =
                     this@FakeRadioController.setFixedPosition(destNum, position)
             }
-        scope.block()
+        val blockResult = runCatching { scope.block() }
+        val commitResult = runCatching {
+            withContext(NonCancellable) {
+                adminOperations.add("commit")
+                onEditSettingsCommitted()
+            }
+        }
+
+        blockResult.exceptionOrNull()?.let { blockFailure ->
+            commitResult.exceptionOrNull()?.takeUnless { it === blockFailure }?.let(blockFailure::addSuppressed)
+            throw blockFailure
+        }
+        commitResult.getOrThrow()
     }
 
     override suspend fun editLocalSettings(block: suspend AdminEditScope.() -> Unit) = editSettings(0, block)
@@ -243,9 +335,7 @@ class FakeRadioController :
 
     // --- Helper methods for testing ---
 
-    fun setConnectionState(state: ConnectionState) {
-        _connectionState.value = state
-    }
+    fun setConnectionState(state: ConnectionState) = connectionStateHolder.setConnectionState(state)
 
     fun setClientNotification(notification: ClientNotification?) {
         _clientNotification.value = notification

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -82,6 +82,10 @@ class FakeRadioController :
     val moduleConfigs: List<ModuleConfig>
         get() = moduleConfigWrites.map(ModuleConfigWrite::config)
 
+    /** Module configuration payloads written inside a local edit transaction (whose destination sentinel is zero). */
+    val localModuleConfigs: List<ModuleConfig>
+        get() = moduleConfigWrites.filter { it.destination == 0 }.map(ModuleConfigWrite::config)
+
     /** Destination node for every module configuration write, in order. */
     val moduleConfigDestinations: List<Int>
         get() = moduleConfigWrites.map(ModuleConfigWrite::destination)
@@ -208,7 +212,7 @@ class FakeRadioController :
         recordModuleConfigWrite(destNum, config, invokeStandaloneHook = true)
     }
 
-    private suspend fun recordConfigWrite(destNum: Int, config: Config, invokeStandaloneHook: Boolean) {
+    private suspend fun recordConfigWrite(destNum: Int?, config: Config, invokeStandaloneHook: Boolean) {
         configWrites.add(ConfigWrite(destination = destNum, config = config))
         adminOperations.add("config:update")
         if (invokeStandaloneHook) onStandaloneConfig(config)
@@ -287,7 +291,7 @@ class FakeRadioController :
                 override suspend fun setOwner(user: User) = setOwner(destNum, user, generatePacketId())
 
                 override suspend fun setConfig(config: Config) =
-                    recordConfigWrite(destNum, config, invokeStandaloneHook = false)
+                    recordConfigWrite(destNum.takeUnless { it == 0 }, config, invokeStandaloneHook = false)
 
                 override suspend fun setModuleConfig(config: ModuleConfig) =
                     recordModuleConfigWrite(destNum, config, invokeStandaloneHook = false)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -127,7 +127,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
 
     /** Thread-safe snapshot of writes accepted by the currently admitted fake transport session. */
     val sentToRadio: List<ByteArray>
-        get() = synchronized(sessionAdmissionLock) { _sentToRadio.toList() }
+        get() = synchronized(sessionAdmissionLock) { _sentToRadio.map { it.copyOf() } }
 
     var connectCalled = false
     var restartTransportCalled: Boolean = false
@@ -142,7 +142,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
     override fun trySendToRadio(bytes: ByteArray): Boolean {
         val admittedSession = admitSessionOperation() ?: return false
         return try {
-            synchronized(sessionAdmissionLock) { _sentToRadio.add(bytes) }
+            synchronized(sessionAdmissionLock) { _sentToRadio.add(bytes.copyOf()) }
             true
         } finally {
             releaseSessionOperation(admittedSession)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -123,17 +123,26 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
     private val _connectionError = MutableSharedFlow<String>()
     override val connectionError: Flow<String> = _connectionError.asFlow()
 
-    val sentToRadio = mutableListOf<ByteArray>()
+    private val _sentToRadio = mutableListOf<ByteArray>()
+
+    /** Thread-safe snapshot of writes accepted by the currently admitted fake transport session. */
+    val sentToRadio: List<ByteArray>
+        get() = synchronized(sessionAdmissionLock) { _sentToRadio.toList() }
+
     var connectCalled = false
     var restartTransportCalled: Boolean = false
         private set
 
     override fun isMockTransport(): Boolean = true
 
+    /**
+     * Records [bytes] only while a transport session is admitted. Tests must select a non-null device address and call
+     * [connect] before sending; attempts outside that lifecycle return false and leave [sentToRadio] unchanged.
+     */
     override fun trySendToRadio(bytes: ByteArray): Boolean {
         val admittedSession = admitSessionOperation() ?: return false
         return try {
-            synchronized(sessionAdmissionLock) { sentToRadio.add(bytes) }
+            synchronized(sessionAdmissionLock) { _sentToRadio.add(bytes) }
             true
         } finally {
             releaseSessionOperation(admittedSession)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -91,16 +91,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
         session: RadioSessionContext,
         block: suspend (RadioSessionLease) -> Unit,
     ): Boolean {
-        val admittedSession =
-            synchronized(sessionAdmissionLock) {
-                val active = _activeSession.value
-                if (!sessionAdmissionOpen || active != session) {
-                    null
-                } else {
-                    admittedSessionOperations++
-                    active
-                }
-            } ?: return false
+        val admittedSession = admitSessionOperation(session) ?: return false
 
         val lease =
             object : RadioSessionLease {
@@ -114,20 +105,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
             block(lease)
             return true
         } finally {
-            val waiter =
-                synchronized(sessionAdmissionLock) {
-                    check(_activeSession.value == admittedSession) {
-                        "Fake session changed before an admitted operation released its lease"
-                    }
-                    check(admittedSessionOperations > 0) { "Session operation count underflow" }
-                    admittedSessionOperations--
-                    if (admittedSessionOperations == 0) {
-                        sessionDrainWaiter.also { sessionDrainWaiter = null }
-                    } else {
-                        null
-                    }
-                }
-            waiter?.complete(Unit)
+            releaseSessionOperation(admittedSession)
         }
     }
 
@@ -152,8 +130,14 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
 
     override fun isMockTransport(): Boolean = true
 
-    override fun sendToRadio(bytes: ByteArray) {
-        sentToRadio.add(bytes)
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
+        val admittedSession = admitSessionOperation() ?: return false
+        return try {
+            synchronized(sessionAdmissionLock) { sentToRadio.add(bytes) }
+            true
+        } finally {
+            releaseSessionOperation(admittedSession)
+        }
     }
 
     override fun connect() {
@@ -179,6 +163,35 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
     override fun setDeviceAddress(deviceAddr: String?): Boolean {
         _currentDeviceAddressFlow.value = deviceAddr
         return true
+    }
+
+    private fun admitSessionOperation(expectedSession: RadioSessionContext? = null): RadioSessionContext? =
+        synchronized(sessionAdmissionLock) {
+            val active = _activeSession.value
+            val matchesExpectedSession = expectedSession == null || active == expectedSession
+            if (!sessionAdmissionOpen || active == null || !matchesExpectedSession) {
+                null
+            } else {
+                admittedSessionOperations++
+                active
+            }
+        }
+
+    private fun releaseSessionOperation(admittedSession: RadioSessionContext) {
+        val waiter =
+            synchronized(sessionAdmissionLock) {
+                check(_activeSession.value == admittedSession) {
+                    "Fake session changed before an admitted operation released its lease"
+                }
+                check(admittedSessionOperations > 0) { "Session operation count underflow" }
+                admittedSessionOperations--
+                if (admittedSessionOperations == 0) {
+                    sessionDrainWaiter.also { sessionDrainWaiter = null }
+                } else {
+                    null
+                }
+            }
+        waiter?.complete(Unit)
     }
 
     private fun admitSelectedSession() {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeServiceRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeServiceRepository.kt
@@ -26,6 +26,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.model.service.LockdownTokenInfo
 import org.meshtastic.core.model.service.TracerouteResponse
+import org.meshtastic.core.repository.ConnectionStateHolder
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.MeshPacket
@@ -33,12 +34,13 @@ import org.meshtastic.proto.MeshPacket
 @Suppress("TooManyFunctions")
 class FakeServiceRepository : ServiceRepository {
     /** Canonical app-level connection state — the single source of truth for UI/feature tests. */
-    private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    override val connectionState: StateFlow<ConnectionState> = _connectionState
+    private val connectionStateHolder = ConnectionStateHolder()
+    override val connectionLifecycle = connectionStateHolder.connectionLifecycle
+    override val connectionState = connectionStateHolder.connectionState
+    override val connectionEpochs = connectionStateHolder.connectionEpochs
 
-    override fun setConnectionState(connectionState: ConnectionState) {
-        _connectionState.value = connectionState
-    }
+    override fun setConnectionState(connectionState: ConnectionState) =
+        connectionStateHolder.setConnectionState(connectionState)
 
     private val _clientNotification = MutableStateFlow<ClientNotification?>(null)
     override val clientNotification: StateFlow<ClientNotification?> = _clientNotification

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -79,6 +80,22 @@ class FakeRadioInterfaceServiceSessionTest {
         service.disconnect()
         assertFalse(service.trySendToRadio(bytes))
         assertEquals(1, service.sentToRadio.size)
+    }
+
+    @Test
+    fun `recorded radio writes are isolated from caller mutation`() = runTest {
+        val service = FakeRadioInterfaceService(serviceScope = backgroundScope)
+        val bytes = byteArrayOf(1, 2, 3)
+        service.setDeviceAddress("ble:test")
+        service.connect()
+
+        assertTrue(service.trySendToRadio(bytes))
+        bytes[0] = 9
+        val recorded = service.sentToRadio.single()
+        assertContentEquals(byteArrayOf(1, 2, 3), recorded)
+
+        recorded[1] = 8
+        assertContentEquals(byteArrayOf(1, 2, 3), service.sentToRadio.single())
     }
 
     @Test

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceServiceSessionTest.kt
@@ -63,6 +63,25 @@ class FakeRadioInterfaceServiceSessionTest {
     }
 
     @Test
+    fun `trySendToRadio records bytes only while a session is admitted`() = runTest {
+        val service = FakeRadioInterfaceService(serviceScope = backgroundScope)
+        val bytes = byteArrayOf(1, 2, 3)
+
+        assertFalse(service.trySendToRadio(bytes))
+        assertTrue(service.sentToRadio.isEmpty())
+
+        service.setDeviceAddress("ble:test")
+        service.connect()
+        assertTrue(service.trySendToRadio(bytes))
+        assertEquals(1, service.sentToRadio.size)
+        assertTrue(bytes.contentEquals(service.sentToRadio.single()))
+
+        service.disconnect()
+        assertFalse(service.trySendToRadio(bytes))
+        assertEquals(1, service.sentToRadio.size)
+    }
+
+    @Test
     fun `disconnect closes admission and waits for admitted fake session work`() = runTest {
         val service = FakeRadioInterfaceService(serviceScope = backgroundScope)
         service.setDeviceAddress("ble:test")

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -313,10 +313,7 @@ class RepositoryFakesTest {
         // the runtime rebuilds the exception (same class, same message, new instance) to attach the coroutine's
         // stack frames. Production's editSettingsSuppressesCommitFailureOnBlockFailure uses message comparison for
         // the same reason.
-        assertEquals(
-            listOf(commitFailure.message),
-            failure.suppressedExceptions.map(Throwable::message),
-        )
+        assertEquals(listOf(commitFailure.message), failure.suppressedExceptions.map(Throwable::message))
         assertEquals(listOf("begin", "commit"), controller.adminOperations)
     }
 

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -35,6 +35,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -314,6 +315,7 @@ class RepositoryFakesTest {
         // stack frames. Production's editSettingsSuppressesCommitFailureOnBlockFailure uses message comparison for
         // the same reason.
         assertEquals(listOf(commitFailure.message), failure.suppressedExceptions.map(Throwable::message))
+        assertIs<IllegalArgumentException>(failure.suppressedExceptions.single())
         assertEquals(listOf("begin", "commit"), controller.adminOperations)
     }
 

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -308,7 +308,15 @@ class RepositoryFakesTest {
         val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { throw blockFailure } }
 
         assertSame(blockFailure, failure)
-        assertSame(commitFailure, failure.suppressedExceptions.single())
+        // Compare by message instead of instance: kotlinx-coroutines 1.11 enables StackTraceRecovery by default on
+        // JVM, so when onEditSettingsCommitted's throw crosses the withContext(NonCancellable) suspension boundary
+        // the runtime rebuilds the exception (same class, same message, new instance) to attach the coroutine's
+        // stack frames. Production's editSettingsSuppressesCommitFailureOnBlockFailure uses message comparison for
+        // the same reason.
+        assertEquals(
+            listOf(commitFailure.message),
+            failure.suppressedExceptions.map(Throwable::message),
+        )
         assertEquals(listOf("begin", "commit"), controller.adminOperations)
     }
 

--- a/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
+++ b/core/testing/src/commonTest/kotlin/org/meshtastic/core/testing/RepositoryFakesTest.kt
@@ -17,18 +17,28 @@
 package org.meshtastic.core.testing
 
 import app.cash.turbine.test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.QuickChatAction
+import org.meshtastic.core.model.ConnectionEpochs
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.Position
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.meshtastic.core.model.Position as ModelPosition
 
 class RepositoryFakesTest {
 
@@ -130,6 +140,176 @@ class RepositoryFakesTest {
         assertEquals("active", manager.lastAssociatedAddress)
         assertEquals(3, manager.lastAssociatedNode)
         assertEquals("fresh", manager.lastAssociatedDeviceId)
+    }
+
+    @Test
+    fun `service repository fake preserves connection epoch semantics`() {
+        val repository = FakeServiceRepository()
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), repository.connectionEpochs.value)
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), repository.connectionEpochs.value)
+
+        repository.setConnectionState(ConnectionState.Connecting)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 1,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            repository.connectionEpochs.value,
+        )
+
+        repository.setConnectionState(ConnectionState.Connected)
+        assertEquals(
+            ConnectionEpochs(
+                departures = 1,
+                completedHandshakes = 2,
+                handshakesAtLastDeparture = 1,
+                lastDepartureState = ConnectionState.Connecting,
+            ),
+            repository.connectionEpochs.value,
+        )
+    }
+
+    @Test
+    fun `FakeRadioController preserves configuration and fixed-position evidence until reset`() = runTest {
+        val controller = FakeRadioController()
+        val local = Config(device = Config.DeviceConfig())
+        val admin = Config(lora = Config.LoRaConfig(hop_limit = 5))
+        val module = ModuleConfig(serial = ModuleConfig.SerialConfig(enabled = true))
+        val position = ModelPosition(latitude = 1.0, longitude = 2.0, altitude = 3)
+
+        controller.setLocalConfig(local)
+        controller.setConfig(destNum = 7, config = admin, packetId = 8)
+        controller.setModuleConfig(destNum = 7, config = module, packetId = 9)
+        controller.setFixedPosition(destNum = 7, position = position)
+        controller.setConnectionState(ConnectionState.Connected)
+
+        assertEquals(
+            listOf(
+                FakeRadioController.ConfigWrite(destination = null, config = local),
+                FakeRadioController.ConfigWrite(destination = 7, config = admin),
+            ),
+            controller.configWrites,
+        )
+        assertEquals(listOf(local), controller.localConfigs)
+        assertEquals(local, controller.lastLocalConfig)
+        assertEquals(
+            listOf(FakeRadioController.ModuleConfigWrite(destination = 7, config = module)),
+            controller.moduleConfigWrites,
+        )
+        assertEquals(listOf(module), controller.moduleConfigs)
+        assertEquals(listOf(7), controller.moduleConfigDestinations)
+        assertEquals(listOf(position), controller.fixedPositions)
+        assertEquals(ConnectionState.Connected, controller.connectionState.value)
+        assertEquals(ConnectionEpochs(completedHandshakes = 1), controller.connectionEpochs.value)
+
+        controller.reset()
+
+        assertTrue(controller.configWrites.isEmpty())
+        assertTrue(controller.localConfigs.isEmpty())
+        assertTrue(controller.moduleConfigWrites.isEmpty())
+        assertTrue(controller.moduleConfigs.isEmpty())
+        assertTrue(controller.moduleConfigDestinations.isEmpty())
+        assertTrue(controller.fixedPositions.isEmpty())
+        assertEquals(ConnectionState.Disconnected, controller.connectionState.value)
+        assertEquals(ConnectionEpochs(), controller.connectionEpochs.value)
+    }
+
+    @Test
+    fun `FakeRadioController scopes standalone hooks per write`() = runTest {
+        val controller = FakeRadioController()
+        val transactionStarted = CompletableDeferred<Unit>()
+        val finishTransaction = CompletableDeferred<Unit>()
+        val standaloneHooks = mutableListOf<String>()
+        controller.onStandaloneConfig = { standaloneHooks += "config" }
+        controller.onStandaloneModuleConfig = { standaloneHooks += "module" }
+
+        val transaction = async {
+            controller.editSettings(destNum = 7) {
+                transactionStarted.complete(Unit)
+                finishTransaction.await()
+                setConfig(Config(device = Config.DeviceConfig()))
+                setModuleConfig(ModuleConfig(serial = ModuleConfig.SerialConfig(enabled = true)))
+            }
+        }
+        transactionStarted.await()
+
+        controller.setConfig(destNum = 8, config = Config(power = Config.PowerConfig()), packetId = 1)
+        controller.setModuleConfig(
+            destNum = 8,
+            config = ModuleConfig(mqtt = ModuleConfig.MQTTConfig(enabled = true)),
+            packetId = 2,
+        )
+        finishTransaction.complete(Unit)
+        transaction.await()
+
+        assertEquals(listOf("config", "module"), standaloneHooks)
+        assertEquals(
+            listOf(
+                FakeRadioController.ConfigWrite(destination = 8, config = Config(power = Config.PowerConfig())),
+                FakeRadioController.ConfigWrite(destination = 7, config = Config(device = Config.DeviceConfig())),
+            ),
+            controller.configWrites,
+        )
+        assertEquals(
+            listOf(
+                FakeRadioController.ModuleConfigWrite(
+                    destination = 8,
+                    config = ModuleConfig(mqtt = ModuleConfig.MQTTConfig(enabled = true)),
+                ),
+                FakeRadioController.ModuleConfigWrite(
+                    destination = 7,
+                    config = ModuleConfig(serial = ModuleConfig.SerialConfig(enabled = true)),
+                ),
+            ),
+            controller.moduleConfigWrites,
+        )
+        assertEquals(
+            listOf("begin", "config:update", "module:update", "config:update", "module:update", "commit"),
+            controller.adminOperations,
+        )
+    }
+
+    @Test
+    fun `FakeRadioController rejects edit settings before running writes when begin fails`() = runTest {
+        val controller = FakeRadioController().apply { failEditSettingsBegin = true }
+        var blockRan = false
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { blockRan = true } }
+
+        assertEquals("Fake edit-settings begin failure", failure.message)
+        assertFalse(blockRan)
+        assertTrue(controller.editSettingsCalled)
+        assertEquals(listOf(0), controller.editSettingsDestinations)
+        assertTrue(controller.adminOperations.isEmpty())
+    }
+
+    @Test
+    fun `FakeRadioController reset clears begin-boundary failure hook`() {
+        val controller = FakeRadioController().apply { failEditSettingsBegin = true }
+
+        controller.reset()
+
+        assertFalse(controller.failEditSettingsBegin)
+    }
+
+    @Test
+    fun `FakeRadioController commits after block failure and preserves failure precedence`() = runTest {
+        val controller = FakeRadioController()
+        val blockFailure = IllegalStateException("write failed")
+        val commitFailure = IllegalArgumentException("commit failed")
+        controller.onEditSettingsCommitted = { throw commitFailure }
+
+        val failure = assertFailsWith<IllegalStateException> { controller.editLocalSettings { throw blockFailure } }
+
+        assertSame(blockFailure, failure)
+        assertSame(commitFailure, failure.suppressedExceptions.single())
+        assertEquals(listOf("begin", "commit"), controller.adminOperations)
     }
 
     @Test

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -89,8 +89,9 @@ class NoopRadioInterfaceService : RadioInterfaceService {
     override val meshActivity: Flow<MeshActivity> = MutableSharedFlow<MeshActivity>()
     override val connectionError: Flow<String> = MutableSharedFlow<String>()
 
-    override fun sendToRadio(bytes: ByteArray) {
+    override fun trySendToRadio(bytes: ByteArray): Boolean {
         logWarn("NoopRadioInterfaceService.sendToRadio(${bytes.size} bytes)")
+        return false
     }
 
     override fun resetReceivedBuffer() {

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -90,7 +90,7 @@ class NoopRadioInterfaceService : RadioInterfaceService {
     override val connectionError: Flow<String> = MutableSharedFlow<String>()
 
     override fun trySendToRadio(bytes: ByteArray): Boolean {
-        logWarn("NoopRadioInterfaceService.sendToRadio(${bytes.size} bytes)")
+        logWarn("NoopRadioInterfaceService.trySendToRadio(${bytes.size} bytes)")
         return false
     }
 

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngine.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngine.kt
@@ -51,6 +51,7 @@ import org.meshtastic.core.repository.DiscoveryPacketCollector
 import org.meshtastic.core.repository.DiscoveryPacketCollectorRegistry
 import org.meshtastic.core.repository.MeshPrefs
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.PacketQueueRejectedException
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.repository.ServiceRepository
@@ -418,8 +419,12 @@ class DiscoveryScanEngine(
     private suspend fun requestNeighborInfoAtDwellBoundary() {
         val myNodeNum = nodeRepository.myNodeInfo.value?.myNodeNum ?: return
         val packetId = radioController.generatePacketId()
-        radioController.requestNeighborInfo(packetId, myNodeNum)
-        Logger.d { "DiscoveryScanEngine: requested NeighborInfo from local node $myNodeNum (packetId=$packetId)" }
+        try {
+            radioController.requestNeighborInfo(packetId, myNodeNum)
+            Logger.d { "DiscoveryScanEngine: requested NeighborInfo from local node $myNodeNum (packetId=$packetId)" }
+        } catch (e: PacketQueueRejectedException) {
+            Logger.d(e) { "DiscoveryScanEngine: NeighborInfo request rejected during transport transition" }
+        }
     }
 
     private suspend fun runDwell(presetName: String, durationSeconds: Long): Boolean {

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/CommonNodeRequestActions.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/CommonNodeRequestActions.kt
@@ -25,6 +25,7 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.TelemetryType
+import org.meshtastic.core.repository.PacketQueueRejectedException
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.UiText
@@ -59,13 +60,22 @@ constructor(
         snackbarManager.showSnackbar(message = text.resolve())
     }
 
-    override suspend fun requestUserInfo(destNum: Int, longName: String) {
+    private suspend fun runRequest(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: PacketQueueRejectedException) {
+            Logger.w(e) { "Node request rejected by outbound packet queue" }
+            snackbarManager.showSnackbar(checkNotNull(e.message))
+        }
+    }
+
+    override suspend fun requestUserInfo(destNum: Int, longName: String) = runRequest {
         Logger.i { "Requesting UserInfo for '$destNum'" }
         radioController.requestUserInfo(destNum)
         showFeedback(UiText.Resource(Res.string.requesting_from, Res.string.user_info, longName))
     }
 
-    override suspend fun requestNeighborInfo(destNum: Int, longName: String) {
+    override suspend fun requestNeighborInfo(destNum: Int, longName: String) = runRequest {
         Logger.i { "Requesting NeighborInfo for '$destNum'" }
         val packetId = radioController.generatePacketId()
         radioController.requestNeighborInfo(packetId, destNum)
@@ -73,13 +83,13 @@ constructor(
         showFeedback(UiText.Resource(Res.string.requesting_from, Res.string.neighbor_info, longName))
     }
 
-    override suspend fun requestPosition(destNum: Int, longName: String, position: Position) {
+    override suspend fun requestPosition(destNum: Int, longName: String, position: Position) = runRequest {
         Logger.i { "Requesting position for '$destNum'" }
         radioController.requestPosition(destNum, position)
         showFeedback(UiText.Resource(Res.string.requesting_from, Res.string.position, longName))
     }
 
-    override suspend fun requestTelemetry(destNum: Int, longName: String, type: TelemetryType) {
+    override suspend fun requestTelemetry(destNum: Int, longName: String, type: TelemetryType) = runRequest {
         Logger.i { "Requesting telemetry for '$destNum'" }
         val packetId = radioController.generatePacketId()
         radioController.requestTelemetry(packetId, destNum, type.ordinal)
@@ -98,7 +108,7 @@ constructor(
         showFeedback(UiText.Resource(Res.string.requesting_from, typeRes, longName))
     }
 
-    override suspend fun requestTraceroute(destNum: Int, longName: String) {
+    override suspend fun requestTraceroute(destNum: Int, longName: String) = runRequest {
         Logger.i { "Requesting traceroute for '$destNum'" }
         val packetId = radioController.generatePacketId()
         radioController.requestTraceroute(packetId, destNum)

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
@@ -45,6 +45,7 @@ import org.meshtastic.core.resources.UiText
 import org.meshtastic.core.resources.connect_radio_for_remote_admin
 import org.meshtastic.core.resources.remote_admin_unreachable
 import org.meshtastic.core.ui.util.SnackbarManager
+import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.node.component.NodeMenuAction
 import org.meshtastic.feature.node.domain.usecase.GetNodeDetailsUseCase
@@ -143,27 +144,27 @@ class NodeDetailViewModel(
             is NodeMenuAction.Favorite -> nodeManagementActions.requestFavoriteNode(viewModelScope, action.node)
 
             is NodeMenuAction.RequestUserInfo ->
-                viewModelScope.launch {
+                safeLaunch(tag = "requestUserInfo") {
                     nodeRequestActions.requestUserInfo(action.node.num, action.node.user.long_name)
                 }
 
             is NodeMenuAction.RequestNeighborInfo ->
-                viewModelScope.launch {
+                safeLaunch(tag = "requestNeighborInfo") {
                     nodeRequestActions.requestNeighborInfo(action.node.num, action.node.user.long_name)
                 }
 
             is NodeMenuAction.RequestPosition ->
-                viewModelScope.launch {
+                safeLaunch(tag = "requestPosition") {
                     nodeRequestActions.requestPosition(action.node.num, action.node.user.long_name)
                 }
 
             is NodeMenuAction.RequestTelemetry ->
-                viewModelScope.launch {
+                safeLaunch(tag = "requestTelemetry") {
                     nodeRequestActions.requestTelemetry(action.node.num, action.node.user.long_name, action.type)
                 }
 
             is NodeMenuAction.TraceRoute ->
-                viewModelScope.launch {
+                safeLaunch(tag = "requestTraceroute") {
                     nodeRequestActions.requestTraceroute(action.node.num, action.node.user.long_name)
                 }
 

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -42,6 +42,7 @@ import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioInterfaceService
+import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.node.detail.NodeManagementActions
 import org.meshtastic.feature.node.detail.NodeRequestActions
@@ -213,7 +214,7 @@ class NodeListViewModel(
 
     /** Initiates a trace route request to the specified node. */
     fun traceRoute(node: Node) {
-        viewModelScope.launch { nodeRequestActions.requestTraceroute(node.num, node.user.long_name) }
+        safeLaunch(tag = "requestTraceroute") { nodeRequestActions.requestTraceroute(node.num, node.user.long_name) }
     }
 
     companion object {

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Text
 import androidx.compose.ui.text.AnnotatedString
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,7 +30,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import okio.ByteString.Companion.decodeBase64
@@ -258,13 +256,15 @@ open class MetricsViewModel(
 
     fun requestPosition() {
         (manualNodeId.value ?: nodeIdFromRoute)?.let {
-            viewModelScope.launch { nodeRequestActions.requestPosition(it, state.value.node?.user?.long_name ?: "") }
+            safeLaunch(tag = "requestPosition") {
+                nodeRequestActions.requestPosition(it, state.value.node?.user?.long_name ?: "")
+            }
         }
     }
 
     fun requestTelemetry(type: TelemetryType) {
         (manualNodeId.value ?: nodeIdFromRoute)?.let {
-            viewModelScope.launch {
+            safeLaunch(tag = "requestTelemetry") {
                 nodeRequestActions.requestTelemetry(it, state.value.node?.user?.long_name ?: "", type)
             }
         }
@@ -272,13 +272,15 @@ open class MetricsViewModel(
 
     fun requestTraceroute() {
         (manualNodeId.value ?: nodeIdFromRoute)?.let {
-            viewModelScope.launch { nodeRequestActions.requestTraceroute(it, state.value.node?.user?.long_name ?: "") }
+            safeLaunch(tag = "requestTraceroute") {
+                nodeRequestActions.requestTraceroute(it, state.value.node?.user?.long_name ?: "")
+            }
         }
     }
 
     fun requestNeighborInfo() {
         (manualNodeId.value ?: nodeIdFromRoute)?.let {
-            viewModelScope.launch {
+            safeLaunch(tag = "requestNeighborInfo") {
                 nodeRequestActions.requestNeighborInfo(it, state.value.node?.user?.long_name ?: "")
             }
         }

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/detail/CommonNodeRequestActionsTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/detail/CommonNodeRequestActionsTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.detail
+
+import androidx.compose.material3.SnackbarDuration
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.repository.PacketQueueRejectedException
+import org.meshtastic.core.repository.RadioController
+import org.meshtastic.core.ui.util.SnackbarManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CommonNodeRequestActionsTest {
+    private val radioController: RadioController = mock()
+    private val snackbarManager = RecordingSnackbarManager()
+    private val actions = CommonNodeRequestActions(radioController, snackbarManager)
+
+    private class RecordingSnackbarManager : SnackbarManager() {
+        val messages = mutableListOf<String>()
+
+        override fun showSnackbar(
+            message: String,
+            actionLabel: String?,
+            withDismissAction: Boolean,
+            duration: SnackbarDuration,
+            onAction: (() -> Unit)?,
+        ) {
+            messages += message
+        }
+    }
+
+    @Test
+    fun `traceroute queue rejection is surfaced without starting the request timer`() = runTest {
+        val rejection = PacketQueueRejectedException("Traceroute request")
+        every { radioController.generatePacketId() } returns 42
+        everySuspend { radioController.requestTraceroute(42, 1234) } throws rejection
+
+        actions.requestTraceroute(destNum = 1234, longName = "Test Node")
+
+        assertNull(actions.lastTracerouteTime.value)
+        assertEquals(listOf(checkNotNull(rejection.message)), snackbarManager.messages)
+    }
+
+    @Test
+    fun `neighbor queue rejection is surfaced without starting the request timer`() = runTest {
+        val rejection = PacketQueueRejectedException("Neighbor info request")
+        every { radioController.generatePacketId() } returns 43
+        everySuspend { radioController.requestNeighborInfo(43, 1234) } throws rejection
+
+        actions.requestNeighborInfo(destNum = 1234, longName = "Test Node")
+
+        assertEquals(emptyMap(), actions.lastRequestNeighborTimes.value)
+        assertEquals(listOf(checkNotNull(rejection.message)), snackbarManager.messages)
+    }
+}

--- a/feature/widget/src/main/kotlin/org/meshtastic/feature/widget/RefreshLocalStatsAction.kt
+++ b/feature/widget/src/main/kotlin/org/meshtastic/feature/widget/RefreshLocalStatsAction.kt
@@ -26,6 +26,7 @@ import org.koin.core.component.inject
 import org.meshtastic.core.model.TelemetryType
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.NodeManager
+import org.meshtastic.core.repository.PacketQueueRejectedException
 
 class RefreshLocalStatsAction :
     ActionCallback,
@@ -41,7 +42,15 @@ class RefreshLocalStatsAction :
             return
         }
 
-        commandSender.requestTelemetry(commandSender.generatePacketId(), myNodeNum, TelemetryType.LOCAL_STATS.ordinal)
-        commandSender.requestTelemetry(commandSender.generatePacketId(), myNodeNum, TelemetryType.DEVICE.ordinal)
+        requestTelemetryBestEffort(myNodeNum, TelemetryType.LOCAL_STATS)
+        requestTelemetryBestEffort(myNodeNum, TelemetryType.DEVICE)
+    }
+
+    private suspend fun requestTelemetryBestEffort(myNodeNum: Int, type: TelemetryType) {
+        try {
+            commandSender.requestTelemetry(commandSender.generatePacketId(), myNodeNum, type.ordinal)
+        } catch (e: PacketQueueRejectedException) {
+            Logger.w(e) { "RefreshLocalStatsAction: $type request rejected by packet queue" }
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change makes packet admission, dispatch, transport, and connection lifecycle outcomes explicit. It handles queue rejection, cancellation, reconnect, shutdown, and transport races. It also applies lifecycle evidence to admin settings transactions and adds focused test coverage.

## Key changes

### Features
- Added `AwaitedSendStatus` and `AwaitedSendResult` for detailed send outcomes and dispatch state.
- Added `ConnectionLifecycle`, `ConnectionEpochs`, and lock-free `ConnectionStateHolder`.
- Added lifecycle-aware handling for local and remote admin settings commits.
- Added queue ownership, dispatch tracking, timeout handling, and generation-safe queue restarts.
- Normalized zero request IDs to generated nonzero IDs.
- Added tagged `safeLaunch` calls for node requests.

### Fixes
- Detects radio queue admission failures and throws `PacketQueueRejectedException`.
- Prevents duplicate response reservations and stale completions after reconnects.
- Distinguishes dispatch, rejection, timeout, cancellation, disconnection, and transport failure.
- Starts response timeouts at transmission instead of queue entry.
- Preserves accepted local commits during shutdown races.
- Rejects remote or pre-dispatch commit failures.
- Rejects sends after transport session loss.
- Records the actual packet status for reaction messages.
- Prevents timers and local state updates when packet admission fails.
- Handles expected queue rejections in background discovery, telemetry, and connection-management flows.

### Refactors
- Changed transport admission to Boolean-returning `trySendToRadio`.
- Added `sendAdminAwaitResult` and `sendToRadioAndAwaitResult`.
- Kept existing Boolean methods as compatibility wrappers over detailed results.
- Renamed `removeResponse` to `completeDispatchedResponse`.
- Centralized queue admission and rejection handling in `CommandSenderImpl`.
- Updated repository, service, network transport, fake, test, and desktop stub implementations.
- Added `kotlinx.atomicfu` to the repository module.

## Breaking changes and migration

- Update `PacketHandler.sendToRadio` callers to handle the returned `Boolean`.
- Use `sendToRadioAndAwaitResult` when detailed send results are required.
- Implement `trySendToRadio(bytes: ByteArray): Boolean` in transport service implementations.
- Update command sender implementations to support `sendAdminAwaitResult`.
- Replace `removeResponse` calls with `completeDispatchedResponse`.
- Handle `PacketQueueRejectedException` when queue admission failure requires recovery or reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->