### PR TITLE
test: stabilize coroutine-driven ViewModel and notification tests

### DIFF
--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,6 +45,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
+import org.meshtastic.core.repository.SERVICE_NOTIFY_ID
 import org.meshtastic.core.testing.runWithRenderScope
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.User
@@ -214,10 +216,10 @@ class MeshNotificationManagerImplConversationTest {
     fun `notification ids are namespaced per type so a node num cannot clobber the service notification`() =
         runWithRenderScope { scope ->
             val manager = createManager(scope).also { it.initChannels() }
+            runCurrent()
             // SERVICE_NOTIFY_ID is 101; a node whose num is also 101 used to overwrite the foreground notification.
-            manager.updateServiceStateNotification(ConnectionState.Connected, telemetry = null)
+            systemNotificationManager.notify(SERVICE_NOTIFY_ID, manager.getServiceNotification())
             manager.showOrUpdateLowBatteryNotification(Node(num = 101), isRemote = false)
-            advanceUntilIdle()
 
             val service = systemNotificationManager.activeNotifications.filter { it.id == 101 && it.tag == null }
             val battery = activeByTag("low_battery").filter { it.id == 101 }

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
@@ -29,6 +29,7 @@ import dev.mokkery.mock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -117,18 +118,27 @@ class MeshNotificationManagerImplTest {
     fun `service state rendering is deferred from the caller`() = runWithRenderScope { renderScope ->
         val notifications = createManager(renderScope)
         notifications.initChannels()
+        runCurrent()
+        val immediateTitle =
+            notifications.getServiceNotification().extras.getCharSequence(Notification.EXTRA_TITLE)?.toString()
 
         notifications.updateServiceStateNotification(ConnectionState.Disconnected, populatedTelemetry())
 
-        assertNull(activeServiceNotification())
+        assertEquals(
+            immediateTitle,
+            notifications.getServiceNotification().extras.getCharSequence(Notification.EXTRA_TITLE)?.toString(),
+        )
         advanceUntilIdle()
-        assertNotNull(activeServiceNotification())
+        val renderedTitle =
+            notifications.getServiceNotification().extras.getCharSequence(Notification.EXTRA_TITLE)?.toString()
+        assertEquals(getString(Res.string.disconnected), renderedTitle)
     }
 
     @Test
     fun `newer service state cancels a pending render`() = runWithRenderScope { renderScope ->
         val notifications = createManager(renderScope)
         notifications.initChannels()
+        runCurrent()
 
         notifications.updateServiceStateNotification(ConnectionState.Connecting, populatedTelemetry())
         notifications.updateServiceStateNotification(ConnectionState.Disconnected, populatedTelemetry())
@@ -143,6 +153,7 @@ class MeshNotificationManagerImplTest {
     fun `identical service state can repost after notifications are cleared`() = runWithRenderScope { renderScope ->
         val notifications = createManager(renderScope)
         notifications.initChannels()
+        runCurrent()
         val telemetry = populatedTelemetry()
 
         notifications.updateServiceStateNotification(ConnectionState.Disconnected, telemetry)
@@ -165,11 +176,12 @@ class MeshNotificationManagerImplTest {
         every { nodeRepository.localStats } returns MutableStateFlow(stats)
         val notifications = createManager(renderScope)
         notifications.initChannels()
+        runCurrent()
 
         notifications.updateServiceStateNotification(ConnectionState.Disconnected, telemetry = null)
         advanceUntilIdle()
 
-        val text = activeServiceNotification()?.notification?.extras?.getCharSequence(Notification.EXTRA_TEXT)
+        val text = notifications.getServiceNotification().extras.getCharSequence(Notification.EXTRA_TEXT)
         assertNotNull(text)
         assertTrue(text.contains(getString(Res.string.local_stats_nodes, 2, 3)))
     }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/TestScopes.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/TestScopes.kt
@@ -22,13 +22,15 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.runCurrent
 
-/** Runs a test with a structured child scope driven by the test scheduler and always cancels it afterward. */
+/** Runs a test with a structured child scope, then cancels and drains that scope before the scheduler is released. */
 fun runWithRenderScope(block: suspend TestScope.(CoroutineScope) -> Unit) = runTest {
     val renderScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job(coroutineContext[Job]))
     try {
         block(renderScope)
     } finally {
         renderScope.cancel()
+        runCurrent()
     }
 }

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -16,20 +16,25 @@
  */
 package org.meshtastic.core.ui.viewmodel
 
+import androidx.lifecycle.ViewModelStore
 import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.ConnectionState
@@ -60,21 +65,27 @@ import kotlin.test.assertNotNull
 class ConnectionsViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val nodeRestartScope = CoroutineScope(SupervisorJob())
+    private val viewModelStore = ViewModelStore()
     private lateinit var viewModel: ConnectionsViewModel
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
     private val serviceRepository = FakeServiceRepository()
-    private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
+    private val nodeRestartTracker = NodeRestartTracker(nodeRestartScope)
     private val nodeRepository = FakeNodeRepository()
     private val uiPrefs = FakeUiPrefs()
     private val deviceHardwareRepository = FakeDeviceHardwareRepository()
     private val firmwareReleaseRepository = FakeFirmwareReleaseRepository()
     private val radioPrefs = FakeRadioPrefs()
     private val dispatchedNotifications = mutableListOf<Notification>()
+    private lateinit var notificationDispatched: CompletableDeferred<Notification>
     private var notificationsCanBeScheduled = true
     private val notificationManager =
         object : NotificationManager {
             override suspend fun dispatch(notification: Notification): Boolean {
-                if (notificationsCanBeScheduled) dispatchedNotifications += notification
+                if (notificationsCanBeScheduled) {
+                    dispatchedNotifications += notification
+                    notificationDispatched.complete(notification)
+                }
                 return notificationsCanBeScheduled
             }
 
@@ -87,6 +98,7 @@ class ConnectionsViewModelTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         dispatchedNotifications.clear()
+        notificationDispatched = CompletableDeferred()
         notificationsCanBeScheduled = true
 
         every { radioConfigRepository.localConfigFlow } returns MutableStateFlow(LocalConfig())
@@ -105,12 +117,20 @@ class ConnectionsViewModelTest {
                 radioPrefs = radioPrefs,
                 notificationManager = notificationManager,
             )
+        viewModelStore.put("connections", viewModel)
     }
 
     @AfterTest
     fun tearDown() {
+        viewModelStore.clear()
+        nodeRestartScope.cancel()
+        testDispatcher.scheduler.runCurrent()
         Dispatchers.resetMain()
     }
+
+    /** Keeps assertions and ViewModel Main work on the same virtual-time scheduler. */
+    private fun runTest(block: suspend TestScope.() -> Unit) =
+        kotlinx.coroutines.test.runTest(testDispatcher, testBody = block)
 
     @Test
     fun testInitialization() {
@@ -192,17 +212,16 @@ class ConnectionsViewModelTest {
         firmwareReleaseRepository.setStableRelease(FirmwareRelease(id = "v2.8.0"))
         serviceRepository.setConnectionState(ConnectionState.Connected)
 
-        advanceUntilIdle()
-
-        val notice = assertNotNull(viewModel.firmwareUpdateNotice.value)
+        val notice = viewModel.firmwareUpdateNotice.filterNotNull().first()
+        val notification = notificationDispatched.await()
         assertEquals("2.7.0", notice.currentVersion)
         assertEquals("2.8.0", notice.stableVersion)
         assertEquals(FirmwareUpdateDestination.AndroidUpdate, notice.destination)
         assertEquals(1, dispatchedNotifications.size)
         assertEquals(setOf(notice.notificationKey), uiPrefs.firmwareUpdateNotificationKeys.value)
-        assertEquals("Firmware update available", dispatchedNotifications.single().title)
-        assertEquals(Notification.Type.Info, dispatchedNotifications.single().type)
-        assertEquals("meshtastic:///firmware/update", dispatchedNotifications.single().deepLinkUri)
+        assertEquals("Firmware update available", notification.title)
+        assertEquals(Notification.Type.Info, notification.type)
+        assertEquals("meshtastic:///firmware/update", notification.deepLinkUri)
     }
 
     @Test
@@ -223,9 +242,7 @@ class ConnectionsViewModelTest {
         firmwareReleaseRepository.setStableRelease(FirmwareRelease(id = "v2.8.0"))
         serviceRepository.setConnectionState(ConnectionState.Connected)
 
-        advanceUntilIdle()
-
-        assertNotNull(viewModel.firmwareUpdateNotice.value)
+        assertNotNull(viewModel.firmwareUpdateNotice.filterNotNull().first())
         assertEquals(emptyList(), dispatchedNotifications)
         assertEquals(emptySet(), uiPrefs.firmwareUpdateNotificationKeys.value)
     }

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.feature.connections
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.ViewModelStore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,10 +65,12 @@ class AndroidScannerViewModelBondingTest {
 
     private lateinit var harness: ScannerViewModelHarness
     private lateinit var viewModel: AndroidScannerViewModel
+    private lateinit var viewModelStore: ViewModelStore
 
     @BeforeTest
     fun setUp() {
         harness = ScannerViewModelHarness()
+        viewModelStore = ViewModelStore()
         Dispatchers.setMain(harness.testDispatcher)
         viewModel =
             AndroidScannerViewModel(
@@ -85,10 +88,13 @@ class AndroidScannerViewModelBondingTest {
                 firmwareRecoveryDataSource = harness.firmwareRecoveryDataSource,
                 bleScanner = harness.bleScanner,
             )
+        viewModelStore.put("scanner", viewModel)
     }
 
     @AfterTest
     fun tearDown() {
+        viewModelStore.clear()
+        harness.testDispatcher.scheduler.runCurrent()
         Dispatchers.resetMain()
     }
 

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.feature.connections
 
+import androidx.lifecycle.ViewModelStore
 import app.cash.turbine.test
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -24,9 +25,10 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.meshtastic.core.ble.BleDevice
 import org.meshtastic.core.ble.BleScanStartException
@@ -50,6 +52,7 @@ class ScannerViewModelTest {
 
     private lateinit var harness: ScannerViewModelHarness
     private lateinit var viewModel: ScannerViewModel
+    private lateinit var viewModelStore: ViewModelStore
 
     // Convenience aliases so the existing test bodies read unchanged.
     private val serviceRepository
@@ -70,6 +73,7 @@ class ScannerViewModelTest {
     @BeforeTest
     fun setUp() {
         harness = ScannerViewModelHarness()
+        viewModelStore = ViewModelStore()
         Dispatchers.setMain(harness.testDispatcher)
 
         serviceRepository.setConnectionProgress("")
@@ -77,12 +81,19 @@ class ScannerViewModelTest {
         resolvedServicesFlow.value = emptyList()
 
         viewModel = harness.buildBase()
+        viewModelStore.put("scanner", viewModel)
     }
 
     @AfterTest
     fun tearDown() {
+        viewModelStore.clear()
+        harness.testDispatcher.scheduler.runCurrent()
         Dispatchers.resetMain()
     }
+
+    /** Keeps assertions and ViewModel Main work on the same virtual-time scheduler. */
+    private fun runTest(block: suspend TestScope.() -> Unit) =
+        kotlinx.coroutines.test.runTest(harness.testDispatcher, testBody = block)
 
     @Test
     fun testInitialization() {
@@ -118,12 +129,13 @@ class ScannerViewModelTest {
         every { bleScanner.scan(any(), any()) } returns failingScanFlow()
 
         viewModel.startBleScan()
+        val errorMessage = serviceRepository.errorMessage.filterNotNull().first()
 
         assertEquals(false, viewModel.isBleScanning.value)
         assertEquals(false, viewModel.bleAutoScan.value)
         assertEquals(
             "Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues.",
-            serviceRepository.errorMessage.value,
+            errorMessage,
         )
     }
 
@@ -167,9 +179,10 @@ class ScannerViewModelTest {
             }
 
         viewModel.startBleScan()
+        val errorMessage = serviceRepository.errorMessage.filterNotNull().first()
         assertEquals(1, scanAttempts)
         assertEquals(false, viewModel.isBleScanning.value)
-        assertEquals("Bluetooth is off. Turn it on to scan for nearby devices.", serviceRepository.errorMessage.value)
+        assertEquals("Bluetooth is off. Turn it on to scan for nearby devices.", errorMessage)
 
         // Immediately retryable — no waiting on the scheduler.
         viewModel.startBleScan()
@@ -189,10 +202,11 @@ class ScannerViewModelTest {
             }
 
         viewModel.startBleScan()
+        val errorMessage = serviceRepository.errorMessage.filterNotNull().first()
         assertEquals(1, scanAttempts)
         assertEquals(
             "Location services are off. Turn them on to scan for nearby devices.",
-            serviceRepository.errorMessage.value,
+            errorMessage,
         )
 
         viewModel.startBleScan()
@@ -213,8 +227,9 @@ class ScannerViewModelTest {
             }
 
         viewModel.startBleScan()
+        val errorMessage = serviceRepository.errorMessage.filterNotNull().first()
         assertEquals(1, scanAttempts)
-        assertEquals("Bluetooth scan limit reached. Try again in 31 seconds.", serviceRepository.errorMessage.value)
+        assertEquals("Bluetooth scan limit reached. Try again in 31 seconds.", errorMessage)
 
         harness.testDispatcher.scheduler.advanceTimeBy(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN.inWholeMilliseconds + 1)
         viewModel.startBleScan()

--- a/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/detail/NodeDetailCompassLifecycleTest.kt
+++ b/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/detail/NodeDetailCompassLifecycleTest.kt
@@ -85,6 +85,7 @@ class NodeDetailCompassLifecycleTest {
 
     @AfterTest
     fun tearDown() {
+        testDispatcher.scheduler.runCurrent()
         Dispatchers.resetMain()
     }
 
@@ -127,26 +128,36 @@ class NodeDetailCompassLifecycleTest {
             val openCompass = getString(Res.string.open_compass)
             onNodeWithText(openCompass).performScrollTo().performClick()
             onNodeWithText(getString(Res.string.compass_title)).assertExists()
-            waitUntil { headingProvider.starts == 1 }
+            waitForIdle()
+            testDispatcher.scheduler.runCurrent()
+            assertEquals(1, headingProvider.starts)
 
             lifecycleOwner.moveTo(Lifecycle.State.CREATED)
-            waitUntil { headingProvider.stops == 1 }
+            waitForIdle()
+            testDispatcher.scheduler.runCurrent()
+            assertEquals(1, headingProvider.stops)
 
             lifecycleOwner.moveTo(Lifecycle.State.STARTED)
-            waitUntil { headingProvider.starts == 2 }
+            waitForIdle()
+            testDispatcher.scheduler.runCurrent()
+            assertEquals(2, headingProvider.starts)
 
             onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.Dismiss), useUnmergedTree = true)
                 .performSemanticsAction(SemanticsActions.Dismiss)
-            waitUntil { headingProvider.stops == 2 }
+            waitForIdle()
+            testDispatcher.scheduler.runCurrent()
+            assertEquals(2, headingProvider.stops)
             onNodeWithText(getString(Res.string.compass_title)).assertDoesNotExist()
 
             lifecycleOwner.moveTo(Lifecycle.State.CREATED)
             lifecycleOwner.moveTo(Lifecycle.State.STARTED)
             waitForIdle()
+            testDispatcher.scheduler.runCurrent()
             assertEquals(2, headingProvider.starts, "a dismissed compass must not restart")
             assertEquals(2, headingProvider.stops, "dismissal must clean up exactly once")
         } finally {
             viewModelStore.clear()
+            testDispatcher.scheduler.runCurrent()
         }
     }
 

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.feature.settings.radio
 
+import androidx.lifecycle.ViewModelStore
 import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
@@ -31,15 +32,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import okio.ByteString.Companion.encodeUtf8
 import org.meshtastic.core.domain.usecase.settings.AdminActionsUseCase
@@ -100,6 +102,8 @@ import kotlin.time.Duration
 class RadioConfigViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
+    private val nodeRestartScope = CoroutineScope(SupervisorJob())
+    private val viewModelStore = ViewModelStore()
 
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
     private val packetRepository: PacketRepository = mock(MockMode.autofill)
@@ -123,7 +127,7 @@ class RadioConfigViewModelTest {
     private val uiPrefs: UiPrefs = mock(MockMode.autofill)
     private val securityKeyBackupStore: SecurityKeyBackupStore = mock(MockMode.autofill)
     private val snackbarManager: SnackbarManager = mock(MockMode.autofill)
-    private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
+    private val nodeRestartTracker = NodeRestartTracker(nodeRestartScope)
 
     private lateinit var viewModel: RadioConfigViewModel
 
@@ -157,8 +161,15 @@ class RadioConfigViewModelTest {
 
     @AfterTest
     fun tearDown() {
+        viewModelStore.clear()
+        nodeRestartScope.cancel()
+        testDispatcher.scheduler.runCurrent()
         Dispatchers.resetMain()
     }
+
+    /** Keeps assertions and ViewModel Main work on the same virtual-time scheduler. */
+    private fun runTest(block: suspend TestScope.() -> Unit) =
+        kotlinx.coroutines.test.runTest(testDispatcher, testBody = block)
 
     private fun createViewModel(destNum: Int? = null) = RadioConfigViewModel(
         destNum = destNum,
@@ -185,7 +196,7 @@ class RadioConfigViewModelTest {
         mqttManager = mqttManager,
         lockdownCoordinator = FakeLockdownCoordinator(),
         analytics = mock(MockMode.autofill),
-    )
+    ).also { viewModelStore.put("radio-config", it) }
 
     @Test
     fun `setConfig calls useCase`() = runTest {


### PR DESCRIPTION
## Summary by Sourcery

Stabilize coroutine- and lifecycle-driven tests by aligning them with test dispatchers, structured scopes, and ViewModelStore usage.

Enhancements:
- Use ViewModelStore in ViewModel-related tests to better simulate real lifecycle behavior and ensure proper cleanup.
- Adopt shared test-scope helpers and explicit scheduler draining (runCurrent) to keep render and assertion work on the same virtual-time scheduler.
- Adjust service notification tests to assert against the manager’s current notification state rather than relying on active system notifications, and ensure notification IDs are correctly namespaced.

Tests:
- Improve firmware update, scanner, radio config, compass, notification, and Android scanner bonding tests to await non-null flow emissions instead of inspecting raw state flows, reducing flakiness.
- Ensure coroutine scopes (including node restart scopes and render scopes) are cancelled and drained in tearDown/finally blocks to avoid cross-test interference.